### PR TITLE
fix(koa): don't compress assets via send

### DIFF
--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.js
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.js
@@ -426,6 +426,9 @@ export default function createPostGraphileHttpRequestHandler(options) {
 
         // Sends the asset at this path. Defaults to a `statusCode` of 200.
         res.statusCode = 200
+        if (req._koaCtx) {
+          req._koaCtx.compress = false
+        }
         await new Promise((resolve, reject) => {
           const stream = sendFile(req, assetPathRelative, {
             index: false,


### PR DESCRIPTION
Koa sometimes seems to hang when loading GraphiQL; I've not been able to deliberately reproduce it. This seems to be solving it so far... Really we ought to replace `sendFile` with something Koa-friendly.