### PR TITLE
fix(koa): don't compress server-sent events stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.0.0-rc.1.1",
+  "version": "4.0.0-rc.1.2",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/src/postgraphile/http/setupServerSentEvents.js
+++ b/src/postgraphile/http/setupServerSentEvents.js
@@ -17,6 +17,7 @@ export default function setupServerSentEvents(req, res, options) {
   const stream = isKoa ? new PassThrough() : null
   if (isKoa) {
     req._koaCtx.response.body = stream
+    req._koaCtx.compress = false
   }
 
   const sse = str => {


### PR DESCRIPTION
Otherwise watching changes in GraphiQL doesn't work if you're using the Koa compress middleware.