### PR TITLE
feat: SQL perf++; CLI overhall; CLI opts to use Json/Uuid & reduce nullables

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-minify": "~0.5.3",
-    "pg-sql2": "^1.0.0-alpha1.0",
+    "pg-sql2": "1.0.0-beta.7",
     "pluralize": "^3.0.0",
     "postgraphile-core": "4.0.0-alpha.3",
     "postgres-interval": "^1.0.2",

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pg-minify": "~0.5.3",
     "pg-sql2": "^1.0.0-alpha1.0",
     "pluralize": "^3.0.0",
-    "postgraphile-core": "4.0.0-alpha.2",
+    "postgraphile-core": "4.0.0-alpha.3",
     "postgres-interval": "^1.0.2",
     "send": "^0.16.1",
     "tslib": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pg-minify": "~0.5.3",
     "pg-sql2": "1.0.0-beta.7",
     "pluralize": "^3.0.0",
-    "postgraphile-core": "4.0.0-alpha.3",
+    "postgraphile-core": "4.0.0-alpha.4",
     "postgres-interval": "^1.0.2",
     "send": "^0.16.1",
     "tslib": "^1.5.0"

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "pg-minify": "~0.5.3",
     "pg-sql2": "^1.0.0-alpha1.0",
     "pluralize": "^3.0.0",
-    "postgraphile-core": "4.0.0-alpha.1",
+    "postgraphile-core": "4.0.0-alpha.2",
     "postgres-interval": "^1.0.2",
     "send": "^0.16.1",
     "tslib": "^1.5.0"

