### PR TITLE
feat(postgraphile): adding query batching #634

### DIFF
--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -234,7 +234,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       await request(server)
         .post('/graphql')
         .send({ query: '{' })
-        .expect(400)
+        .expect(200)
         .expect('Content-Type', /json/)
         .expect({
           errors: [
@@ -251,7 +251,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       await request(server)
         .post('/graphql')
         .send({ query: '{notFound}' })
-        .expect(400)
+        .expect(200)
         .expect('Content-Type', /json/)
         .expect({
           errors: [
@@ -398,7 +398,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       await request(server)
         .post('/graphql')
         .send({ query: '{hello}', variables: 2 })
-        .expect(400)
+        .expect(200)
         .expect({
           errors: [{ message: 'Variables must be an object, not \'number\'.' }],
         })
@@ -409,7 +409,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       await request(server)
         .post('/graphql')
         .send({ query: '{hello}', operationName: 2 })
-        .expect(400)
+        .expect(200)
         .expect({
           errors: [
             { message: 'Operation name must be a string, not \'number\'.' },

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.js
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.js
@@ -130,21 +130,21 @@ const runQuery = async (
   debugRequest('Running Query.')
 
   // Validate our params object a bit.
-  if (params == null){
+  if (params == null) {
     return {
       status: 400,
       errors: 'Must provide an object parameters, not nullish value.',
     }
   }
 
-  if (typeof params !== 'object'){
+  if (typeof params !== 'object') {
     return {
       status: 400,
       errors: `Expected parameter object, not value of type '${typeof params}'.`,
     }
   }
 
-  if (!params.query){
+  if (!params.query) {
     return {
       status: 400,
       errors: 'Must provide a query string.',
@@ -172,7 +172,7 @@ const runQuery = async (
   }
 
   // Throw an error if `variables` is not an object.
-  if (params.variables != null && typeof params.variables !== 'object'){
+  if (params.variables != null && typeof params.variables !== 'object') {
     return {
       status: 400,
       errors: `Variables must be an object, not '${typeof params.variables}'.`,
@@ -183,7 +183,7 @@ const runQuery = async (
   if (
     params.operationName != null &&
     typeof params.operationName !== 'string'
-  ){
+  ) {
     return {
       status: 400,
       errors: `Operation name must be a string, not '${typeof params.operationName}'.`,
@@ -601,7 +601,7 @@ export default function createPostGraphileHttpRequestHandler(options) {
       //   be executing.
       params = typeof req.body === 'string' ? { query: req.body } : req.body
 
-      if (Array.isArray(params)){
+      if (Array.isArray(params)) {
         result = await Promise.all(params.map(param => runQuery(
           req,
           res,
@@ -613,7 +613,7 @@ export default function createPostGraphileHttpRequestHandler(options) {
           queryTimeStart,
           param,
         )))
-      }else{
+      } else {
         result = await runQuery(
           req,
           res,

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.js
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.js
@@ -107,7 +107,6 @@ const withPostGraphileContextFromReqResGenerator = options => {
   }
 }
 
-
 /**
  * Runs a GraphQL Query. Can be mapped over a list of batched queries
  *
@@ -124,7 +123,7 @@ const runQuery = async (
   pgRole,
   queryTimeStart,
   params
-)=>{
+) => {
 
   let queryDocumentAst
 
@@ -133,22 +132,22 @@ const runQuery = async (
   // Validate our params object a bit.
   if (params == null){
     return {
-      status:400,
-      errors:'Must provide an object parameters, not nullish value.'
+      status: 400,
+      errors: 'Must provide an object parameters, not nullish value.',
     }
   }
 
   if (typeof params !== 'object'){
     return {
-      status:400,
-      errors:`Expected parameter object, not value of type '${typeof params}'.`
+      status: 400,
+      errors: `Expected parameter object, not value of type '${typeof params}'.`,
     }
   }
 
   if (!params.query){
     return {
-      status:400,
-      errors:'Must provide a query string.'
+      status: 400,
+      errors: 'Must provide a query string.',
     }
   }
 
@@ -165,8 +164,8 @@ const runQuery = async (
         params.variables = JSON.parse(params.variables)
       } catch (error) {
         return {
-          status:400,
-          errors:`Error parsing variables: ${error}`
+          status: 400,
+          errors: `Error parsing variables: ${error}`,
         }
       }
     }
@@ -175,8 +174,8 @@ const runQuery = async (
   // Throw an error if `variables` is not an object.
   if (params.variables != null && typeof params.variables !== 'object'){
     return {
-      status:400,
-      errors:`Variables must be an object, not '${typeof params.variables}'.`
+      status: 400,
+      errors: `Variables must be an object, not '${typeof params.variables}'.`,
     }
   }
 
@@ -186,8 +185,8 @@ const runQuery = async (
     typeof params.operationName !== 'string'
   ){
     return {
-      status:400,
-      errors:`Operation name must be a string, not '${typeof params.operationName}'.`
+      status: 400,
+      errors: `Operation name must be a string, not '${typeof params.operationName}'.`,
     }
   }
 
@@ -198,8 +197,8 @@ const runQuery = async (
     queryDocumentAst = parseGraphql(source)
   } catch (error) {
     return {
-      status:400,
-      errors:`Error parsing query: '${error}'.`
+      status: 400,
+      errors: `Error parsing query: '${error}'.`,
     }
   }
 
@@ -213,8 +212,8 @@ const runQuery = async (
   // send the errors to the client with a `400` code.
   if (validationErrors.length > 0) {
     return {
-      status:400,
-      errors:validationErrors
+      status: 400,
+      errors: validationErrors,
     }
   }
 
@@ -603,7 +602,7 @@ export default function createPostGraphileHttpRequestHandler(options) {
       params = typeof req.body === 'string' ? { query: req.body } : req.body
 
       if (Array.isArray(params)){
-        result = await Promise.all(params.map(param=>runQuery(
+        result = await Promise.all(params.map(param => runQuery(
           req,
           res,
           handleErrors,
@@ -612,7 +611,7 @@ export default function createPostGraphileHttpRequestHandler(options) {
           withPostGraphileContextFromReqRes,
           pgRole,
           queryTimeStart,
-          param
+          param,
         )))
       }else{
         result = await runQuery(
@@ -624,7 +623,7 @@ export default function createPostGraphileHttpRequestHandler(options) {
           withPostGraphileContextFromReqRes,
           pgRole,
           queryTimeStart,
-          params
+          params,
         )
       }
 


### PR DESCRIPTION
I've modified the HTTP handler to accept an array of queries for query batching as discussed in #634. 

Quick summary of changes: I extracted out the query running logic into its own function then map it over the incoming queries if they are in an array.

There are a couple things in this change to take note of and change if there's a better approach.  So looking for input on these:

1. This changes how errors are returned for individual queries.  Query errors will always return with a 200 status code and with the ususal "errors" entry in the returned object. This is so that if a single query fails the rest do not.  I've also added a "status" entry with the old status code in the returned error data object , not sure if this is even helpful.

2.  I've moved some of the logging steps around not sure if this will have a negative impact on performance.

3.  I feel like this could be refactored further, but wanted to get something working out there.