--- a/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchema-test.js.snap
+++ b/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchema-test.js.snap
@@ -62,7 +62,7 @@ type CompoundKeysConnection {
   edges: [CompoundKeysEdge!]!
 
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey]!
+  nodes: [CompoundKey!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -116,7 +116,7 @@ type CreateCompoundKeyPayload {
   \"\"\"The \`CompoundKey\` that was created by this mutation.\"\"\"
   compoundKey: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -157,7 +157,7 @@ type CreateEdgeCasePayload {
   \"\"\"The \`EdgeCase\` that was created by this mutation.\"\"\"
   edgeCase: EdgeCase
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`EdgeCase\`. May be used by Relay 1.\"\"\"
   edgeCaseEdge(
     \"\"\"The method to use when ordering \`EdgeCase\`.\"\"\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
@@ -192,7 +192,7 @@ type CreatePersonPayload {
   \"\"\"The \`Person\` that was created by this mutation.\"\"\"
   person: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -251,7 +251,7 @@ type DeleteCompoundKeyPayload {
   \"\"\"The \`CompoundKey\` that was deleted by this mutation.\"\"\"
   compoundKey: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -316,7 +316,7 @@ type DeletePersonPayload {
   \"\"\"The \`Person\` that was deleted by this mutation.\"\"\"
   person: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -365,7 +365,7 @@ type EdgeCasesConnection {
   edges: [EdgeCasesEdge!]!
 
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase]!
+  nodes: [EdgeCase!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -451,7 +451,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \"\"\"A \`Int\` edge in the connection.\"\"\"
@@ -697,7 +697,7 @@ type PeopleConnection {
   edges: [PeopleEdge!]!
 
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person]!
+  nodes: [Person!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -1094,7 +1094,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -1186,7 +1186,7 @@ type UpdateCompoundKeyPayload {
   \"\"\"The \`CompoundKey\` that was updated by this mutation.\"\"\"
   compoundKey: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -1264,7 +1264,7 @@ type UpdatePersonPayload {
   \"\"\"The \`Person\` that was updated by this mutation.\"\"\"
   person: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -1508,7 +1508,7 @@ type CreateTypePayload {
   \"\"\"The \`Type\` that was created by this mutation.\"\"\"
   type: Type
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -1543,7 +1543,7 @@ type CreateUpdatableViewPayload {
   \"\"\"The \`UpdatableView\` that was created by this mutation.\"\"\"
   updatableView: UpdatableView
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`UpdatableView\`. May be used by Relay 1.\"\"\"
   updatableViewEdge(
     \"\"\"The method to use when ordering \`UpdatableView\`.\"\"\"
     orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
@@ -1643,7 +1643,7 @@ type DeleteTypePayload {
   \"\"\"The \`Type\` that was deleted by this mutation.\"\"\"
   type: Type
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2233,7 +2233,7 @@ type TypesConnection {
   edges: [TypesEdge!]!
 
   \"\"\"A list of \`Type\` objects.\"\"\"
-  nodes: [Type]!
+  nodes: [Type!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -2354,7 +2354,7 @@ type UpdatableViewsConnection {
   edges: [UpdatableViewsEdge!]!
 
   \"\"\"A list of \`UpdatableView\` objects.\"\"\"
-  nodes: [UpdatableView]!
+  nodes: [UpdatableView!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -2435,7 +2435,7 @@ type UpdateTypePayload {
   \"\"\"The \`Type\` that was updated by this mutation.\"\"\"
   type: Type
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2801,7 +2801,7 @@ type CompoundKeysConnection {
   edges: [CompoundKeysEdge!]!
 
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey]!
+  nodes: [CompoundKey!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -2899,7 +2899,7 @@ type CreateCompoundKeyPayload {
   \"\"\"The \`CompoundKey\` that was created by this mutation.\"\"\"
   compoundKey: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -2940,7 +2940,7 @@ type CreateEdgeCasePayload {
   \"\"\"The \`EdgeCase\` that was created by this mutation.\"\"\"
   edgeCase: EdgeCase
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`EdgeCase\`. May be used by Relay 1.\"\"\"
   edgeCaseEdge(
     \"\"\"The method to use when ordering \`EdgeCase\`.\"\"\"
     orderBy: [EdgeCasesOrderBy!] = [NATURAL]
@@ -2978,7 +2978,7 @@ type CreateForeignKeyPayload {
   \"\"\"The \`ForeignKey\` that was created by this mutation.\"\"\"
   foreignKey: ForeignKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`ForeignKey\`. May be used by Relay 1.\"\"\"
   foreignKeyEdge(
     \"\"\"The method to use when ordering \`ForeignKey\`.\"\"\"
     orderBy: [ForeignKeysOrderBy!] = [NATURAL]
@@ -3016,7 +3016,7 @@ type CreatePersonPayload {
   \"\"\"The \`Person\` that was created by this mutation.\"\"\"
   person: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3054,7 +3054,7 @@ type CreatePostPayload {
   \"\"\"The \`Post\` that was created by this mutation.\"\"\"
   post: Post
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3094,7 +3094,7 @@ type CreateSimilarTable1Payload {
   \"\"\"The \`SimilarTable1\` that was created by this mutation.\"\"\"
   similarTable1: SimilarTable1
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
   similarTable1Edge(
     \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3129,7 +3129,7 @@ type CreateSimilarTable2Payload {
   \"\"\"The \`SimilarTable2\` that was created by this mutation.\"\"\"
   similarTable2: SimilarTable2
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
   similarTable2Edge(
     \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3164,7 +3164,7 @@ type CreateTypePayload {
   \"\"\"The \`Type\` that was created by this mutation.\"\"\"
   type: Type
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3199,7 +3199,7 @@ type CreateUpdatableViewPayload {
   \"\"\"The \`UpdatableView\` that was created by this mutation.\"\"\"
   updatableView: UpdatableView
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`UpdatableView\`. May be used by Relay 1.\"\"\"
   updatableViewEdge(
     \"\"\"The method to use when ordering \`UpdatableView\`.\"\"\"
     orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
@@ -3296,7 +3296,7 @@ type DeleteCompoundKeyPayload {
   \"\"\"The \`CompoundKey\` that was deleted by this mutation.\"\"\"
   compoundKey: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3361,7 +3361,7 @@ type DeletePersonPayload {
   \"\"\"The \`Person\` that was deleted by this mutation.\"\"\"
   person: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3412,7 +3412,7 @@ type DeletePostPayload {
   \"\"\"The \`Post\` that was deleted by this mutation.\"\"\"
   post: Post
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3465,7 +3465,7 @@ type DeleteSimilarTable1Payload {
   \"\"\"The \`SimilarTable1\` that was deleted by this mutation.\"\"\"
   similarTable1: SimilarTable1
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
   similarTable1Edge(
     \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3513,7 +3513,7 @@ type DeleteSimilarTable2Payload {
   \"\"\"The \`SimilarTable2\` that was deleted by this mutation.\"\"\"
   similarTable2: SimilarTable2
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
   similarTable2Edge(
     \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3561,7 +3561,7 @@ type DeleteTypePayload {
   \"\"\"The \`Type\` that was deleted by this mutation.\"\"\"
   type: Type
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -3605,7 +3605,7 @@ type EdgeCasesConnection {
   edges: [EdgeCasesEdge!]!
 
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase]!
+  nodes: [EdgeCase!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -3698,7 +3698,7 @@ type ForeignKeysConnection {
   edges: [ForeignKeysEdge!]!
 
   \"\"\"A list of \`ForeignKey\` objects.\"\"\"
-  nodes: [ForeignKey]!
+  nodes: [ForeignKey!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -3816,7 +3816,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \"\"\"A \`Int\` edge in the connection.\"\"\"
@@ -4449,7 +4449,7 @@ type NonUpdatableViewsConnection {
   edges: [NonUpdatableViewsEdge!]!
 
   \"\"\"A list of \`NonUpdatableView\` objects.\"\"\"
-  nodes: [NonUpdatableView]!
+  nodes: [NonUpdatableView!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -4499,7 +4499,7 @@ type PeopleConnection {
   edges: [PeopleEdge!]!
 
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person]!
+  nodes: [Person!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -4792,7 +4792,7 @@ type PostsConnection {
   edges: [PostsEdge!]!
 
   \"\"\"A list of \`Post\` objects.\"\"\"
-  nodes: [Post]!
+  nodes: [Post!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -5323,7 +5323,7 @@ type SimilarTable1SConnection {
   edges: [SimilarTable1SEdge!]!
 
   \"\"\"A list of \`SimilarTable1\` objects.\"\"\"
-  nodes: [SimilarTable1]!
+  nodes: [SimilarTable1!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -5412,7 +5412,7 @@ type SimilarTable2SConnection {
   edges: [SimilarTable2SEdge!]!
 
   \"\"\"A list of \`SimilarTable2\` objects.\"\"\"
-  nodes: [SimilarTable2]!
+  nodes: [SimilarTable2!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -5467,7 +5467,7 @@ type TableMutationPayload {
   personByAuthorId: Person
   post: Post
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5497,7 +5497,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -5701,7 +5701,7 @@ type TypesConnection {
   edges: [TypesEdge!]!
 
   \"\"\"A list of \`Type\` objects.\"\"\"
-  nodes: [Type]!
+  nodes: [Type!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -5854,7 +5854,7 @@ type UpdatableViewsConnection {
   edges: [UpdatableViewsEdge!]!
 
   \"\"\"A list of \`UpdatableView\` objects.\"\"\"
-  nodes: [UpdatableView]!
+  nodes: [UpdatableView!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -5933,7 +5933,7 @@ type UpdateCompoundKeyPayload {
   \"\"\"The \`CompoundKey\` that was updated by this mutation.\"\"\"
   compoundKey: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
@@ -6011,7 +6011,7 @@ type UpdatePersonPayload {
   \"\"\"The \`Person\` that was updated by this mutation.\"\"\"
   person: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
@@ -6071,7 +6071,7 @@ type UpdatePostPayload {
   \"\"\"The \`Post\` that was updated by this mutation.\"\"\"
   post: Post
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
@@ -6133,7 +6133,7 @@ type UpdateSimilarTable1Payload {
   \"\"\"The \`SimilarTable1\` that was updated by this mutation.\"\"\"
   similarTable1: SimilarTable1
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
   similarTable1Edge(
     \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
     orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -6190,7 +6190,7 @@ type UpdateSimilarTable2Payload {
   \"\"\"The \`SimilarTable2\` that was updated by this mutation.\"\"\"
   similarTable2: SimilarTable2
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
   similarTable2Edge(
     \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
     orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
@@ -6247,7 +6247,7 @@ type UpdateTypePayload {
   \"\"\"The \`Type\` that was updated by this mutation.\"\"\"
   type: Type
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
@@ -6309,7 +6309,7 @@ type CompoundKeysConnection {
   edges: [CompoundKeysEdge!]!
 
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey]!
+  nodes: [CompoundKey!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -6379,7 +6379,7 @@ type EdgeCasesConnection {
   edges: [EdgeCasesEdge!]!
 
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase]!
+  nodes: [EdgeCase!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -6465,7 +6465,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int]!
+  nodes: [Int!]!
 }
 
 \"\"\"A \`Int\` edge in the connection.\"\"\"
@@ -6606,7 +6606,7 @@ type PeopleConnection {
   edges: [PeopleEdge!]!
 
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person]!
+  nodes: [Person!]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -6979,7 +6979,7 @@ type TableSetMutationPayload {
   clientMutationId: String
   people: [Person]
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]

--- a/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchema-test.js.snap
+++ b/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchema-test.js.snap
@@ -62,7 +62,7 @@ type CompoundKeysConnection {
   edges: [CompoundKeysEdge!]!
 
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey!]!
+  nodes: [CompoundKey]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -77,7 +77,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \"\"\"The \`CompoundKey\` at the end of the edge.\"\"\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \"\"\"Methods to use when ordering \`CompoundKey\`.\"\"\"
@@ -365,7 +365,7 @@ type EdgeCasesConnection {
   edges: [EdgeCasesEdge!]!
 
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase!]!
+  nodes: [EdgeCase]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -380,7 +380,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \"\"\"The \`EdgeCase\` at the end of the edge.\"\"\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \"\"\"Methods to use when ordering \`EdgeCase\`.\"\"\"
@@ -451,7 +451,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int!]!
+  nodes: [Int]!
 }
 
 \"\"\"A \`Int\` edge in the connection.\"\"\"
@@ -697,7 +697,7 @@ type PeopleConnection {
   edges: [PeopleEdge!]!
 
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person!]!
+  nodes: [Person]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -712,7 +712,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \"\"\"The \`Person\` at the end of the edge.\"\"\"
-  node: Person!
+  node: Person
 }
 
 \"\"\"Methods to use when ordering \`Person\`.\"\"\"
@@ -2233,7 +2233,7 @@ type TypesConnection {
   edges: [TypesEdge!]!
 
   \"\"\"A list of \`Type\` objects.\"\"\"
-  nodes: [Type!]!
+  nodes: [Type]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -2248,7 +2248,7 @@ type TypesEdge {
   cursor: Cursor
 
   \"\"\"The \`Type\` at the end of the edge.\"\"\"
-  node: Type!
+  node: Type
 }
 
 \"\"\"Methods to use when ordering \`Type\`.\"\"\"
@@ -2354,7 +2354,7 @@ type UpdatableViewsConnection {
   edges: [UpdatableViewsEdge!]!
 
   \"\"\"A list of \`UpdatableView\` objects.\"\"\"
-  nodes: [UpdatableView!]!
+  nodes: [UpdatableView]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -2369,7 +2369,7 @@ type UpdatableViewsEdge {
   cursor: Cursor
 
   \"\"\"The \`UpdatableView\` at the end of the edge.\"\"\"
-  node: UpdatableView!
+  node: UpdatableView
 }
 
 \"\"\"Methods to use when ordering \`UpdatableView\`.\"\"\"
@@ -2449,7 +2449,7 @@ scalar UUID
 "
 `;
 
-exports[`test prints a schema with the default options 1`] = `
+exports[`test prints a schema with nulls reduced and old Json, Uuid 1`] = `
 "\"\"\"All input for the \`add1Mutation\` mutation.\"\"\"
 input Add1MutationInput {
   arg0: Int!
@@ -2838,7 +2838,7 @@ type CompoundType {
   b: String
   c: Color
   computedField: Int
-  d: UUID
+  d: Uuid
   fooBar: Int
 }
 
@@ -2847,7 +2847,7 @@ input CompoundTypeInput {
   a: Int
   b: String
   c: Color
-  d: UUID
+  d: Uuid
   fooBar: Int
 }
 
@@ -3831,7 +3831,7 @@ type IntSetQueryEdge {
 \"\"\"
 A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
 \"\"\"
-scalar JSON
+scalar Json
 
 \"\"\"All input for the \`jsonIdentityMutation\` mutation.\"\"\"
 input JsonIdentityMutationInput {
@@ -3840,7 +3840,7 @@ input JsonIdentityMutationInput {
   payload verbatim. May be used to track mutations by the client.
   \"\"\"
   clientMutationId: String
-  json: JSON
+  json: Json
 }
 
 \"\"\"The output of our \`jsonIdentityMutation\` mutation.\"\"\"
@@ -3850,7 +3850,7 @@ type JsonIdentityMutationPayload {
   unchanged and unused. May be used by a client to track mutations.
   \"\"\"
   clientMutationId: String
-  json: JSON
+  json: Json
 
   \"\"\"
   Our root query field type. Allows us to run any query from our mutation payload.
@@ -5160,7 +5160,7 @@ type Query implements Node {
     y: Int
     z: Int
   ): IntSetQueryConnection!
-  jsonIdentity(json: JSON): JSON
+  jsonIdentity(json: Json): Json
   noArgsQuery: Int
 
   \"\"\"Fetches an object given its globally unique \`ID\`.\"\"\"
@@ -5241,7 +5241,7 @@ type Query implements Node {
     nodeId: ID!
   ): Type
   typeById(id: Int!): Type
-  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: Json!, f: FloatRangeInput!): Boolean
 }
 
 \"\"\"All input for the \`returnVoidMutation\` mutation.\"\"\"
@@ -5527,8 +5527,8 @@ type Type implements Node {
   enum: Color!
   id: Int!
   interval: Interval!
-  json: JSON!
-  jsonb: JSON!
+  json: Json!
+  jsonb: Json!
   money: Float!
   nestedCompoundType: NestedCompoundType!
 
@@ -5589,10 +5589,10 @@ input TypeCondition {
   interval: IntervalInput
 
   \"\"\"Checks for equality with the object’s \`json\` field.\"\"\"
-  json: JSON
+  json: Json
 
   \"\"\"Checks for equality with the object’s \`jsonb\` field.\"\"\"
-  jsonb: JSON
+  jsonb: Json
 
   \"\"\"Checks for equality with the object’s \`money\` field.\"\"\"
   money: Float
@@ -5645,8 +5645,8 @@ input TypeInput {
   enum: Color!
   id: Int
   interval: IntervalInput!
-  json: JSON!
-  jsonb: JSON!
+  json: Json!
+  jsonb: Json!
   money: Float!
   nestedCompoundType: NestedCompoundTypeInput!
   nullableRange: BigFloatRangeInput
@@ -5677,8 +5677,8 @@ input TypePatch {
   enum: Color
   id: Int
   interval: IntervalInput
-  json: JSON
-  jsonb: JSON
+  json: Json
+  jsonb: Json
   money: Float
   nestedCompoundType: NestedCompoundTypeInput
   nullableRange: BigFloatRangeInput
@@ -5731,7 +5731,7 @@ input TypesMutationInput {
   \"\"\"
   clientMutationId: String
   d: [Int]!
-  e: JSON!
+  e: Json!
   f: FloatRangeInput!
 }
 
@@ -6257,6 +6257,3818 @@ type UpdateTypePayload {
 \"\"\"
 A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
 \"\"\"
+scalar Uuid
+"
+`;
+
+exports[`test prints a schema with the default options 1`] = `
+"\"\"\"All input for the \`add1Mutation\` mutation.\"\"\"
+input Add1MutationInput {
+  arg0: Int!
+  arg1: Int!
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`add1Mutation\` mutation.\"\"\"
+type Add1MutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`add2Mutation\` mutation.\"\"\"
+input Add2MutationInput {
+  a: Int!
+  b: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`add2Mutation\` mutation.\"\"\"
+type Add2MutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`add3Mutation\` mutation.\"\"\"
+input Add3MutationInput {
+  a: Int
+  arg1: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`add3Mutation\` mutation.\"\"\"
+type Add3MutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`add4Mutation\` mutation.\"\"\"
+input Add4MutationInput {
+  arg0: Int
+  b: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`add4Mutation\` mutation.\"\"\"
+type Add4MutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+scalar AnInt
+
+\"\"\"A range of \`AnInt\`.\"\"\"
+type AnIntRange {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: AnIntRangeBound
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: AnIntRangeBound
+}
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+type AnIntRangeBound {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: AnInt!
+}
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+input AnIntRangeBoundInput {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: AnInt!
+}
+
+\"\"\"A range of \`AnInt\`.\"\"\"
+input AnIntRangeInput {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: AnIntRangeBoundInput
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: AnIntRangeBoundInput
+}
+
+scalar AnotherInt
+
+\"\"\"All input for the \`authenticate\` mutation.\"\"\"
+input AuthenticateInput {
+  a: Int
+  b: Int
+  c: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"All input for the \`authenticateMany\` mutation.\"\"\"
+input AuthenticateManyInput {
+  a: Int
+  b: Int
+  c: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`authenticateMany\` mutation.\"\"\"
+type AuthenticateManyPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  jwtTokens: [JwtToken]
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"The output of our \`authenticate\` mutation.\"\"\"
+type AuthenticatePayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  jwtToken: JwtToken
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"
+A floating point number that requires more precision than IEEE 754 binary 64
+\"\"\"
+scalar BigFloat
+
+\"\"\"A range of \`BigFloat\`.\"\"\"
+type BigFloatRange {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: BigFloatRangeBound
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: BigFloatRangeBound
+}
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+type BigFloatRangeBound {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: BigFloat!
+}
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+input BigFloatRangeBoundInput {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: BigFloat!
+}
+
+\"\"\"A range of \`BigFloat\`.\"\"\"
+input BigFloatRangeInput {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: BigFloatRangeBoundInput
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: BigFloatRangeBoundInput
+}
+
+\"\"\"
+A signed eight-byte integer. The upper big integer values are greater then the
+max value for a JavaScript number. Therefore all big integers will be output as
+strings and not numbers.
+\"\"\"
+scalar BigInt
+
+enum Color {
+  BLUE
+  GREEN
+  RED
+}
+
+type CompoundKey implements Node {
+  extra: Boolean
+
+  \"\"\"Reads and enables pagination through a set of \`ForeignKey\`.\"\"\"
+  foreignKeysByCompoundKey1AndCompoundKey2(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: ForeignKeyCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`ForeignKey\`.\"\"\"
+    orderBy: [ForeignKeysOrderBy!] = [NATURAL]
+  ): ForeignKeysConnection!
+
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId1: Person
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId2: Person
+  personId1: Int!
+  personId2: Int!
+}
+
+\"\"\"
+A condition to be used against \`CompoundKey\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\"\"\"
+input CompoundKeyCondition {
+  \"\"\"Checks for equality with the object’s \`extra\` field.\"\"\"
+  extra: Boolean
+
+  \"\"\"Checks for equality with the object’s \`personId1\` field.\"\"\"
+  personId1: Int
+
+  \"\"\"Checks for equality with the object’s \`personId2\` field.\"\"\"
+  personId2: Int
+}
+
+\"\"\"An input for mutations affecting \`CompoundKey\`\"\"\"
+input CompoundKeyInput {
+  extra: Boolean
+  personId1: Int!
+  personId2: Int!
+}
+
+\"\"\"
+Represents an update to a \`CompoundKey\`. Fields that are set will be updated.
+\"\"\"
+input CompoundKeyPatch {
+  extra: Boolean
+  personId1: Int
+  personId2: Int
+}
+
+\"\"\"A connection to a list of \`CompoundKey\` values.\"\"\"
+type CompoundKeysConnection {
+  \"\"\"
+  A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [CompoundKeysEdge!]!
+
+  \"\"\"A list of \`CompoundKey\` objects.\"\"\"
+  nodes: [CompoundKey]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`CompoundKey\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`CompoundKey\` edge in the connection.\"\"\"
+type CompoundKeysEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`CompoundKey\` at the end of the edge.\"\"\"
+  node: CompoundKey
+}
+
+\"\"\"Methods to use when ordering \`CompoundKey\`.\"\"\"
+enum CompoundKeysOrderBy {
+  EXTRA_ASC
+  EXTRA_DESC
+  NATURAL
+  PERSON_ID_1_ASC
+  PERSON_ID_1_DESC
+  PERSON_ID_2_ASC
+  PERSON_ID_2_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\"\"\"Awesome feature!\"\"\"
+type CompoundType {
+  a: Int
+  b: String
+  c: Color
+  computedField: Int
+  d: UUID
+  fooBar: Int
+}
+
+\"\"\"An input for mutations affecting \`CompoundType\`\"\"\"
+input CompoundTypeInput {
+  a: Int
+  b: String
+  c: Color
+  d: UUID
+  fooBar: Int
+}
+
+\"\"\"All input for the \`compoundTypeMutation\` mutation.\"\"\"
+input CompoundTypeMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  object: CompoundTypeInput
+}
+
+\"\"\"The output of our \`compoundTypeMutation\` mutation.\"\"\"
+type CompoundTypeMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  compoundType: CompoundType
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the create \`CompoundKey\` mutation.\"\"\"
+input CreateCompoundKeyInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`CompoundKey\` to be created by this mutation.\"\"\"
+  compoundKey: CompoundKeyInput!
+}
+
+\"\"\"The output of our create \`CompoundKey\` mutation.\"\"\"
+type CreateCompoundKeyPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`CompoundKey\` that was created by this mutation.\"\"\"
+  compoundKey: CompoundKey
+
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
+  compoundKeyEdge(
+    \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId1: Person
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId2: Person
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the create \`EdgeCase\` mutation.\"\"\"
+input CreateEdgeCaseInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`EdgeCase\` to be created by this mutation.\"\"\"
+  edgeCase: EdgeCaseInput!
+}
+
+\"\"\"The output of our create \`EdgeCase\` mutation.\"\"\"
+type CreateEdgeCasePayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`EdgeCase\` that was created by this mutation.\"\"\"
+  edgeCase: EdgeCase
+
+  \"\"\"An edge for our \`EdgeCase\`. May be used by Relay 1.\"\"\"
+  edgeCaseEdge(
+    \"\"\"The method to use when ordering \`EdgeCase\`.\"\"\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the create \`ForeignKey\` mutation.\"\"\"
+input CreateForeignKeyInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`ForeignKey\` to be created by this mutation.\"\"\"
+  foreignKey: ForeignKeyInput!
+}
+
+\"\"\"The output of our create \`ForeignKey\` mutation.\"\"\"
+type CreateForeignKeyPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.\"\"\"
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+
+  \"\"\"The \`ForeignKey\` that was created by this mutation.\"\"\"
+  foreignKey: ForeignKey
+
+  \"\"\"An edge for our \`ForeignKey\`. May be used by Relay 1.\"\"\"
+  foreignKeyEdge(
+    \"\"\"The method to use when ordering \`ForeignKey\`.\"\"\"
+    orderBy: [ForeignKeysOrderBy!] = [NATURAL]
+  ): ForeignKeysEdge
+
+  \"\"\"Reads a single \`Person\` that is related to this \`ForeignKey\`.\"\"\"
+  personByPersonId: Person
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the create \`Person\` mutation.\"\"\"
+input CreatePersonInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`Person\` to be created by this mutation.\"\"\"
+  person: PersonInput!
+}
+
+\"\"\"The output of our create \`Person\` mutation.\"\"\"
+type CreatePersonPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`Person\` that was created by this mutation.\"\"\"
+  person: Person
+
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
+  personEdge(
+    \"\"\"The method to use when ordering \`Person\`.\"\"\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the create \`Post\` mutation.\"\"\"
+input CreatePostInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`Post\` to be created by this mutation.\"\"\"
+  post: PostInput!
+}
+
+\"\"\"The output of our create \`Post\` mutation.\"\"\"
+type CreatePostPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
+  personByAuthorId: Person
+
+  \"\"\"The \`Post\` that was created by this mutation.\"\"\"
+  post: Post
+
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
+  postEdge(
+    \"\"\"The method to use when ordering \`Post\`.\"\"\"
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the create \`SimilarTable1\` mutation.\"\"\"
+input CreateSimilarTable1Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`SimilarTable1\` to be created by this mutation.\"\"\"
+  similarTable1: SimilarTable1Input!
+}
+
+\"\"\"The output of our create \`SimilarTable1\` mutation.\"\"\"
+type CreateSimilarTable1Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`SimilarTable1\` that was created by this mutation.\"\"\"
+  similarTable1: SimilarTable1
+
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
+  similarTable1Edge(
+    \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable1SEdge
+}
+
+\"\"\"All input for the create \`SimilarTable2\` mutation.\"\"\"
+input CreateSimilarTable2Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`SimilarTable2\` to be created by this mutation.\"\"\"
+  similarTable2: SimilarTable2Input!
+}
+
+\"\"\"The output of our create \`SimilarTable2\` mutation.\"\"\"
+type CreateSimilarTable2Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`SimilarTable2\` that was created by this mutation.\"\"\"
+  similarTable2: SimilarTable2
+
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
+  similarTable2Edge(
+    \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable2SEdge
+}
+
+\"\"\"All input for the create \`Type\` mutation.\"\"\"
+input CreateTypeInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`Type\` to be created by this mutation.\"\"\"
+  type: TypeInput!
+}
+
+\"\"\"The output of our create \`Type\` mutation.\"\"\"
+type CreateTypePayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`Type\` that was created by this mutation.\"\"\"
+  type: Type
+
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
+  typeEdge(
+    \"\"\"The method to use when ordering \`Type\`.\"\"\"
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TypesEdge
+}
+
+\"\"\"All input for the create \`UpdatableView\` mutation.\"\"\"
+input CreateUpdatableViewInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`UpdatableView\` to be created by this mutation.\"\"\"
+  updatableView: UpdatableViewInput!
+}
+
+\"\"\"The output of our create \`UpdatableView\` mutation.\"\"\"
+type CreateUpdatableViewPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`UpdatableView\` that was created by this mutation.\"\"\"
+  updatableView: UpdatableView
+
+  \"\"\"An edge for our \`UpdatableView\`. May be used by Relay 1.\"\"\"
+  updatableViewEdge(
+    \"\"\"The method to use when ordering \`UpdatableView\`.\"\"\"
+    orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
+  ): UpdatableViewsEdge
+}
+
+\"\"\"A location in a connection that can be used for resuming pagination.\"\"\"
+scalar Cursor
+
+\"\"\"The day, does not include a time.\"\"\"
+scalar Date
+
+\"\"\"A range of \`Date\`.\"\"\"
+type DateRange {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: DateRangeBound
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: DateRangeBound
+}
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+type DateRangeBound {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: Date!
+}
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+input DateRangeBoundInput {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: Date!
+}
+
+\"\"\"A range of \`Date\`.\"\"\"
+input DateRangeInput {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: DateRangeBoundInput
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: DateRangeBoundInput
+}
+
+\"\"\"
+A point in time as described by the [ISO
+8601](https://en.wikipedia.org/wiki/ISO_8601) standard. May or may not include a timezone.
+\"\"\"
+scalar Datetime
+
+\"\"\"
+All input for the \`deleteCompoundKeyByPersonId1AndPersonId2\` mutation.
+\"\"\"
+input DeleteCompoundKeyByPersonId1AndPersonId2Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  personId1: Int!
+  personId2: Int!
+}
+
+\"\"\"All input for the \`deleteCompoundKey\` mutation.\"\"\"
+input DeleteCompoundKeyInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be deleted.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our delete \`CompoundKey\` mutation.\"\"\"
+type DeleteCompoundKeyPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`CompoundKey\` that was deleted by this mutation.\"\"\"
+  compoundKey: CompoundKey
+
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
+  compoundKeyEdge(
+    \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+  deletedCompoundKeyId: ID
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId1: Person
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId2: Person
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`deletePersonByEmail\` mutation.\"\"\"
+input DeletePersonByEmailInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  email: Email!
+}
+
+\"\"\"All input for the \`deletePersonById\` mutation.\"\"\"
+input DeletePersonByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+}
+
+\"\"\"All input for the \`deletePerson\` mutation.\"\"\"
+input DeletePersonInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be deleted.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our delete \`Person\` mutation.\"\"\"
+type DeletePersonPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  deletedPersonId: ID
+
+  \"\"\"The \`Person\` that was deleted by this mutation.\"\"\"
+  person: Person
+
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
+  personEdge(
+    \"\"\"The method to use when ordering \`Person\`.\"\"\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`deletePostById\` mutation.\"\"\"
+input DeletePostByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+}
+
+\"\"\"All input for the \`deletePost\` mutation.\"\"\"
+input DeletePostInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`Post\` to be deleted.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our delete \`Post\` mutation.\"\"\"
+type DeletePostPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  deletedPostId: ID
+
+  \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
+  personByAuthorId: Person
+
+  \"\"\"The \`Post\` that was deleted by this mutation.\"\"\"
+  post: Post
+
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
+  postEdge(
+    \"\"\"The method to use when ordering \`Post\`.\"\"\"
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`deleteSimilarTable1ById\` mutation.\"\"\"
+input DeleteSimilarTable1ByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+}
+
+\"\"\"All input for the \`deleteSimilarTable1\` mutation.\"\"\"
+input DeleteSimilarTable1Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`SimilarTable1\` to be deleted.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our delete \`SimilarTable1\` mutation.\"\"\"
+type DeleteSimilarTable1Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  deletedSimilarTable1Id: ID
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`SimilarTable1\` that was deleted by this mutation.\"\"\"
+  similarTable1: SimilarTable1
+
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
+  similarTable1Edge(
+    \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable1SEdge
+}
+
+\"\"\"All input for the \`deleteSimilarTable2ById\` mutation.\"\"\"
+input DeleteSimilarTable2ByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+}
+
+\"\"\"All input for the \`deleteSimilarTable2\` mutation.\"\"\"
+input DeleteSimilarTable2Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`SimilarTable2\` to be deleted.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our delete \`SimilarTable2\` mutation.\"\"\"
+type DeleteSimilarTable2Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  deletedSimilarTable2Id: ID
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`SimilarTable2\` that was deleted by this mutation.\"\"\"
+  similarTable2: SimilarTable2
+
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
+  similarTable2Edge(
+    \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable2SEdge
+}
+
+\"\"\"All input for the \`deleteTypeById\` mutation.\"\"\"
+input DeleteTypeByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+}
+
+\"\"\"All input for the \`deleteType\` mutation.\"\"\"
+input DeleteTypeInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`Type\` to be deleted.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our delete \`Type\` mutation.\"\"\"
+type DeleteTypePayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  deletedTypeId: ID
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`Type\` that was deleted by this mutation.\"\"\"
+  type: Type
+
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
+  typeEdge(
+    \"\"\"The method to use when ordering \`Type\`.\"\"\"
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TypesEdge
+}
+
+type EdgeCase {
+  computed: String
+  notNullHasDefault: Boolean!
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\"\"\"
+A condition to be used against \`EdgeCase\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\"\"\"
+input EdgeCaseCondition {
+  \"\"\"Checks for equality with the object’s \`notNullHasDefault\` field.\"\"\"
+  notNullHasDefault: Boolean
+
+  \"\"\"Checks for equality with the object’s \`rowId\` field.\"\"\"
+  rowId: Int
+
+  \"\"\"Checks for equality with the object’s \`wontCastEasy\` field.\"\"\"
+  wontCastEasy: Int
+}
+
+\"\"\"An input for mutations affecting \`EdgeCase\`\"\"\"
+input EdgeCaseInput {
+  notNullHasDefault: Boolean
+  rowId: Int
+  wontCastEasy: Int
+}
+
+\"\"\"A connection to a list of \`EdgeCase\` values.\"\"\"
+type EdgeCasesConnection {
+  \"\"\"
+  A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [EdgeCasesEdge!]!
+
+  \"\"\"A list of \`EdgeCase\` objects.\"\"\"
+  nodes: [EdgeCase]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`EdgeCase\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`EdgeCase\` edge in the connection.\"\"\"
+type EdgeCasesEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`EdgeCase\` at the end of the edge.\"\"\"
+  node: EdgeCase
+}
+
+\"\"\"Methods to use when ordering \`EdgeCase\`.\"\"\"
+enum EdgeCasesOrderBy {
+  NATURAL
+  NOT_NULL_HAS_DEFAULT_ASC
+  NOT_NULL_HAS_DEFAULT_DESC
+  ROW_ID_ASC
+  ROW_ID_DESC
+  WONT_CAST_EASY_ASC
+  WONT_CAST_EASY_DESC
+}
+
+scalar Email
+
+\"\"\"
+The value at one end of a range. A range can either include this value, or not.
+\"\"\"
+input FloatRangeBoundInput {
+  \"\"\"Whether or not the value of this bound is included in the range.\"\"\"
+  inclusive: Boolean!
+
+  \"\"\"The value at one end of our range.\"\"\"
+  value: Float!
+}
+
+\"\"\"A range of \`Float\`.\"\"\"
+input FloatRangeInput {
+  \"\"\"The ending bound of our range.\"\"\"
+  end: FloatRangeBoundInput
+
+  \"\"\"The starting bound of our range.\"\"\"
+  start: FloatRangeBoundInput
+}
+
+type ForeignKey {
+  compoundKey1: Int
+  compoundKey2: Int
+
+  \"\"\"Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.\"\"\"
+  compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
+
+  \"\"\"Reads a single \`Person\` that is related to this \`ForeignKey\`.\"\"\"
+  personByPersonId: Person
+  personId: Int
+}
+
+\"\"\"
+A condition to be used against \`ForeignKey\` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+\"\"\"
+input ForeignKeyCondition {
+  \"\"\"Checks for equality with the object’s \`compoundKey1\` field.\"\"\"
+  compoundKey1: Int
+
+  \"\"\"Checks for equality with the object’s \`compoundKey2\` field.\"\"\"
+  compoundKey2: Int
+
+  \"\"\"Checks for equality with the object’s \`personId\` field.\"\"\"
+  personId: Int
+}
+
+\"\"\"An input for mutations affecting \`ForeignKey\`\"\"\"
+input ForeignKeyInput {
+  compoundKey1: Int
+  compoundKey2: Int
+  personId: Int
+}
+
+\"\"\"A connection to a list of \`ForeignKey\` values.\"\"\"
+type ForeignKeysConnection {
+  \"\"\"
+  A list of edges which contains the \`ForeignKey\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [ForeignKeysEdge!]!
+
+  \"\"\"A list of \`ForeignKey\` objects.\"\"\"
+  nodes: [ForeignKey]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`ForeignKey\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`ForeignKey\` edge in the connection.\"\"\"
+type ForeignKeysEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`ForeignKey\` at the end of the edge.\"\"\"
+  node: ForeignKey
+}
+
+\"\"\"Methods to use when ordering \`ForeignKey\`.\"\"\"
+enum ForeignKeysOrderBy {
+  COMPOUND_KEY_1_ASC
+  COMPOUND_KEY_1_DESC
+  COMPOUND_KEY_2_ASC
+  COMPOUND_KEY_2_DESC
+  NATURAL
+  PERSON_ID_ASC
+  PERSON_ID_DESC
+}
+
+\"\"\"
+An interval of time that has passed where the smallest distinct unit is a second.
+\"\"\"
+type Interval {
+  \"\"\"A quantity of days.\"\"\"
+  days: Int
+
+  \"\"\"A quantity of hours.\"\"\"
+  hours: Int
+
+  \"\"\"A quantity of minutes.\"\"\"
+  minutes: Int
+
+  \"\"\"A quantity of months.\"\"\"
+  months: Int
+
+  \"\"\"
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  \"\"\"
+  seconds: Float
+
+  \"\"\"A quantity of years.\"\"\"
+  years: Int
+}
+
+\"\"\"
+An interval of time that has passed where the smallest distinct unit is a second.
+\"\"\"
+input IntervalInput {
+  \"\"\"A quantity of days.\"\"\"
+  days: Int
+
+  \"\"\"A quantity of hours.\"\"\"
+  hours: Int
+
+  \"\"\"A quantity of minutes.\"\"\"
+  minutes: Int
+
+  \"\"\"A quantity of months.\"\"\"
+  months: Int
+
+  \"\"\"
+  A quantity of seconds. This is the only non-integer field, as all the other
+  fields will dump their overflow into a smaller unit of time. Intervals don’t
+  have a smaller unit than seconds.
+  \"\"\"
+  seconds: Float
+
+  \"\"\"A quantity of years.\"\"\"
+  years: Int
+}
+
+\"\"\"All input for the \`intSetMutation\` mutation.\"\"\"
+input IntSetMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  x: Int
+  y: Int
+  z: Int
+}
+
+\"\"\"The output of our \`intSetMutation\` mutation.\"\"\"
+type IntSetMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integers: [Int]
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"A connection to a list of \`Int\` values.\"\"\"
+type IntSetQueryConnection {
+  \"\"\"
+  A list of edges which contains the \`Int\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [IntSetQueryEdge!]!
+
+  \"\"\"A list of \`Int\` objects.\"\"\"
+  nodes: [Int]!
+}
+
+\"\"\"A \`Int\` edge in the connection.\"\"\"
+type IntSetQueryEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`Int\` at the end of the edge.\"\"\"
+  node: Int
+}
+
+\"\"\"
+A JavaScript object encoded in the JSON format as specified by [ECMA-404](http://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf).
+\"\"\"
+scalar JSON
+
+\"\"\"All input for the \`jsonIdentityMutation\` mutation.\"\"\"
+input JsonIdentityMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  json: JSON
+}
+
+\"\"\"The output of our \`jsonIdentityMutation\` mutation.\"\"\"
+type JsonIdentityMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  json: JSON
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+type JwtToken {
+  a: Int
+  b: Int
+  c: Int
+  exp: Int
+  role: String
+}
+
+\"\"\"All input for the \`mult1\` mutation.\"\"\"
+input Mult1Input {
+  arg0: Int
+  arg1: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`mult1\` mutation.\"\"\"
+type Mult1Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`mult2\` mutation.\"\"\"
+input Mult2Input {
+  arg0: Int
+  arg1: Int
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`mult2\` mutation.\"\"\"
+type Mult2Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`mult3\` mutation.\"\"\"
+input Mult3Input {
+  arg0: Int!
+  arg1: Int!
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`mult3\` mutation.\"\"\"
+type Mult3Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`mult4\` mutation.\"\"\"
+input Mult4Input {
+  arg0: Int!
+  arg1: Int!
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`mult4\` mutation.\"\"\"
+type Mult4Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"
+The root mutation type which contains root level fields which mutate data.
+\"\"\"
+type Mutation {
+  \"\"\"lol, add some stuff 1 mutation\"\"\"
+  add1Mutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Add1MutationInput!
+  ): Add1MutationPayload
+
+  \"\"\"lol, add some stuff 2 mutation\"\"\"
+  add2Mutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Add2MutationInput!
+  ): Add2MutationPayload
+
+  \"\"\"lol, add some stuff 3 mutation\"\"\"
+  add3Mutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Add3MutationInput!
+  ): Add3MutationPayload
+
+  \"\"\"lol, add some stuff 4 mutation\"\"\"
+  add4Mutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Add4MutationInput!
+  ): Add4MutationPayload
+  authenticate(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: AuthenticateInput!
+  ): AuthenticatePayload
+  authenticateMany(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: AuthenticateManyInput!
+  ): AuthenticateManyPayload
+  compoundTypeMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CompoundTypeMutationInput!
+  ): CompoundTypeMutationPayload
+
+  \"\"\"Creates a single \`CompoundKey\`.\"\"\"
+  createCompoundKey(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateCompoundKeyInput!
+  ): CreateCompoundKeyPayload
+
+  \"\"\"Creates a single \`EdgeCase\`.\"\"\"
+  createEdgeCase(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateEdgeCaseInput!
+  ): CreateEdgeCasePayload
+
+  \"\"\"Creates a single \`ForeignKey\`.\"\"\"
+  createForeignKey(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateForeignKeyInput!
+  ): CreateForeignKeyPayload
+
+  \"\"\"Creates a single \`Person\`.\"\"\"
+  createPerson(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreatePersonInput!
+  ): CreatePersonPayload
+
+  \"\"\"Creates a single \`Post\`.\"\"\"
+  createPost(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreatePostInput!
+  ): CreatePostPayload
+
+  \"\"\"Creates a single \`SimilarTable1\`.\"\"\"
+  createSimilarTable1(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateSimilarTable1Input!
+  ): CreateSimilarTable1Payload
+
+  \"\"\"Creates a single \`SimilarTable2\`.\"\"\"
+  createSimilarTable2(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateSimilarTable2Input!
+  ): CreateSimilarTable2Payload
+
+  \"\"\"Creates a single \`Type\`.\"\"\"
+  createType(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateTypeInput!
+  ): CreateTypePayload
+
+  \"\"\"Creates a single \`UpdatableView\`.\"\"\"
+  createUpdatableView(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: CreateUpdatableViewInput!
+  ): CreateUpdatableViewPayload
+
+  \"\"\"Deletes a single \`CompoundKey\` using its globally unique id.\"\"\"
+  deleteCompoundKey(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteCompoundKeyInput!
+  ): DeleteCompoundKeyPayload
+
+  \"\"\"Deletes a single \`CompoundKey\` using a unique key.\"\"\"
+  deleteCompoundKeyByPersonId1AndPersonId2(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteCompoundKeyByPersonId1AndPersonId2Input!
+  ): DeleteCompoundKeyPayload
+
+  \"\"\"Deletes a single \`Person\` using its globally unique id.\"\"\"
+  deletePerson(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeletePersonInput!
+  ): DeletePersonPayload
+
+  \"\"\"Deletes a single \`Person\` using a unique key.\"\"\"
+  deletePersonByEmail(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeletePersonByEmailInput!
+  ): DeletePersonPayload
+
+  \"\"\"Deletes a single \`Person\` using a unique key.\"\"\"
+  deletePersonById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeletePersonByIdInput!
+  ): DeletePersonPayload
+
+  \"\"\"Deletes a single \`Post\` using its globally unique id.\"\"\"
+  deletePost(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeletePostInput!
+  ): DeletePostPayload
+
+  \"\"\"Deletes a single \`Post\` using a unique key.\"\"\"
+  deletePostById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeletePostByIdInput!
+  ): DeletePostPayload
+
+  \"\"\"Deletes a single \`SimilarTable1\` using its globally unique id.\"\"\"
+  deleteSimilarTable1(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteSimilarTable1Input!
+  ): DeleteSimilarTable1Payload
+
+  \"\"\"Deletes a single \`SimilarTable1\` using a unique key.\"\"\"
+  deleteSimilarTable1ById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteSimilarTable1ByIdInput!
+  ): DeleteSimilarTable1Payload
+
+  \"\"\"Deletes a single \`SimilarTable2\` using its globally unique id.\"\"\"
+  deleteSimilarTable2(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteSimilarTable2Input!
+  ): DeleteSimilarTable2Payload
+
+  \"\"\"Deletes a single \`SimilarTable2\` using a unique key.\"\"\"
+  deleteSimilarTable2ById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteSimilarTable2ByIdInput!
+  ): DeleteSimilarTable2Payload
+
+  \"\"\"Deletes a single \`Type\` using its globally unique id.\"\"\"
+  deleteType(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteTypeInput!
+  ): DeleteTypePayload
+
+  \"\"\"Deletes a single \`Type\` using a unique key.\"\"\"
+  deleteTypeById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: DeleteTypeByIdInput!
+  ): DeleteTypePayload
+  intSetMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: IntSetMutationInput!
+  ): IntSetMutationPayload
+  jsonIdentityMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: JsonIdentityMutationInput!
+  ): JsonIdentityMutationPayload
+  mult1(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Mult1Input!
+  ): Mult1Payload
+  mult2(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Mult2Input!
+  ): Mult2Payload
+  mult3(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Mult3Input!
+  ): Mult3Payload
+  mult4(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: Mult4Input!
+  ): Mult4Payload
+  noArgsMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: NoArgsMutationInput!
+  ): NoArgsMutationPayload
+  returnVoidMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: ReturnVoidMutationInput!
+  ): ReturnVoidMutationPayload
+  tableMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: TableMutationInput!
+  ): TableMutationPayload
+
+  \"\"\"Reads and enables pagination through a set of \`Person\`.\"\"\"
+  tableSetMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: TableSetMutationInput!
+  ): TableSetMutationPayload
+  typesMutation(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: TypesMutationInput!
+  ): TypesMutationPayload
+
+  \"\"\"
+  Updates a single \`CompoundKey\` using its globally unique id and a patch.
+  \"\"\"
+  updateCompoundKey(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateCompoundKeyInput!
+  ): UpdateCompoundKeyPayload
+
+  \"\"\"Updates a single \`CompoundKey\` using a unique key and a patch.\"\"\"
+  updateCompoundKeyByPersonId1AndPersonId2(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateCompoundKeyByPersonId1AndPersonId2Input!
+  ): UpdateCompoundKeyPayload
+
+  \"\"\"Updates a single \`Person\` using its globally unique id and a patch.\"\"\"
+  updatePerson(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdatePersonInput!
+  ): UpdatePersonPayload
+
+  \"\"\"Updates a single \`Person\` using a unique key and a patch.\"\"\"
+  updatePersonByEmail(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdatePersonByEmailInput!
+  ): UpdatePersonPayload
+
+  \"\"\"Updates a single \`Person\` using a unique key and a patch.\"\"\"
+  updatePersonById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdatePersonByIdInput!
+  ): UpdatePersonPayload
+
+  \"\"\"Updates a single \`Post\` using its globally unique id and a patch.\"\"\"
+  updatePost(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdatePostInput!
+  ): UpdatePostPayload
+
+  \"\"\"Updates a single \`Post\` using a unique key and a patch.\"\"\"
+  updatePostById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdatePostByIdInput!
+  ): UpdatePostPayload
+
+  \"\"\"
+  Updates a single \`SimilarTable1\` using its globally unique id and a patch.
+  \"\"\"
+  updateSimilarTable1(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateSimilarTable1Input!
+  ): UpdateSimilarTable1Payload
+
+  \"\"\"Updates a single \`SimilarTable1\` using a unique key and a patch.\"\"\"
+  updateSimilarTable1ById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateSimilarTable1ByIdInput!
+  ): UpdateSimilarTable1Payload
+
+  \"\"\"
+  Updates a single \`SimilarTable2\` using its globally unique id and a patch.
+  \"\"\"
+  updateSimilarTable2(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateSimilarTable2Input!
+  ): UpdateSimilarTable2Payload
+
+  \"\"\"Updates a single \`SimilarTable2\` using a unique key and a patch.\"\"\"
+  updateSimilarTable2ById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateSimilarTable2ByIdInput!
+  ): UpdateSimilarTable2Payload
+
+  \"\"\"Updates a single \`Type\` using its globally unique id and a patch.\"\"\"
+  updateType(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateTypeInput!
+  ): UpdateTypePayload
+
+  \"\"\"Updates a single \`Type\` using a unique key and a patch.\"\"\"
+  updateTypeById(
+    \"\"\"
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    \"\"\"
+    input: UpdateTypeByIdInput!
+  ): UpdateTypePayload
+}
+
+type NestedCompoundType {
+  a: CompoundType
+  b: CompoundType
+  bazBuz: Int
+}
+
+\"\"\"An input for mutations affecting \`NestedCompoundType\`\"\"\"
+input NestedCompoundTypeInput {
+  a: CompoundTypeInput
+  b: CompoundTypeInput
+  bazBuz: Int
+}
+
+\"\"\"All input for the \`noArgsMutation\` mutation.\"\"\"
+input NoArgsMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`noArgsMutation\` mutation.\"\"\"
+type NoArgsMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  integer: Int
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"An object with a globally unique \`ID\`.\"\"\"
+interface Node {
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+}
+
+type NonUpdatableView {
+  column: Int
+}
+
+\"\"\"
+A condition to be used against \`NonUpdatableView\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\"\"\"
+input NonUpdatableViewCondition {
+  \"\"\"Checks for equality with the object’s \`column\` field.\"\"\"
+  column: Int
+}
+
+\"\"\"A connection to a list of \`NonUpdatableView\` values.\"\"\"
+type NonUpdatableViewsConnection {
+  \"\"\"
+  A list of edges which contains the \`NonUpdatableView\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [NonUpdatableViewsEdge!]!
+
+  \"\"\"A list of \`NonUpdatableView\` objects.\"\"\"
+  nodes: [NonUpdatableView]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"
+  The count of *all* \`NonUpdatableView\` you could get from the connection.
+  \"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`NonUpdatableView\` edge in the connection.\"\"\"
+type NonUpdatableViewsEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`NonUpdatableView\` at the end of the edge.\"\"\"
+  node: NonUpdatableView
+}
+
+\"\"\"Methods to use when ordering \`NonUpdatableView\`.\"\"\"
+enum NonUpdatableViewsOrderBy {
+  COLUMN_ASC
+  COLUMN_DESC
+  NATURAL
+}
+
+\"\"\"Information about pagination in a connection.\"\"\"
+type PageInfo {
+  \"\"\"When paginating forwards, the cursor to continue.\"\"\"
+  endCursor: Cursor
+
+  \"\"\"When paginating forwards, are there more items?\"\"\"
+  hasNextPage: Boolean!
+
+  \"\"\"When paginating backwards, are there more items?\"\"\"
+  hasPreviousPage: Boolean!
+
+  \"\"\"When paginating backwards, the cursor to continue.\"\"\"
+  startCursor: Cursor
+}
+
+\"\"\"A connection to a list of \`Person\` values.\"\"\"
+type PeopleConnection {
+  \"\"\"
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [PeopleEdge!]!
+
+  \"\"\"A list of \`Person\` objects.\"\"\"
+  nodes: [Person]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`Person\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`Person\` edge in the connection.\"\"\"
+type PeopleEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`Person\` at the end of the edge.\"\"\"
+  node: Person
+}
+
+\"\"\"Methods to use when ordering \`Person\`.\"\"\"
+enum PeopleOrderBy {
+  ABOUT_ASC
+  ABOUT_DESC
+  CREATED_AT_ASC
+  CREATED_AT_DESC
+  EMAIL_ASC
+  EMAIL_DESC
+  ID_ASC
+  ID_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\"\"\"Person test comment\"\"\"
+type Person implements Node {
+  about: String
+
+  \"\"\"Reads and enables pagination through a set of \`CompoundKey\`.\"\"\"
+  compoundKeysByPersonId1(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: CompoundKeyCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection!
+
+  \"\"\"Reads and enables pagination through a set of \`CompoundKey\`.\"\"\"
+  compoundKeysByPersonId2(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: CompoundKeyCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection!
+  createdAt: Datetime
+  email: Email!
+  firstName: String
+  firstPost: Post
+
+  \"\"\"Reads and enables pagination through a set of \`ForeignKey\`.\"\"\"
+  foreignKeysByPersonId(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: ForeignKeyCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`ForeignKey\`.\"\"\"
+    orderBy: [ForeignKeysOrderBy!] = [NATURAL]
+  ): ForeignKeysConnection!
+
+  \"\"\"Reads and enables pagination through a set of \`Person\`.\"\"\"
+  friends(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+  ): PeopleConnection!
+  id: Int!
+
+  \"\"\"The person’s name\"\"\"
+  name: String!
+
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"Reads and enables pagination through a set of \`Post\`.\"\"\"
+  postsByAuthorId(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: PostCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`Post\`.\"\"\"
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsConnection!
+}
+
+\"\"\"
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\"\"\"
+input PersonCondition {
+  \"\"\"Checks for equality with the object’s \`about\` field.\"\"\"
+  about: String
+
+  \"\"\"Checks for equality with the object’s \`createdAt\` field.\"\"\"
+  createdAt: Datetime
+
+  \"\"\"Checks for equality with the object’s \`email\` field.\"\"\"
+  email: Email
+
+  \"\"\"Checks for equality with the object’s \`id\` field.\"\"\"
+  id: Int
+
+  \"\"\"Checks for equality with the object’s \`name\` field.\"\"\"
+  name: String
+}
+
+\"\"\"An input for mutations affecting \`Person\`\"\"\"
+input PersonInput {
+  about: String
+  createdAt: Datetime
+  email: Email!
+  id: Int
+
+  \"\"\"The person’s name\"\"\"
+  name: String!
+}
+
+\"\"\"
+Represents an update to a \`Person\`. Fields that are set will be updated.
+\"\"\"
+input PersonPatch {
+  about: String
+  createdAt: Datetime
+  email: Email
+  id: Int
+
+  \"\"\"The person’s name\"\"\"
+  name: String
+}
+
+type Post implements Node {
+  authorId: Int
+  body: String
+  headline: String!
+  headlineTrimmed(length: Int, omission: String): String
+  id: Int!
+
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
+  personByAuthorId: Person
+}
+
+\"\"\"
+A condition to be used against \`Post\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\"\"\"
+input PostCondition {
+  \"\"\"Checks for equality with the object’s \`authorId\` field.\"\"\"
+  authorId: Int
+
+  \"\"\"Checks for equality with the object’s \`body\` field.\"\"\"
+  body: String
+
+  \"\"\"Checks for equality with the object’s \`headline\` field.\"\"\"
+  headline: String
+
+  \"\"\"Checks for equality with the object’s \`id\` field.\"\"\"
+  id: Int
+}
+
+\"\"\"An input for mutations affecting \`Post\`\"\"\"
+input PostInput {
+  authorId: Int
+  body: String
+  headline: String!
+  id: Int
+}
+
+\"\"\"
+Represents an update to a \`Post\`. Fields that are set will be updated.
+\"\"\"
+input PostPatch {
+  authorId: Int
+  body: String
+  headline: String
+  id: Int
+}
+
+\"\"\"A connection to a list of \`Post\` values.\"\"\"
+type PostsConnection {
+  \"\"\"
+  A list of edges which contains the \`Post\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [PostsEdge!]!
+
+  \"\"\"A list of \`Post\` objects.\"\"\"
+  nodes: [Post]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`Post\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`Post\` edge in the connection.\"\"\"
+type PostsEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`Post\` at the end of the edge.\"\"\"
+  node: Post
+}
+
+\"\"\"Methods to use when ordering \`Post\`.\"\"\"
+enum PostsOrderBy {
+  AUTHOR_ID_ASC
+  AUTHOR_ID_DESC
+  BODY_ASC
+  BODY_DESC
+  HEADLINE_ASC
+  HEADLINE_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\"\"\"The root query type which gives access points into the data universe.\"\"\"
+type Query implements Node {
+  \"\"\"lol, add some stuff 1 query\"\"\"
+  add1Query(arg0: Int!, arg1: Int!): Int
+
+  \"\"\"lol, add some stuff 2 query\"\"\"
+  add2Query(a: Int!, b: Int): Int
+
+  \"\"\"lol, add some stuff 3 query\"\"\"
+  add3Query(a: Int, arg1: Int): Int
+
+  \"\"\"lol, add some stuff 4 query\"\"\"
+  add4Query(arg0: Int, b: Int): Int
+
+  \"\"\"Reads and enables pagination through a set of \`CompoundKey\`.\"\"\"
+  allCompoundKeys(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: CompoundKeyCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysConnection
+
+  \"\"\"Reads and enables pagination through a set of \`EdgeCase\`.\"\"\"
+  allEdgeCases(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: EdgeCaseCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`EdgeCase\`.\"\"\"
+    orderBy: [EdgeCasesOrderBy!] = [NATURAL]
+  ): EdgeCasesConnection
+
+  \"\"\"Reads and enables pagination through a set of \`ForeignKey\`.\"\"\"
+  allForeignKeys(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: ForeignKeyCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`ForeignKey\`.\"\"\"
+    orderBy: [ForeignKeysOrderBy!] = [NATURAL]
+  ): ForeignKeysConnection
+
+  \"\"\"Reads and enables pagination through a set of \`NonUpdatableView\`.\"\"\"
+  allNonUpdatableViews(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: NonUpdatableViewCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`NonUpdatableView\`.\"\"\"
+    orderBy: [NonUpdatableViewsOrderBy!] = [NATURAL]
+  ): NonUpdatableViewsConnection
+
+  \"\"\"Reads and enables pagination through a set of \`Person\`.\"\"\"
+  allPeople(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: PersonCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`Person\`.\"\"\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleConnection
+
+  \"\"\"Reads and enables pagination through a set of \`Post\`.\"\"\"
+  allPosts(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: PostCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`Post\`.\"\"\"
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsConnection
+
+  \"\"\"Reads and enables pagination through a set of \`SimilarTable1\`.\"\"\"
+  allSimilarTable1S(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: SimilarTable1Condition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable1SConnection
+
+  \"\"\"Reads and enables pagination through a set of \`SimilarTable2\`.\"\"\"
+  allSimilarTable2S(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: SimilarTable2Condition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable2SConnection
+
+  \"\"\"Reads and enables pagination through a set of \`Type\`.\"\"\"
+  allTypes(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: TypeCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`Type\`.\"\"\"
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TypesConnection
+
+  \"\"\"Reads and enables pagination through a set of \`UpdatableView\`.\"\"\"
+  allUpdatableViews(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"
+    A condition to be used in determining which values should be returned by the collection.
+    \"\"\"
+    condition: UpdatableViewCondition
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+
+    \"\"\"The method to use when ordering \`UpdatableView\`.\"\"\"
+    orderBy: [UpdatableViewsOrderBy!] = [NATURAL]
+  ): UpdatableViewsConnection
+
+  \"\"\"Reads a single \`CompoundKey\` using its globally unique \`ID\`.\"\"\"
+  compoundKey(
+    \"\"\"
+    The globally unique \`ID\` to be used in selecting a single \`CompoundKey\`.
+    \"\"\"
+    nodeId: ID!
+  ): CompoundKey
+  compoundKeyByPersonId1AndPersonId2(personId1: Int!, personId2: Int!): CompoundKey
+  compoundTypeQuery(object: CompoundTypeInput): CompoundType
+  intSetQuery(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+    x: Int
+    y: Int
+    z: Int
+  ): IntSetQueryConnection!
+  jsonIdentity(json: JSON): JSON
+  noArgsQuery: Int
+
+  \"\"\"Fetches an object given its globally unique \`ID\`.\"\"\"
+  node(
+    \"\"\"The globally unique \`ID\`.\"\"\"
+    nodeId: ID!
+  ): Node
+
+  \"\"\"
+  The root query type must be a \`Node\` to work well with Relay 1 mutations. This just resolves to \`query\`.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"Reads a single \`Person\` using its globally unique \`ID\`.\"\"\"
+  person(
+    \"\"\"The globally unique \`ID\` to be used in selecting a single \`Person\`.\"\"\"
+    nodeId: ID!
+  ): Person
+  personByEmail(email: Email!): Person
+  personById(id: Int!): Person
+
+  \"\"\"Reads a single \`Post\` using its globally unique \`ID\`.\"\"\"
+  post(
+    \"\"\"The globally unique \`ID\` to be used in selecting a single \`Post\`.\"\"\"
+    nodeId: ID!
+  ): Post
+  postById(id: Int!): Post
+
+  \"\"\"
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  \"\"\"
+  query: Query!
+
+  \"\"\"Reads a single \`SimilarTable1\` using its globally unique \`ID\`.\"\"\"
+  similarTable1(
+    \"\"\"
+    The globally unique \`ID\` to be used in selecting a single \`SimilarTable1\`.
+    \"\"\"
+    nodeId: ID!
+  ): SimilarTable1
+  similarTable1ById(id: Int!): SimilarTable1
+
+  \"\"\"Reads a single \`SimilarTable2\` using its globally unique \`ID\`.\"\"\"
+  similarTable2(
+    \"\"\"
+    The globally unique \`ID\` to be used in selecting a single \`SimilarTable2\`.
+    \"\"\"
+    nodeId: ID!
+  ): SimilarTable2
+  similarTable2ById(id: Int!): SimilarTable2
+  tableQuery(id: Int): Post
+
+  \"\"\"Reads and enables pagination through a set of \`Person\`.\"\"\"
+  tableSetQuery(
+    \"\"\"Read all values in the set after (below) this cursor.\"\"\"
+    after: Cursor
+
+    \"\"\"Read all values in the set before (above) this cursor.\"\"\"
+    before: Cursor
+
+    \"\"\"Only read the first \`n\` values of the set.\"\"\"
+    first: Int
+
+    \"\"\"Only read the last \`n\` values of the set.\"\"\"
+    last: Int
+
+    \"\"\"
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    \"\"\"
+    offset: Int
+  ): PeopleConnection!
+
+  \"\"\"Reads a single \`Type\` using its globally unique \`ID\`.\"\"\"
+  type(
+    \"\"\"The globally unique \`ID\` to be used in selecting a single \`Type\`.\"\"\"
+    nodeId: ID!
+  ): Type
+  typeById(id: Int!): Type
+  typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
+}
+
+\"\"\"All input for the \`returnVoidMutation\` mutation.\"\"\"
+input ReturnVoidMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`returnVoidMutation\` mutation.\"\"\"
+type ReturnVoidMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+type SimilarTable1 implements Node {
+  col1: Int
+  col2: Int
+  col3: Int!
+  id: Int!
+
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"
+A condition to be used against \`SimilarTable1\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\"\"\"
+input SimilarTable1Condition {
+  \"\"\"Checks for equality with the object’s \`col1\` field.\"\"\"
+  col1: Int
+
+  \"\"\"Checks for equality with the object’s \`col2\` field.\"\"\"
+  col2: Int
+
+  \"\"\"Checks for equality with the object’s \`col3\` field.\"\"\"
+  col3: Int
+
+  \"\"\"Checks for equality with the object’s \`id\` field.\"\"\"
+  id: Int
+}
+
+\"\"\"An input for mutations affecting \`SimilarTable1\`\"\"\"
+input SimilarTable1Input {
+  col1: Int
+  col2: Int
+  col3: Int!
+  id: Int
+}
+
+\"\"\"
+Represents an update to a \`SimilarTable1\`. Fields that are set will be updated.
+\"\"\"
+input SimilarTable1Patch {
+  col1: Int
+  col2: Int
+  col3: Int
+  id: Int
+}
+
+\"\"\"A connection to a list of \`SimilarTable1\` values.\"\"\"
+type SimilarTable1SConnection {
+  \"\"\"
+  A list of edges which contains the \`SimilarTable1\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [SimilarTable1SEdge!]!
+
+  \"\"\"A list of \`SimilarTable1\` objects.\"\"\"
+  nodes: [SimilarTable1]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`SimilarTable1\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`SimilarTable1\` edge in the connection.\"\"\"
+type SimilarTable1SEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`SimilarTable1\` at the end of the edge.\"\"\"
+  node: SimilarTable1
+}
+
+\"\"\"Methods to use when ordering \`SimilarTable1\`.\"\"\"
+enum SimilarTable1SOrderBy {
+  COL1_ASC
+  COL1_DESC
+  COL2_ASC
+  COL2_DESC
+  COL3_ASC
+  COL3_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+type SimilarTable2 implements Node {
+  col3: Int!
+  col4: Int
+  col5: Int
+  id: Int!
+
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"
+A condition to be used against \`SimilarTable2\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\"\"\"
+input SimilarTable2Condition {
+  \"\"\"Checks for equality with the object’s \`col3\` field.\"\"\"
+  col3: Int
+
+  \"\"\"Checks for equality with the object’s \`col4\` field.\"\"\"
+  col4: Int
+
+  \"\"\"Checks for equality with the object’s \`col5\` field.\"\"\"
+  col5: Int
+
+  \"\"\"Checks for equality with the object’s \`id\` field.\"\"\"
+  id: Int
+}
+
+\"\"\"An input for mutations affecting \`SimilarTable2\`\"\"\"
+input SimilarTable2Input {
+  col3: Int!
+  col4: Int
+  col5: Int
+  id: Int
+}
+
+\"\"\"
+Represents an update to a \`SimilarTable2\`. Fields that are set will be updated.
+\"\"\"
+input SimilarTable2Patch {
+  col3: Int
+  col4: Int
+  col5: Int
+  id: Int
+}
+
+\"\"\"A connection to a list of \`SimilarTable2\` values.\"\"\"
+type SimilarTable2SConnection {
+  \"\"\"
+  A list of edges which contains the \`SimilarTable2\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [SimilarTable2SEdge!]!
+
+  \"\"\"A list of \`SimilarTable2\` objects.\"\"\"
+  nodes: [SimilarTable2]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`SimilarTable2\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`SimilarTable2\` edge in the connection.\"\"\"
+type SimilarTable2SEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`SimilarTable2\` at the end of the edge.\"\"\"
+  node: SimilarTable2
+}
+
+\"\"\"Methods to use when ordering \`SimilarTable2\`.\"\"\"
+enum SimilarTable2SOrderBy {
+  COL3_ASC
+  COL3_DESC
+  COL4_ASC
+  COL4_DESC
+  COL5_ASC
+  COL5_DESC
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+\"\"\"All input for the \`tableMutation\` mutation.\"\"\"
+input TableMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int
+}
+
+\"\"\"The output of our \`tableMutation\` mutation.\"\"\"
+type TableMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
+  personByAuthorId: Person
+  post: Post
+
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
+  postEdge(
+    \"\"\"The method to use when ordering \`Post\`.\"\"\"
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`tableSetMutation\` mutation.\"\"\"
+input TableSetMutationInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+}
+
+\"\"\"The output of our \`tableSetMutation\` mutation.\"\"\"
+type TableSetMutationPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+  people: [Person]
+
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
+  personEdge(
+    \"\"\"The method to use when ordering \`Person\`.\"\"\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"
+The exact time of day, does not include the date. May or may not have a timezone offset.
+\"\"\"
+scalar Time
+
+type Type implements Node {
+  anIntRange: AnIntRange!
+  bigint: BigInt!
+  boolean: Boolean!
+  compoundType: CompoundType!
+  date: Date!
+  daterange: DateRange!
+  decimal: BigFloat!
+  domain: AnInt!
+  domain2: AnotherInt!
+  enum: Color!
+  id: Int!
+  interval: Interval!
+  json: JSON!
+  jsonb: JSON!
+  money: Float!
+  nestedCompoundType: NestedCompoundType!
+
+  \"\"\"
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  \"\"\"
+  nodeId: ID!
+  nullableRange: BigFloatRange
+  numeric: BigFloat!
+  numrange: BigFloatRange!
+  smallint: Int!
+  textArray: [String]!
+  time: Time!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  timetz: Time!
+  varchar: String!
+}
+
+\"\"\"
+A condition to be used against \`Type\` object types. All fields are tested for equality and combined with a logical ‘and.’
+\"\"\"
+input TypeCondition {
+  \"\"\"Checks for equality with the object’s \`anIntRange\` field.\"\"\"
+  anIntRange: AnIntRangeInput
+
+  \"\"\"Checks for equality with the object’s \`bigint\` field.\"\"\"
+  bigint: BigInt
+
+  \"\"\"Checks for equality with the object’s \`boolean\` field.\"\"\"
+  boolean: Boolean
+
+  \"\"\"Checks for equality with the object’s \`compoundType\` field.\"\"\"
+  compoundType: CompoundTypeInput
+
+  \"\"\"Checks for equality with the object’s \`date\` field.\"\"\"
+  date: Date
+
+  \"\"\"Checks for equality with the object’s \`daterange\` field.\"\"\"
+  daterange: DateRangeInput
+
+  \"\"\"Checks for equality with the object’s \`decimal\` field.\"\"\"
+  decimal: BigFloat
+
+  \"\"\"Checks for equality with the object’s \`domain\` field.\"\"\"
+  domain: AnInt
+
+  \"\"\"Checks for equality with the object’s \`domain2\` field.\"\"\"
+  domain2: AnotherInt
+
+  \"\"\"Checks for equality with the object’s \`enum\` field.\"\"\"
+  enum: Color
+
+  \"\"\"Checks for equality with the object’s \`id\` field.\"\"\"
+  id: Int
+
+  \"\"\"Checks for equality with the object’s \`interval\` field.\"\"\"
+  interval: IntervalInput
+
+  \"\"\"Checks for equality with the object’s \`json\` field.\"\"\"
+  json: JSON
+
+  \"\"\"Checks for equality with the object’s \`jsonb\` field.\"\"\"
+  jsonb: JSON
+
+  \"\"\"Checks for equality with the object’s \`money\` field.\"\"\"
+  money: Float
+
+  \"\"\"Checks for equality with the object’s \`nestedCompoundType\` field.\"\"\"
+  nestedCompoundType: NestedCompoundTypeInput
+
+  \"\"\"Checks for equality with the object’s \`nullableRange\` field.\"\"\"
+  nullableRange: BigFloatRangeInput
+
+  \"\"\"Checks for equality with the object’s \`numeric\` field.\"\"\"
+  numeric: BigFloat
+
+  \"\"\"Checks for equality with the object’s \`numrange\` field.\"\"\"
+  numrange: BigFloatRangeInput
+
+  \"\"\"Checks for equality with the object’s \`smallint\` field.\"\"\"
+  smallint: Int
+
+  \"\"\"Checks for equality with the object’s \`textArray\` field.\"\"\"
+  textArray: [String]
+
+  \"\"\"Checks for equality with the object’s \`time\` field.\"\"\"
+  time: Time
+
+  \"\"\"Checks for equality with the object’s \`timestamp\` field.\"\"\"
+  timestamp: Datetime
+
+  \"\"\"Checks for equality with the object’s \`timestamptz\` field.\"\"\"
+  timestamptz: Datetime
+
+  \"\"\"Checks for equality with the object’s \`timetz\` field.\"\"\"
+  timetz: Time
+
+  \"\"\"Checks for equality with the object’s \`varchar\` field.\"\"\"
+  varchar: String
+}
+
+\"\"\"An input for mutations affecting \`Type\`\"\"\"
+input TypeInput {
+  anIntRange: AnIntRangeInput!
+  bigint: BigInt!
+  boolean: Boolean!
+  compoundType: CompoundTypeInput!
+  date: Date!
+  daterange: DateRangeInput!
+  decimal: BigFloat!
+  domain: AnInt!
+  domain2: AnotherInt!
+  enum: Color!
+  id: Int
+  interval: IntervalInput!
+  json: JSON!
+  jsonb: JSON!
+  money: Float!
+  nestedCompoundType: NestedCompoundTypeInput!
+  nullableRange: BigFloatRangeInput
+  numeric: BigFloat!
+  numrange: BigFloatRangeInput!
+  smallint: Int!
+  textArray: [String]!
+  time: Time!
+  timestamp: Datetime!
+  timestamptz: Datetime!
+  timetz: Time!
+  varchar: String!
+}
+
+\"\"\"
+Represents an update to a \`Type\`. Fields that are set will be updated.
+\"\"\"
+input TypePatch {
+  anIntRange: AnIntRangeInput
+  bigint: BigInt
+  boolean: Boolean
+  compoundType: CompoundTypeInput
+  date: Date
+  daterange: DateRangeInput
+  decimal: BigFloat
+  domain: AnInt
+  domain2: AnotherInt
+  enum: Color
+  id: Int
+  interval: IntervalInput
+  json: JSON
+  jsonb: JSON
+  money: Float
+  nestedCompoundType: NestedCompoundTypeInput
+  nullableRange: BigFloatRangeInput
+  numeric: BigFloat
+  numrange: BigFloatRangeInput
+  smallint: Int
+  textArray: [String]
+  time: Time
+  timestamp: Datetime
+  timestamptz: Datetime
+  timetz: Time
+  varchar: String
+}
+
+\"\"\"A connection to a list of \`Type\` values.\"\"\"
+type TypesConnection {
+  \"\"\"
+  A list of edges which contains the \`Type\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [TypesEdge!]!
+
+  \"\"\"A list of \`Type\` objects.\"\"\"
+  nodes: [Type]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`Type\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`Type\` edge in the connection.\"\"\"
+type TypesEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`Type\` at the end of the edge.\"\"\"
+  node: Type
+}
+
+\"\"\"All input for the \`typesMutation\` mutation.\"\"\"
+input TypesMutationInput {
+  a: BigInt!
+  b: Boolean!
+  c: String!
+
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  d: [Int]!
+  e: JSON!
+  f: FloatRangeInput!
+}
+
+\"\"\"The output of our \`typesMutation\` mutation.\"\"\"
+type TypesMutationPayload {
+  boolean: Boolean
+
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"Methods to use when ordering \`Type\`.\"\"\"
+enum TypesOrderBy {
+  AN_INT_RANGE_ASC
+  AN_INT_RANGE_DESC
+  BIGINT_ASC
+  BIGINT_DESC
+  BOOLEAN_ASC
+  BOOLEAN_DESC
+  COMPOUND_TYPE_ASC
+  COMPOUND_TYPE_DESC
+  DATE_ASC
+  DATE_DESC
+  DATERANGE_ASC
+  DATERANGE_DESC
+  DECIMAL_ASC
+  DECIMAL_DESC
+  DOMAIN_ASC
+  DOMAIN_DESC
+  DOMAIN2_ASC
+  DOMAIN2_DESC
+  ENUM_ASC
+  ENUM_DESC
+  ID_ASC
+  ID_DESC
+  INTERVAL_ASC
+  INTERVAL_DESC
+  JSON_ASC
+  JSON_DESC
+  JSONB_ASC
+  JSONB_DESC
+  MONEY_ASC
+  MONEY_DESC
+  NATURAL
+  NESTED_COMPOUND_TYPE_ASC
+  NESTED_COMPOUND_TYPE_DESC
+  NULLABLE_RANGE_ASC
+  NULLABLE_RANGE_DESC
+  NUMERIC_ASC
+  NUMERIC_DESC
+  NUMRANGE_ASC
+  NUMRANGE_DESC
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  SMALLINT_ASC
+  SMALLINT_DESC
+  TEXT_ARRAY_ASC
+  TEXT_ARRAY_DESC
+  TIME_ASC
+  TIME_DESC
+  TIMESTAMP_ASC
+  TIMESTAMP_DESC
+  TIMESTAMPTZ_ASC
+  TIMESTAMPTZ_DESC
+  TIMETZ_ASC
+  TIMETZ_DESC
+  VARCHAR_ASC
+  VARCHAR_DESC
+}
+
+\"\"\"YOYOYO!!\"\"\"
+type UpdatableView {
+  \"\"\"This is constantly 2\"\"\"
+  constant: Int
+  description: String
+  name: String
+  x: Int
+}
+
+\"\"\"
+A condition to be used against \`UpdatableView\` object types. All fields are
+tested for equality and combined with a logical ‘and.’
+\"\"\"
+input UpdatableViewCondition {
+  \"\"\"Checks for equality with the object’s \`constant\` field.\"\"\"
+  constant: Int
+
+  \"\"\"Checks for equality with the object’s \`description\` field.\"\"\"
+  description: String
+
+  \"\"\"Checks for equality with the object’s \`name\` field.\"\"\"
+  name: String
+
+  \"\"\"Checks for equality with the object’s \`x\` field.\"\"\"
+  x: Int
+}
+
+\"\"\"An input for mutations affecting \`UpdatableView\`\"\"\"
+input UpdatableViewInput {
+  \"\"\"This is constantly 2\"\"\"
+  constant: Int
+  description: String
+  name: String
+  x: Int
+}
+
+\"\"\"A connection to a list of \`UpdatableView\` values.\"\"\"
+type UpdatableViewsConnection {
+  \"\"\"
+  A list of edges which contains the \`UpdatableView\` and cursor to aid in pagination.
+  \"\"\"
+  edges: [UpdatableViewsEdge!]!
+
+  \"\"\"A list of \`UpdatableView\` objects.\"\"\"
+  nodes: [UpdatableView]!
+
+  \"\"\"Information to aid in pagination.\"\"\"
+  pageInfo: PageInfo!
+
+  \"\"\"The count of *all* \`UpdatableView\` you could get from the connection.\"\"\"
+  totalCount: Int
+}
+
+\"\"\"A \`UpdatableView\` edge in the connection.\"\"\"
+type UpdatableViewsEdge {
+  \"\"\"A cursor for use in pagination.\"\"\"
+  cursor: Cursor
+
+  \"\"\"The \`UpdatableView\` at the end of the edge.\"\"\"
+  node: UpdatableView
+}
+
+\"\"\"Methods to use when ordering \`UpdatableView\`.\"\"\"
+enum UpdatableViewsOrderBy {
+  CONSTANT_ASC
+  CONSTANT_DESC
+  DESCRIPTION_ASC
+  DESCRIPTION_DESC
+  NAME_ASC
+  NAME_DESC
+  NATURAL
+  X_ASC
+  X_DESC
+}
+
+\"\"\"
+All input for the \`updateCompoundKeyByPersonId1AndPersonId2\` mutation.
+\"\"\"
+input UpdateCompoundKeyByPersonId1AndPersonId2Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \"\"\"
+  compoundKeyPatch: CompoundKeyPatch!
+  personId1: Int!
+  personId2: Int!
+}
+
+\"\"\"All input for the \`updateCompoundKey\` mutation.\"\"\"
+input UpdateCompoundKeyInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  An object where the defined keys will be set on the \`CompoundKey\` being updated.
+  \"\"\"
+  compoundKeyPatch: CompoundKeyPatch!
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`CompoundKey\` to be updated.
+  \"\"\"
+  nodeId: ID!
+}
+
+\"\"\"The output of our update \`CompoundKey\` mutation.\"\"\"
+type UpdateCompoundKeyPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`CompoundKey\` that was updated by this mutation.\"\"\"
+  compoundKey: CompoundKey
+
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
+  compoundKeyEdge(
+    \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
+    orderBy: [CompoundKeysOrderBy!] = [PRIMARY_KEY_ASC]
+  ): CompoundKeysEdge
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId1: Person
+
+  \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
+  personByPersonId2: Person
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`updatePersonByEmail\` mutation.\"\"\"
+input UpdatePersonByEmailInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  email: Email!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \"\"\"
+  personPatch: PersonPatch!
+}
+
+\"\"\"All input for the \`updatePersonById\` mutation.\"\"\"
+input UpdatePersonByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \"\"\"
+  personPatch: PersonPatch!
+}
+
+\"\"\"All input for the \`updatePerson\` mutation.\"\"\"
+input UpdatePersonInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`Person\` to be updated.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Person\` being updated.
+  \"\"\"
+  personPatch: PersonPatch!
+}
+
+\"\"\"The output of our update \`Person\` mutation.\"\"\"
+type UpdatePersonPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"The \`Person\` that was updated by this mutation.\"\"\"
+  person: Person
+
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
+  personEdge(
+    \"\"\"The method to use when ordering \`Person\`.\"\"\"
+    orderBy: [PeopleOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PeopleEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`updatePostById\` mutation.\"\"\"
+input UpdatePostByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Post\` being updated.
+  \"\"\"
+  postPatch: PostPatch!
+}
+
+\"\"\"All input for the \`updatePost\` mutation.\"\"\"
+input UpdatePostInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`Post\` to be updated.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Post\` being updated.
+  \"\"\"
+  postPatch: PostPatch!
+}
+
+\"\"\"The output of our update \`Post\` mutation.\"\"\"
+type UpdatePostPayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
+  personByAuthorId: Person
+
+  \"\"\"The \`Post\` that was updated by this mutation.\"\"\"
+  post: Post
+
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
+  postEdge(
+    \"\"\"The method to use when ordering \`Post\`.\"\"\"
+    orderBy: [PostsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): PostsEdge
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+}
+
+\"\"\"All input for the \`updateSimilarTable1ById\` mutation.\"\"\"
+input UpdateSimilarTable1ByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`SimilarTable1\` being updated.
+  \"\"\"
+  similarTable1Patch: SimilarTable1Patch!
+}
+
+\"\"\"All input for the \`updateSimilarTable1\` mutation.\"\"\"
+input UpdateSimilarTable1Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`SimilarTable1\` to be updated.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`SimilarTable1\` being updated.
+  \"\"\"
+  similarTable1Patch: SimilarTable1Patch!
+}
+
+\"\"\"The output of our update \`SimilarTable1\` mutation.\"\"\"
+type UpdateSimilarTable1Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`SimilarTable1\` that was updated by this mutation.\"\"\"
+  similarTable1: SimilarTable1
+
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
+  similarTable1Edge(
+    \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
+    orderBy: [SimilarTable1SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable1SEdge
+}
+
+\"\"\"All input for the \`updateSimilarTable2ById\` mutation.\"\"\"
+input UpdateSimilarTable2ByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`SimilarTable2\` being updated.
+  \"\"\"
+  similarTable2Patch: SimilarTable2Patch!
+}
+
+\"\"\"All input for the \`updateSimilarTable2\` mutation.\"\"\"
+input UpdateSimilarTable2Input {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`SimilarTable2\` to be updated.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`SimilarTable2\` being updated.
+  \"\"\"
+  similarTable2Patch: SimilarTable2Patch!
+}
+
+\"\"\"The output of our update \`SimilarTable2\` mutation.\"\"\"
+type UpdateSimilarTable2Payload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`SimilarTable2\` that was updated by this mutation.\"\"\"
+  similarTable2: SimilarTable2
+
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
+  similarTable2Edge(
+    \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
+    orderBy: [SimilarTable2SOrderBy!] = [PRIMARY_KEY_ASC]
+  ): SimilarTable2SEdge
+}
+
+\"\"\"All input for the \`updateTypeById\` mutation.\"\"\"
+input UpdateTypeByIdInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+  id: Int!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Type\` being updated.
+  \"\"\"
+  typePatch: TypePatch!
+}
+
+\"\"\"All input for the \`updateType\` mutation.\"\"\"
+input UpdateTypeInput {
+  \"\"\"
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  The globally unique \`ID\` which will identify a single \`Type\` to be updated.
+  \"\"\"
+  nodeId: ID!
+
+  \"\"\"
+  An object where the defined keys will be set on the \`Type\` being updated.
+  \"\"\"
+  typePatch: TypePatch!
+}
+
+\"\"\"The output of our update \`Type\` mutation.\"\"\"
+type UpdateTypePayload {
+  \"\"\"
+  The exact same \`clientMutationId\` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  \"\"\"
+  clientMutationId: String
+
+  \"\"\"
+  Our root query field type. Allows us to run any query from our mutation payload.
+  \"\"\"
+  query: Query
+
+  \"\"\"The \`Type\` that was updated by this mutation.\"\"\"
+  type: Type
+
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
+  typeEdge(
+    \"\"\"The method to use when ordering \`Type\`.\"\"\"
+    orderBy: [TypesOrderBy!] = [PRIMARY_KEY_ASC]
+  ): TypesEdge
+}
+
+\"\"\"
+A universally unique identifier as defined by [RFC 4122](https://tools.ietf.org/html/rfc4122).
+\"\"\"
 scalar UUID
 "
 `;
@@ -6309,7 +10121,7 @@ type CompoundKeysConnection {
   edges: [CompoundKeysEdge!]!
 
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey!]!
+  nodes: [CompoundKey]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -6324,7 +10136,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \"\"\"The \`CompoundKey\` at the end of the edge.\"\"\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \"\"\"Methods to use when ordering \`CompoundKey\`.\"\"\"
@@ -6379,7 +10191,7 @@ type EdgeCasesConnection {
   edges: [EdgeCasesEdge!]!
 
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase!]!
+  nodes: [EdgeCase]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -6394,7 +10206,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \"\"\"The \`EdgeCase\` at the end of the edge.\"\"\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \"\"\"Methods to use when ordering \`EdgeCase\`.\"\"\"
@@ -6465,7 +10277,7 @@ type IntSetQueryConnection {
   edges: [IntSetQueryEdge!]!
 
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int!]!
+  nodes: [Int]!
 }
 
 \"\"\"A \`Int\` edge in the connection.\"\"\"
@@ -6606,7 +10418,7 @@ type PeopleConnection {
   edges: [PeopleEdge!]!
 
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person!]!
+  nodes: [Person]!
 
   \"\"\"Information to aid in pagination.\"\"\"
   pageInfo: PageInfo!
@@ -6621,7 +10433,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \"\"\"The \`Person\` at the end of the edge.\"\"\"
-  node: Person!
+  node: Person
 }
 
 \"\"\"Methods to use when ordering \`Person\`.\"\"\"

--- a/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchemaExport-test.js.snap
+++ b/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchemaExport-test.js.snap
@@ -338,7 +338,7 @@ input CompoundKeyPatch {
 \"\"\"A connection to a list of \`CompoundKey\` values.\"\"\"
 type CompoundKeysConnection {
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey]!
+  nodes: [CompoundKey!]!
 
   \"\"\"
   A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
@@ -452,7 +452,7 @@ type CreateCompoundKeyPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
   personByPersonId1: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = PRIMARY_KEY_ASC
@@ -487,7 +487,7 @@ type CreateEdgeCasePayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`EdgeCase\`. May be used by Relay 1.\"\"\"
   edgeCaseEdge(
     \"\"\"The method to use when ordering \`EdgeCase\`.\"\"\"
     orderBy: [EdgeCasesOrderBy!] = NATURAL
@@ -528,7 +528,7 @@ type CreateForeignKeyPayload {
   \"\"\"Reads a single \`CompoundKey\` that is related to this \`ForeignKey\`.\"\"\"
   compoundKeyByCompoundKey1AndCompoundKey2: CompoundKey
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`ForeignKey\`. May be used by Relay 1.\"\"\"
   foreignKeyEdge(
     \"\"\"The method to use when ordering \`ForeignKey\`.\"\"\"
     orderBy: [ForeignKeysOrderBy!] = NATURAL
@@ -563,7 +563,7 @@ type CreatePersonPayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = PRIMARY_KEY_ASC
@@ -601,7 +601,7 @@ type CreatePostPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
   personByAuthorId: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = PRIMARY_KEY_ASC
@@ -636,7 +636,7 @@ type CreateSimilarTable1Payload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
   similarTable1Edge(
     \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
     orderBy: [SimilarTable1SOrderBy!] = PRIMARY_KEY_ASC
@@ -671,7 +671,7 @@ type CreateSimilarTable2Payload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
   similarTable2Edge(
     \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
     orderBy: [SimilarTable2SOrderBy!] = PRIMARY_KEY_ASC
@@ -706,7 +706,7 @@ type CreateTypePayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = PRIMARY_KEY_ASC
@@ -741,7 +741,7 @@ type CreateUpdatableViewPayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`UpdatableView\`. May be used by Relay 1.\"\"\"
   updatableViewEdge(
     \"\"\"The method to use when ordering \`UpdatableView\`.\"\"\"
     orderBy: [UpdatableViewsOrderBy!] = NATURAL
@@ -850,7 +850,7 @@ type DeleteCompoundKeyPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
   personByPersonId1: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = PRIMARY_KEY_ASC
@@ -908,7 +908,7 @@ type DeletePersonPayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = PRIMARY_KEY_ASC
@@ -959,7 +959,7 @@ type DeletePostPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
   personByAuthorId: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = PRIMARY_KEY_ASC
@@ -1007,7 +1007,7 @@ type DeleteSimilarTable1Payload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
   similarTable1Edge(
     \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
     orderBy: [SimilarTable1SOrderBy!] = PRIMARY_KEY_ASC
@@ -1055,7 +1055,7 @@ type DeleteSimilarTable2Payload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
   similarTable2Edge(
     \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
     orderBy: [SimilarTable2SOrderBy!] = PRIMARY_KEY_ASC
@@ -1103,7 +1103,7 @@ type DeleteTypePayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = PRIMARY_KEY_ASC
@@ -1142,7 +1142,7 @@ input EdgeCaseInput {
 \"\"\"A connection to a list of \`EdgeCase\` values.\"\"\"
 type EdgeCasesConnection {
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase]!
+  nodes: [EdgeCase!]!
 
   \"\"\"
   A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
@@ -1235,7 +1235,7 @@ input ForeignKeyInput {
 \"\"\"A connection to a list of \`ForeignKey\` values.\"\"\"
 type ForeignKeysConnection {
   \"\"\"A list of \`ForeignKey\` objects.\"\"\"
-  nodes: [ForeignKey]!
+  nodes: [ForeignKey!]!
 
   \"\"\"
   A list of edges which contains the \`ForeignKey\` and cursor to aid in pagination.
@@ -1353,7 +1353,7 @@ type IntSetMutationPayload {
 \"\"\"A connection to a list of \`Int\` values.\"\"\"
 type IntSetQueryConnection {
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int]!
+  nodes: [Int!]!
 
   \"\"\"
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
@@ -1982,7 +1982,7 @@ input NonUpdatableViewCondition {
 \"\"\"A connection to a list of \`NonUpdatableView\` values.\"\"\"
 type NonUpdatableViewsConnection {
   \"\"\"A list of \`NonUpdatableView\` objects.\"\"\"
-  nodes: [NonUpdatableView]!
+  nodes: [NonUpdatableView!]!
 
   \"\"\"
   A list of edges which contains the \`NonUpdatableView\` and cursor to aid in pagination.
@@ -2032,7 +2032,7 @@ type PageInfo {
 \"\"\"A connection to a list of \`Person\` values.\"\"\"
 type PeopleConnection {
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person]!
+  nodes: [Person!]!
 
   \"\"\"
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
@@ -2323,7 +2323,7 @@ input PostPatch {
 \"\"\"A connection to a list of \`Post\` values.\"\"\"
 type PostsConnection {
   \"\"\"A list of \`Post\` objects.\"\"\"
-  nodes: [Post]!
+  nodes: [Post!]!
 
   \"\"\"
   A list of edges which contains the \`Post\` and cursor to aid in pagination.
@@ -2854,7 +2854,7 @@ input SimilarTable1Patch {
 \"\"\"A connection to a list of \`SimilarTable1\` values.\"\"\"
 type SimilarTable1SConnection {
   \"\"\"A list of \`SimilarTable1\` objects.\"\"\"
-  nodes: [SimilarTable1]!
+  nodes: [SimilarTable1!]!
 
   \"\"\"
   A list of edges which contains the \`SimilarTable1\` and cursor to aid in pagination.
@@ -2942,7 +2942,7 @@ input SimilarTable2Patch {
 \"\"\"A connection to a list of \`SimilarTable2\` values.\"\"\"
 type SimilarTable2SConnection {
   \"\"\"A list of \`SimilarTable2\` objects.\"\"\"
-  nodes: [SimilarTable2]!
+  nodes: [SimilarTable2!]!
 
   \"\"\"
   A list of edges which contains the \`SimilarTable2\` and cursor to aid in pagination.
@@ -3007,7 +3007,7 @@ type TableMutationPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
   personByAuthorId: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = PRIMARY_KEY_ASC
@@ -3037,7 +3037,7 @@ type TableSetMutationPayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = PRIMARY_KEY_ASC
@@ -3230,7 +3230,7 @@ input TypePatch {
 \"\"\"A connection to a list of \`Type\` values.\"\"\"
 type TypesConnection {
   \"\"\"A list of \`Type\` objects.\"\"\"
-  nodes: [Type]!
+  nodes: [Type!]!
 
   \"\"\"
   A list of edges which contains the \`Type\` and cursor to aid in pagination.
@@ -3383,7 +3383,7 @@ input UpdatableViewInput {
 \"\"\"A connection to a list of \`UpdatableView\` values.\"\"\"
 type UpdatableViewsConnection {
   \"\"\"A list of \`UpdatableView\` objects.\"\"\"
-  nodes: [UpdatableView]!
+  nodes: [UpdatableView!]!
 
   \"\"\"
   A list of edges which contains the \`UpdatableView\` and cursor to aid in pagination.
@@ -3478,7 +3478,7 @@ type UpdateCompoundKeyPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`CompoundKey\`.\"\"\"
   personByPersonId1: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`CompoundKey\`. May be used by Relay 1.\"\"\"
   compoundKeyEdge(
     \"\"\"The method to use when ordering \`CompoundKey\`.\"\"\"
     orderBy: [CompoundKeysOrderBy!] = PRIMARY_KEY_ASC
@@ -3550,7 +3550,7 @@ type UpdatePersonPayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Person\`. May be used by Relay 1.\"\"\"
   personEdge(
     \"\"\"The method to use when ordering \`Person\`.\"\"\"
     orderBy: [PeopleOrderBy!] = PRIMARY_KEY_ASC
@@ -3610,7 +3610,7 @@ type UpdatePostPayload {
   \"\"\"Reads a single \`Person\` that is related to this \`Post\`.\"\"\"
   personByAuthorId: Person
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Post\`. May be used by Relay 1.\"\"\"
   postEdge(
     \"\"\"The method to use when ordering \`Post\`.\"\"\"
     orderBy: [PostsOrderBy!] = PRIMARY_KEY_ASC
@@ -3667,7 +3667,7 @@ type UpdateSimilarTable1Payload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable1\`. May be used by Relay 1.\"\"\"
   similarTable1Edge(
     \"\"\"The method to use when ordering \`SimilarTable1\`.\"\"\"
     orderBy: [SimilarTable1SOrderBy!] = PRIMARY_KEY_ASC
@@ -3724,7 +3724,7 @@ type UpdateSimilarTable2Payload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`SimilarTable2\`. May be used by Relay 1.\"\"\"
   similarTable2Edge(
     \"\"\"The method to use when ordering \`SimilarTable2\`.\"\"\"
     orderBy: [SimilarTable2SOrderBy!] = PRIMARY_KEY_ASC
@@ -3781,7 +3781,7 @@ type UpdateTypePayload {
   \"\"\"
   query: Query
 
-  \"\"\"An edge for the type. May be used by Relay 1.\"\"\"
+  \"\"\"An edge for our \`Type\`. May be used by Relay 1.\"\"\"
   typeEdge(
     \"\"\"The method to use when ordering \`Type\`.\"\"\"
     orderBy: [TypesOrderBy!] = PRIMARY_KEY_ASC
@@ -5851,9 +5851,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"ForeignKey\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"ForeignKey\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -6739,9 +6743,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"Post\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"Post\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -7178,9 +7186,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"CompoundKey\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"CompoundKey\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -7496,9 +7508,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"Person\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"Person\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -7707,9 +7723,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"NonUpdatableView\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"NonUpdatableView\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -7980,9 +8000,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"SimilarTable1\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"SimilarTable1\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -8319,9 +8343,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"SimilarTable2\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"SimilarTable2\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -9648,9 +9676,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"Type\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"Type\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -10782,9 +10814,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"UpdatableView\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"UpdatableView\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -11057,9 +11093,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"OBJECT\",
-                    \"name\": \"EdgeCase\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"OBJECT\",
+                      \"name\": \"EdgeCase\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -11392,9 +11432,13 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"SCALAR\",
-                    \"name\": \"Int\",
-                    \"ofType\": null
+                    \"kind\": \"NON_NULL\",
+                    \"name\": null,
+                    \"ofType\": {
+                      \"kind\": \"SCALAR\",
+                      \"name\": \"Int\",
+                      \"ofType\": null
+                    }
                   }
                 }
               },
@@ -13121,7 +13165,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"foreignKeyEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`ForeignKey\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -13301,7 +13345,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"postEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Post\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -13469,7 +13513,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"similarTable1Edge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`SimilarTable1\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -13637,7 +13681,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"similarTable2Edge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`SimilarTable2\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -14121,7 +14165,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"typeEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Type\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -14285,7 +14329,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"updatableViewEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`UpdatableView\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -14471,7 +14515,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"compoundKeyEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`CompoundKey\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -14625,7 +14669,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"edgeCaseEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`EdgeCase\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -14807,7 +14851,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"personEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Person\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -14997,7 +15041,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"postEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Post\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -15224,7 +15268,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"similarTable1Edge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`SimilarTable1\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -15451,7 +15495,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"similarTable2Edge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`SimilarTable2\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -15902,7 +15946,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"typeEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Type\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -16143,7 +16187,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"compoundKeyEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`CompoundKey\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -16394,7 +16438,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"personEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Person\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -16629,7 +16673,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"postEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Post\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -16789,7 +16833,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"similarTable1Edge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`SimilarTable1\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -16949,7 +16993,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"similarTable2Edge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`SimilarTable2\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -17109,7 +17153,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"typeEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Type\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -17293,7 +17337,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"compoundKeyEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`CompoundKey\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -17467,7 +17511,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"personEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Person\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -19043,7 +19087,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"postEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Post\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",
@@ -19146,7 +19190,7 @@ exports[`test exports a schema as JSON 1`] = `
             },
             {
               \"name\": \"personEdge\",
-              \"description\": \"An edge for the type. May be used by Relay 1.\",
+              \"description\": \"An edge for our \`Person\`. May be used by Relay 1.\",
               \"args\": [
                 {
                   \"name\": \"orderBy\",

--- a/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchemaExport-test.js.snap
+++ b/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationSchemaExport-test.js.snap
@@ -338,7 +338,7 @@ input CompoundKeyPatch {
 \"\"\"A connection to a list of \`CompoundKey\` values.\"\"\"
 type CompoundKeysConnection {
   \"\"\"A list of \`CompoundKey\` objects.\"\"\"
-  nodes: [CompoundKey!]!
+  nodes: [CompoundKey]!
 
   \"\"\"
   A list of edges which contains the \`CompoundKey\` and cursor to aid in pagination.
@@ -358,7 +358,7 @@ type CompoundKeysEdge {
   cursor: Cursor
 
   \"\"\"The \`CompoundKey\` at the end of the edge.\"\"\"
-  node: CompoundKey!
+  node: CompoundKey
 }
 
 \"\"\"Methods to use when ordering \`CompoundKey\`.\"\"\"
@@ -1142,7 +1142,7 @@ input EdgeCaseInput {
 \"\"\"A connection to a list of \`EdgeCase\` values.\"\"\"
 type EdgeCasesConnection {
   \"\"\"A list of \`EdgeCase\` objects.\"\"\"
-  nodes: [EdgeCase!]!
+  nodes: [EdgeCase]!
 
   \"\"\"
   A list of edges which contains the \`EdgeCase\` and cursor to aid in pagination.
@@ -1162,7 +1162,7 @@ type EdgeCasesEdge {
   cursor: Cursor
 
   \"\"\"The \`EdgeCase\` at the end of the edge.\"\"\"
-  node: EdgeCase!
+  node: EdgeCase
 }
 
 \"\"\"Methods to use when ordering \`EdgeCase\`.\"\"\"
@@ -1235,7 +1235,7 @@ input ForeignKeyInput {
 \"\"\"A connection to a list of \`ForeignKey\` values.\"\"\"
 type ForeignKeysConnection {
   \"\"\"A list of \`ForeignKey\` objects.\"\"\"
-  nodes: [ForeignKey!]!
+  nodes: [ForeignKey]!
 
   \"\"\"
   A list of edges which contains the \`ForeignKey\` and cursor to aid in pagination.
@@ -1255,7 +1255,7 @@ type ForeignKeysEdge {
   cursor: Cursor
 
   \"\"\"The \`ForeignKey\` at the end of the edge.\"\"\"
-  node: ForeignKey!
+  node: ForeignKey
 }
 
 \"\"\"Methods to use when ordering \`ForeignKey\`.\"\"\"
@@ -1353,7 +1353,7 @@ type IntSetMutationPayload {
 \"\"\"A connection to a list of \`Int\` values.\"\"\"
 type IntSetQueryConnection {
   \"\"\"A list of \`Int\` objects.\"\"\"
-  nodes: [Int!]!
+  nodes: [Int]!
 
   \"\"\"
   A list of edges which contains the \`Int\` and cursor to aid in pagination.
@@ -1982,7 +1982,7 @@ input NonUpdatableViewCondition {
 \"\"\"A connection to a list of \`NonUpdatableView\` values.\"\"\"
 type NonUpdatableViewsConnection {
   \"\"\"A list of \`NonUpdatableView\` objects.\"\"\"
-  nodes: [NonUpdatableView!]!
+  nodes: [NonUpdatableView]!
 
   \"\"\"
   A list of edges which contains the \`NonUpdatableView\` and cursor to aid in pagination.
@@ -2004,7 +2004,7 @@ type NonUpdatableViewsEdge {
   cursor: Cursor
 
   \"\"\"The \`NonUpdatableView\` at the end of the edge.\"\"\"
-  node: NonUpdatableView!
+  node: NonUpdatableView
 }
 
 \"\"\"Methods to use when ordering \`NonUpdatableView\`.\"\"\"
@@ -2032,7 +2032,7 @@ type PageInfo {
 \"\"\"A connection to a list of \`Person\` values.\"\"\"
 type PeopleConnection {
   \"\"\"A list of \`Person\` objects.\"\"\"
-  nodes: [Person!]!
+  nodes: [Person]!
 
   \"\"\"
   A list of edges which contains the \`Person\` and cursor to aid in pagination.
@@ -2052,7 +2052,7 @@ type PeopleEdge {
   cursor: Cursor
 
   \"\"\"The \`Person\` at the end of the edge.\"\"\"
-  node: Person!
+  node: Person
 }
 
 \"\"\"Methods to use when ordering \`Person\`.\"\"\"
@@ -2323,7 +2323,7 @@ input PostPatch {
 \"\"\"A connection to a list of \`Post\` values.\"\"\"
 type PostsConnection {
   \"\"\"A list of \`Post\` objects.\"\"\"
-  nodes: [Post!]!
+  nodes: [Post]!
 
   \"\"\"
   A list of edges which contains the \`Post\` and cursor to aid in pagination.
@@ -2343,7 +2343,7 @@ type PostsEdge {
   cursor: Cursor
 
   \"\"\"The \`Post\` at the end of the edge.\"\"\"
-  node: Post!
+  node: Post
 }
 
 \"\"\"Methods to use when ordering \`Post\`.\"\"\"
@@ -2854,7 +2854,7 @@ input SimilarTable1Patch {
 \"\"\"A connection to a list of \`SimilarTable1\` values.\"\"\"
 type SimilarTable1SConnection {
   \"\"\"A list of \`SimilarTable1\` objects.\"\"\"
-  nodes: [SimilarTable1!]!
+  nodes: [SimilarTable1]!
 
   \"\"\"
   A list of edges which contains the \`SimilarTable1\` and cursor to aid in pagination.
@@ -2874,7 +2874,7 @@ type SimilarTable1SEdge {
   cursor: Cursor
 
   \"\"\"The \`SimilarTable1\` at the end of the edge.\"\"\"
-  node: SimilarTable1!
+  node: SimilarTable1
 }
 
 \"\"\"Methods to use when ordering \`SimilarTable1\`.\"\"\"
@@ -2942,7 +2942,7 @@ input SimilarTable2Patch {
 \"\"\"A connection to a list of \`SimilarTable2\` values.\"\"\"
 type SimilarTable2SConnection {
   \"\"\"A list of \`SimilarTable2\` objects.\"\"\"
-  nodes: [SimilarTable2!]!
+  nodes: [SimilarTable2]!
 
   \"\"\"
   A list of edges which contains the \`SimilarTable2\` and cursor to aid in pagination.
@@ -2962,7 +2962,7 @@ type SimilarTable2SEdge {
   cursor: Cursor
 
   \"\"\"The \`SimilarTable2\` at the end of the edge.\"\"\"
-  node: SimilarTable2!
+  node: SimilarTable2
 }
 
 \"\"\"Methods to use when ordering \`SimilarTable2\`.\"\"\"
@@ -3230,7 +3230,7 @@ input TypePatch {
 \"\"\"A connection to a list of \`Type\` values.\"\"\"
 type TypesConnection {
   \"\"\"A list of \`Type\` objects.\"\"\"
-  nodes: [Type!]!
+  nodes: [Type]!
 
   \"\"\"
   A list of edges which contains the \`Type\` and cursor to aid in pagination.
@@ -3250,7 +3250,7 @@ type TypesEdge {
   cursor: Cursor
 
   \"\"\"The \`Type\` at the end of the edge.\"\"\"
-  node: Type!
+  node: Type
 }
 
 \"\"\"All input for the \`typesMutation\` mutation.\"\"\"
@@ -3383,7 +3383,7 @@ input UpdatableViewInput {
 \"\"\"A connection to a list of \`UpdatableView\` values.\"\"\"
 type UpdatableViewsConnection {
   \"\"\"A list of \`UpdatableView\` objects.\"\"\"
-  nodes: [UpdatableView!]!
+  nodes: [UpdatableView]!
 
   \"\"\"
   A list of edges which contains the \`UpdatableView\` and cursor to aid in pagination.
@@ -3403,7 +3403,7 @@ type UpdatableViewsEdge {
   cursor: Cursor
 
   \"\"\"The \`UpdatableView\` at the end of the edge.\"\"\"
-  node: UpdatableView!
+  node: UpdatableView
 }
 
 \"\"\"Methods to use when ordering \`UpdatableView\`.\"\"\"
@@ -5851,13 +5851,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"ForeignKey\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"ForeignKey\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -6743,13 +6739,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"Post\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"Post\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -6970,13 +6962,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`Post\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"Post\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"Post\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -7186,13 +7174,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"CompoundKey\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"CompoundKey\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -7475,13 +7459,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`CompoundKey\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"CompoundKey\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"CompoundKey\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -7508,13 +7488,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"Person\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"Person\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -7601,13 +7577,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`Person\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"Person\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"Person\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -7640,13 +7612,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`ForeignKey\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"ForeignKey\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"ForeignKey\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -7723,13 +7691,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"NonUpdatableView\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"NonUpdatableView\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -7839,13 +7803,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`NonUpdatableView\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"NonUpdatableView\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"NonUpdatableView\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -8000,13 +7960,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"SimilarTable1\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"SimilarTable1\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -8182,13 +8138,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`SimilarTable1\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"SimilarTable1\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"SimilarTable1\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -8343,13 +8295,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"SimilarTable2\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"SimilarTable2\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -8525,13 +8473,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`SimilarTable2\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"SimilarTable2\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"SimilarTable2\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -9676,13 +9620,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"Type\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"Type\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -10665,13 +10605,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`Type\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"Type\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"Type\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -10814,13 +10750,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"UpdatableView\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"UpdatableView\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -10966,13 +10898,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`UpdatableView\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"UpdatableView\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"UpdatableView\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -11093,13 +11021,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"OBJECT\",
-                      \"name\": \"EdgeCase\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"OBJECT\",
+                    \"name\": \"EdgeCase\",
+                    \"ofType\": null
                   }
                 }
               },
@@ -11249,13 +11173,9 @@ exports[`test exports a schema as JSON 1`] = `
               \"description\": \"The \`EdgeCase\` at the end of the edge.\",
               \"args\": [],
               \"type\": {
-                \"kind\": \"NON_NULL\",
-                \"name\": null,
-                \"ofType\": {
-                  \"kind\": \"OBJECT\",
-                  \"name\": \"EdgeCase\",
-                  \"ofType\": null
-                }
+                \"kind\": \"OBJECT\",
+                \"name\": \"EdgeCase\",
+                \"ofType\": null
               },
               \"isDeprecated\": false,
               \"deprecationReason\": null
@@ -11432,13 +11352,9 @@ exports[`test exports a schema as JSON 1`] = `
                   \"kind\": \"LIST\",
                   \"name\": null,
                   \"ofType\": {
-                    \"kind\": \"NON_NULL\",
-                    \"name\": null,
-                    \"ofType\": {
-                      \"kind\": \"SCALAR\",
-                      \"name\": \"Int\",
-                      \"ofType\": null
-                    }
+                    \"kind\": \"SCALAR\",
+                    \"name\": \"Int\",
+                    \"ofType\": null
                   }
                 }
               },

--- a/src/postgraphile/__tests__/postgraphileIntegrationSchema-test.js
+++ b/src/postgraphile/__tests__/postgraphileIntegrationSchema-test.js
@@ -35,6 +35,14 @@ const testFixtures = [
     createSchema: client =>
       createPostGraphileSchema(client, 'c', { disableDefaultMutations: true }),
   },
+  {
+    name: 'prints a schema with nulls reduced and old Json, Uuid',
+    createSchema: client =>
+      createPostGraphileSchema(client, ['a', 'b', 'c'], {
+        setofFunctionsContainNulls: false,
+        legacyJsonUuid: true,
+      }),
+  },
 ]
 
 beforeAll(() => {

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -41,8 +41,9 @@ program
   .option('-m, --max-pool-size <number>', 'the maximum number of clients to keep in the Postgres pool. defaults to 10', parseFloat)
   .option('-r, --default-role <string>', 'the default Postgres role to use when a request is made. supercedes the role used to connect to the database')
   // Schema configuration
-  .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
+  .option('-N, --no-setof-functions-contain-nulls', 'if none of your `RETURNS SETOF compound_type` functions mix NULLs with the results then you may enable this to reduce the nullables in the GraphQL schema')
+  .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
   // Error enhancements
   .option('--show-error-stack', 'show JavaScript error stacks in the GraphQL result errors')
@@ -80,7 +81,6 @@ program
   .option('--secret <string>', 'DEPRECATED: Use jwt-secret instead')
   .option('--jwt-audiences <string>', 'DEPRECATED Use jwt-verify-audience instead', (option: string) => option.split(','))
   // Awkward application workarounds / legacy support
-  .option('--badly-behaved-functions', 'if you have any functions that return setof a compound type (such as a table) and you want to return null for some of the results in the set you must enable this')
   .option('--legacy-relations <omit|deprecated|only>', 'some one-to-one relations were previously detected as one-to-many - should we export \'only\' the old relation shapes, both new and old but mark the old ones as \'deprecated\', or \'omit\' the old relation shapes entirely')
   .option('--legacy-json-uuid', `ONLY use this option if you require the v3 typenames 'Json' and 'Uuid' over 'JSON' and 'UUID'`)
 
@@ -142,7 +142,7 @@ const {
   legacyRelations: rawLegacyRelations = 'deprecated',
   server: yesServer,
   clusterWorkers,
-  badlyBehavedFunctions,
+  setofFunctionsContainNulls = true,
   legacyJsonUuid,
 // tslint:disable-next-line no-any
 } = Object.assign({}, config['options'], program) as any
@@ -259,7 +259,7 @@ const postgraphileOptions = {
   readCache,
   writeCache,
   legacyRelations,
-  badlyBehavedFunctions,
+  setofFunctionsContainNulls,
   legacyJsonUuid,
 }
 

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -72,6 +72,7 @@ program
   .option('--read-cache <path>', '[experimental] reads cached values from local cache file to improve startup time (you may want to do this in production)')
   .option('-X, --no-server', '[experimental] for when you just want to use --write-cache or --export-schema-* and not actually run a server (e.g. CI)')
   .option('--cluster-workers <count>', '[experimental] spawn <count> workers to increase throughput', parseFloat)
+  .option('--badly-behaved-functions', 'if you have any functions that return setof a compound type (such as a table) and you want to return null for some of the results in the set you must enable this')
 
 program.on('--help', () => console.log(`
   Get Started:
@@ -130,6 +131,7 @@ const {
   legacyRelations: rawLegacyRelations = 'deprecated',
   server: yesServer,
   clusterWorkers,
+  badlyBehavedFunctions,
 // tslint:disable-next-line no-any
 } = Object.assign({}, config['options'], program) as any
 
@@ -245,6 +247,7 @@ const postgraphileOptions = {
   readCache,
   writeCache,
   legacyRelations,
+  badlyBehavedFunctions,
 }
 
 if (noServer) {

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -32,6 +32,7 @@ program
   .usage('[options...]')
   .description(manifest.description)
   // .option('-d, --demo', 'run PostGraphile using the demo database connection')
+  // Standard options
   .option('-c, --connection <string>', 'the Postgres connection. if not provided it will be inferred from your environment, example: postgres://user:password@domain:port/db')
   .option('-s, --schema <string>', 'a Postgres schema to be introspected. Use commas to define multiple schemas', (option: string) => option.split(','))
   .option('-w, --watch', 'watches the Postgres schema for changes and reruns introspection if a change was detected')
@@ -39,18 +40,31 @@ program
   .option('-p, --port <number>', 'the port to be used. Defaults to 5000', parseFloat)
   .option('-m, --max-pool-size <number>', 'the maximum number of clients to keep in the Postgres pool. defaults to 10', parseFloat)
   .option('-r, --default-role <string>', 'the default Postgres role to use when a request is made. supercedes the role used to connect to the database')
-  .option('-q, --graphql <path>', 'the route to mount the GraphQL server on. defaults to `/graphql`')
-  .option('-i, --graphiql <path>', 'the route to mount the GraphiQL interface on. defaults to `/graphiql`')
-  .option('-b, --disable-graphiql', 'disables the GraphiQL interface. overrides the GraphiQL route option')
-  .option('--token <identifier>', 'DEPRECATED: use --jwt-token-identifier instead')
-  .option('-o, --cors', 'enable generous CORS settings. this is disabled by default, if possible use a proxy instead')
+  // Schema configuration
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
+  // Error enhancements
+  .option('--show-error-stack', 'show JavaScript error stacks in the GraphQL result errors')
+  .option('--extended-errors <string>', 'a comma separated list of extended Postgres error fields to display in the GraphQL result. Example: \'hint,detail,errcode\'. Default: none', (option: string) => option.split(',').filter(_ => _))
+  // Plugin-related options
+  .option('--append-plugins <string>', 'a comma-separated list of plugins to append to the list of GraphQL schema plugins')
+  .option('--prepend-plugins <string>', 'a comma-separated list of plugins to prepend to the list of GraphQL schema plugins')
+  // Things that relate to -X
+  .option('--read-cache <path>', '[experimental] reads cached values from local cache file to improve startup time (you may want to do this in production)')
+  .option('--write-cache <path>', '[experimental] writes computed values to local cache file so startup can be faster (do this during the build phase)')
+  .option('--export-schema-json <path>', 'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
+  .option('--export-schema-graphql <path>', 'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
+  .option('-X, --no-server', '[experimental] for when you just want to use --write-cache or --export-schema-* and not actually run a server (e.g. CI)')
+  // Webserver configuration
+  .option('-q, --graphql <path>', 'the route to mount the GraphQL server on. defaults to `/graphql`')
+  .option('-i, --graphiql <path>', 'the route to mount the GraphiQL interface on. defaults to `/graphiql`')
+  .option('-b, --disable-graphiql', 'disables the GraphiQL interface. overrides the GraphiQL route option')
+  .option('-o, --cors', 'enable generous CORS settings. this is disabled by default, if possible use a proxy instead')
   .option('-l, --body-size-limit <string>', 'set the maximum size of JSON bodies that can be parsed (default 100kB) The size can be given as a human-readable string, such as \'200kB\' or \'5MB\' (case insensitive).')
-  .option('--secret <string>', 'DEPRECATED: Use jwt-secret instead')
+  .option('--cluster-workers <count>', '[experimental] spawn <count> workers to increase throughput', parseFloat)
+  // JSON-related options
   .option('-e, --jwt-secret <string>', 'the secret to be used when creating and verifying JWTs. if none is provided auth will be disabled')
-  .option('--jwt-audiences <string>', 'DEPRECATED Use jwt-verify-audience instead', (option: string) => option.split(','))
   .option('--jwt-verify-algorithms <string>', 'a comma separated list of the names of the allowed jwt token algorithms', (option: string) => option.split(','))
   .option('-A, --jwt-verify-audience <string>', 'a comma separated list of audiences your jwt token can contain. If no audience is given the audience defaults to `postgraphile`', (option: string) => option.split(','))
   .option('--jwt-verify-clock-tolerance <number>', 'number of seconds to tolerate when checking the nbf and exp claims, to deal with small clock differences among different servers', parseFloat)
@@ -61,25 +75,21 @@ program
   .option('--jwt-verify-subject <string>', 'the name of the allowed jwt token subject')
   .option('--jwt-role <string>', 'a comma seperated list of strings that create a path in the jwt from which to extract the postgres role. if none is provided it will use the key `role` on the root of the jwt.', (option: string) => option.split(','))
   .option('-t, --jwt-token-identifier <identifier>', 'the Postgres identifier for a composite type that will be used to create JWT tokens')
-  .option('--append-plugins <string>', 'a comma-separated list of plugins to append to the list of GraphQL schema plugins')
-  .option('--prepend-plugins <string>', 'a comma-separated list of plugins to prepend to the list of GraphQL schema plugins')
-  .option('--export-schema-json <path>', 'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
-  .option('--export-schema-graphql <path>', 'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
-  .option('--show-error-stack [setting]', 'show JavaScript error stacks in the GraphQL result errors')
-  .option('--extended-errors <string>', 'a comma separated list of extended Postgres error fields to display in the GraphQL result. Example: \'hint,detail,errcode\'. Default: none', (option: string) => option.split(',').filter(_ => _))
-  .option('--legacy-relations <omit|deprecated|only>', 'some one-to-one relations were previously detected as one-to-many - should we export \'only\' the old relation shapes, both new and old but mark the old ones as \'deprecated\', or \'omit\' the old relation shapes entirely')
-  .option('--write-cache <path>', '[experimental] writes computed values to local cache file so startup can be faster (do this during the build phase)')
-  .option('--read-cache <path>', '[experimental] reads cached values from local cache file to improve startup time (you may want to do this in production)')
-  .option('-X, --no-server', '[experimental] for when you just want to use --write-cache or --export-schema-* and not actually run a server (e.g. CI)')
-  .option('--cluster-workers <count>', '[experimental] spawn <count> workers to increase throughput', parseFloat)
+  // Deprecated
+  .option('--token <identifier>', 'DEPRECATED: use --jwt-token-identifier instead')
+  .option('--secret <string>', 'DEPRECATED: Use jwt-secret instead')
+  .option('--jwt-audiences <string>', 'DEPRECATED Use jwt-verify-audience instead', (option: string) => option.split(','))
+  // Awkward application workarounds / legacy support
   .option('--badly-behaved-functions', 'if you have any functions that return setof a compound type (such as a table) and you want to return null for some of the results in the set you must enable this')
+  .option('--legacy-relations <omit|deprecated|only>', 'some one-to-one relations were previously detected as one-to-many - should we export \'only\' the old relation shapes, both new and old but mark the old ones as \'deprecated\', or \'omit\' the old relation shapes entirely')
   .option('--legacy-json-uuid', `ONLY use this option if you require the v3 typenames 'Json' and 'Uuid' over 'JSON' and 'UUID'`)
 
 program.on('--help', () => console.log(`
-  Get Started:
+  Get started:
 
-    $ postgraphile --demo
-    $ postgraphile --schema my_schema
+    $ postgraphile
+    $ postgraphile -c postgres://localhost/my_db
+    $ postgraphile --connection postgres://user:pass@localhost/my_db --schema my_schema --watch --dynamic-json
 `.slice(1)))
 
 program.parse(process.argv)

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -73,6 +73,7 @@ program
   .option('-X, --no-server', '[experimental] for when you just want to use --write-cache or --export-schema-* and not actually run a server (e.g. CI)')
   .option('--cluster-workers <count>', '[experimental] spawn <count> workers to increase throughput', parseFloat)
   .option('--badly-behaved-functions', 'if you have any functions that return setof a compound type (such as a table) and you want to return null for some of the results in the set you must enable this')
+  .option('--legacy-json-uuid', `ONLY use this option if you require the v3 typenames 'Json' and 'Uuid' over 'JSON' and 'UUID'`)
 
 program.on('--help', () => console.log(`
   Get Started:
@@ -132,6 +133,7 @@ const {
   server: yesServer,
   clusterWorkers,
   badlyBehavedFunctions,
+  legacyJsonUuid,
 // tslint:disable-next-line no-any
 } = Object.assign({}, config['options'], program) as any
 
@@ -248,6 +250,7 @@ const postgraphileOptions = {
   writeCache,
   legacyRelations,
   badlyBehavedFunctions,
+  legacyJsonUuid,
 }
 
 if (noServer) {

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -37,6 +37,7 @@ type PostGraphileOptions = {
   readCache?: string,
   writeCache?: string,
   legacyRelations?: 'only' | 'deprecated' | 'omit',
+  badlyBehavedFunctions?: boolean,
 }
 
 type PostgraphileSchemaBuilder = {

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -37,7 +37,7 @@ type PostGraphileOptions = {
   readCache?: string,
   writeCache?: string,
   legacyRelations?: 'only' | 'deprecated' | 'omit',
-  badlyBehavedFunctions?: boolean,
+  setofFunctionsContainNulls?: boolean,
   legacyJsonUuid?: boolean,
 }
 

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -38,6 +38,7 @@ type PostGraphileOptions = {
   writeCache?: string,
   legacyRelations?: 'only' | 'deprecated' | 'omit',
   badlyBehavedFunctions?: boolean,
+  legacyJsonUuid?: boolean,
 }
 
 type PostgraphileSchemaBuilder = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3361,16 +3361,15 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphile-build-pg@4.0.0-alpha.2:
-  version "4.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.0.0-alpha.2.tgz#c58164beae63ae27586182313b8e34f8d3e51eda"
+graphile-build-pg@4.0.0-alpha.3:
+  version "4.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.0.0-alpha.3.tgz#61a130671b8e784dc81450610b78f16597909d32"
   dependencies:
     babel-runtime ">=6 <7"
     chalk "^2.1.0"
     debug ">=2 <3"
     graphile-build "4.0.0-alpha.1"
     graphql-iso-date "^3.2.0"
-    graphql-type-json "^0.1.4"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
     lru-cache "4.1.1"
@@ -3447,10 +3446,6 @@ graphql-request@^1.4.0:
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-1.4.0.tgz#f5b067c83070296d93fb45760e83dfad0d9f537a"
   dependencies:
     cross-fetch "0.0.8"
-
-graphql-type-json@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/graphql-type-json/-/graphql-type-json-0.1.4.tgz#89f13f5d32ce08c9a76c79fdf9c1968384d81a4e"
 
 "graphql@>=0.6 <0.13":
   version "0.12.3"
@@ -6255,13 +6250,13 @@ postcss@^6.0.1:
     source-map "^0.5.6"
     supports-color "^4.1.0"
 
-postgraphile-core@4.0.0-alpha.2:
-  version "4.0.0-alpha.2"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.0.0-alpha.2.tgz#468bd5cc19c63781df08701200db77e1ccc945b4"
+postgraphile-core@4.0.0-alpha.3:
+  version "4.0.0-alpha.3"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.0.0-alpha.3.tgz#5652dac1657cdd3009fe16922b1e2525d7e79471"
   dependencies:
     babel-runtime ">=6 <7"
     graphile-build "4.0.0-alpha.1"
-    graphile-build-pg "4.0.0-alpha.2"
+    graphile-build-pg "4.0.0-alpha.3"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3361,9 +3361,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphile-build-pg@4.0.0-alpha.1:
-  version "4.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.0.0-alpha.1.tgz#7b071e45604dc2e76b18746cb5845935603395fc"
+graphile-build-pg@4.0.0-alpha.2:
+  version "4.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.0.0-alpha.2.tgz#c58164beae63ae27586182313b8e34f8d3e51eda"
   dependencies:
     babel-runtime ">=6 <7"
     chalk "^2.1.0"
@@ -6255,13 +6255,13 @@ postcss@^6.0.1:
     source-map "^0.5.6"
     supports-color "^4.1.0"
 
-postgraphile-core@4.0.0-alpha.1:
-  version "4.0.0-alpha.1"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.0.0-alpha.1.tgz#2a6551624cb737835580bd84bfef515be9a668de"
+postgraphile-core@4.0.0-alpha.2:
+  version "4.0.0-alpha.2"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.0.0-alpha.2.tgz#468bd5cc19c63781df08701200db77e1ccc945b4"
   dependencies:
     babel-runtime ">=6 <7"
     graphile-build "4.0.0-alpha.1"
-    graphile-build-pg "4.0.0-alpha.1"
+    graphile-build-pg "4.0.0-alpha.2"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3361,9 +3361,9 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/graceful-readlink/-/graceful-readlink-1.0.1.tgz#4cafad76bc62f02fa039b2f94e9a3dd3a391a725"
 
-graphile-build-pg@4.0.0-alpha.3:
-  version "4.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.0.0-alpha.3.tgz#61a130671b8e784dc81450610b78f16597909d32"
+graphile-build-pg@4.0.0-alpha.4:
+  version "4.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.0.0-alpha.4.tgz#bebe961106092456760891da0505511117a8fef4"
   dependencies:
     babel-runtime ">=6 <7"
     chalk "^2.1.0"
@@ -3374,7 +3374,7 @@ graphile-build-pg@4.0.0-alpha.3:
     lodash ">=4 <5"
     lru-cache "4.1.1"
     pg-range-parser "^1.0.0"
-    pg-sql2 "^1.0.0-beta.3"
+    pg-sql2 "1.0.0-beta.7"
     pluralize "^5.0.0"
     postgres-interval "1.1.1"
 
@@ -5874,12 +5874,6 @@ pg-sql2@1.0.0-beta.7:
   dependencies:
     debug ">=2 <3"
 
-pg-sql2@^1.0.0-beta.3:
-  version "1.0.0-beta.3"
-  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-1.0.0-beta.3.tgz#0bf0f7072c6428e2971e4a25fda71f7eeef8c2f2"
-  dependencies:
-    debug ">=2 <3"
-
 pg-types@~1.12.1:
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/pg-types/-/pg-types-1.12.1.tgz#d64087e3903b58ffaad279e7595c52208a14c3d2"
@@ -6250,13 +6244,13 @@ postcss@^6.0.1:
     source-map "^0.5.6"
     supports-color "^4.1.0"
 
-postgraphile-core@4.0.0-alpha.3:
-  version "4.0.0-alpha.3"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.0.0-alpha.3.tgz#5652dac1657cdd3009fe16922b1e2525d7e79471"
+postgraphile-core@4.0.0-alpha.4:
+  version "4.0.0-alpha.4"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.0.0-alpha.4.tgz#0233d396c560f900d71945c43970b63dd311040b"
   dependencies:
     babel-runtime ">=6 <7"
     graphile-build "4.0.0-alpha.1"
-    graphile-build-pg "4.0.0-alpha.3"
+    graphile-build-pg "4.0.0-alpha.4"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5868,9 +5868,9 @@ pg-range-parser@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/pg-range-parser/-/pg-range-parser-1.0.0.tgz#561e8c4c3dee98a1caa8288c5c7e4300861819bb"
 
-pg-sql2@^1.0.0-alpha1.0:
-  version "1.0.0-alpha1.0"
-  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-1.0.0-alpha1.0.tgz#13c34041f82fa895bb1fb94eed7ed70a060c394d"
+pg-sql2@1.0.0-beta.7:
+  version "1.0.0-beta.7"
+  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-1.0.0-beta.7.tgz#cf6674f5101af54c8903555c10d013369eb59a10"
   dependencies:
     debug ">=2 <3"
 


### PR DESCRIPTION
- `--legacy-json-uuid` - uses `Uuid` and `Json` over `UUID` and `JSON`
- `--no-setof-functions-contain-nulls` / `-N` - reduces nullables in the schema by promising functions that return setof compound types won't return a null in the middle of the results