### PR TITLE
fix: ignore RBAC by default, tweak CLI & library documentation

### DIFF
--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -87,20 +87,20 @@ pluginHook('cli:flags:add:standard', addFlag)
 
 // Schema configuration
 program
-  .option('-j, --dynamic-json', 'enable dynamic JSON in GraphQL inputs and outputs. uses stringified JSON by default')
-  .option('-N, --no-setof-functions-contain-nulls', 'if none of your `RETURNS SETOF compound_type` functions mix NULLs with the results then you may enable this to reduce the nullables in the GraphQL schema')
+  .option('-j, --dynamic-json', '[RECOMMENDED] enable dynamic JSON in GraphQL inputs and outputs. PostGraphile uses stringified JSON by default')
+  .option('-N, --no-setof-functions-contain-nulls', '[RECOMMENDED] if none of your `RETURNS SETOF compound_type` functions mix NULLs with the results then you may enable this to reduce the nullables in the GraphQL schema')
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
   .option('--simple-collections [omit|both|only]', '"omit" (default) - relay connections only, "only" - simple collections only (no Relay connections), "both" - both')
-  .option('--no-ignore-rbac', 'set this to excludes fields, queries and mutations that the user isn\'t permitted to access; this will be the default in v5')
-  .option('--include-extension-resources', 'by default, tables and functions that come from extensions are excluded; use this flag to include them')
+  .option('--no-ignore-rbac', '[RECOMMENDED] set this to excludes fields, queries and mutations that the user isn\'t permitted to access; this will be the default in v5')
+  .option('--include-extension-resources', 'by default, tables and functions that come from extensions are excluded; use this flag to include them (not recommended)')
 
 pluginHook('cli:flags:add:schema', addFlag)
 
 // Error enhancements
 program
-  .option('--show-error-stack', 'show JavaScript error stacks in the GraphQL result errors')
-  .option('--extended-errors <string>', 'a comma separated list of extended Postgres error fields to display in the GraphQL result. Example: \'hint,detail,errcode\'. Default: none', (option: string) => option.split(',').filter(_ => _))
+  .option('--show-error-stack', 'show JavaScript error stacks in the GraphQL result errors (recommended in development)')
+  .option('--extended-errors <string>', 'a comma separated list of extended Postgres error fields to display in the GraphQL result. Recommended in development: \'hint,detail,errcode\'. Default: none', (option: string) => option.split(',').filter(_ => _))
 
 pluginHook('cli:flags:add:errorHandling', addFlag)
 
@@ -126,11 +126,11 @@ program
   .option('-q, --graphql <path>', 'the route to mount the GraphQL server on. defaults to `/graphql`')
   .option('-i, --graphiql <path>', 'the route to mount the GraphiQL interface on. defaults to `/graphiql`')
   .option('-b, --disable-graphiql', 'disables the GraphiQL interface. overrides the GraphiQL route option')
-  .option('-o, --cors', 'enable generous CORS settings. this is disabled by default, if possible use a proxy instead')
+  .option('-o, --cors', 'enable generous CORS settings; disabled by default, if possible use a proxy instead')
   .option('-l, --body-size-limit <string>', 'set the maximum size of JSON bodies that can be parsed (default 100kB) The size can be given as a human-readable string, such as \'200kB\' or \'5MB\' (case insensitive).')
   .option('--cluster-workers <count>', '[experimental] spawn <count> workers to increase throughput', parseFloat)
   .option('--enable-query-batching', '[experimental] enable the server to process multiple GraphQL queries in one request')
-  .option('--disable-query-log', 'disable logging queries to console')
+  .option('--disable-query-log', 'disable logging queries to console (recommended in production)')
 
 pluginHook('cli:flags:add:webserver', addFlag)
 

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -92,7 +92,7 @@ program
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
   .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
   .option('--simple-collections [omit|both|only]', '"omit" (default) - relay connections only, "only" - simple collections only (no Relay connections), "both" - both')
-  .option('--ignore-rbac', 'by default, PostGraphile excludes fields, queries and mutations that the user isn\'t permitted to access; use this flag to skip these checks and expose everything')
+  .option('--no-ignore-rbac', 'set this to excludes fields, queries and mutations that the user isn\'t permitted to access; this will be the default in v5')
   .option('--include-extension-resources', 'by default, tables and functions that come from extensions are excluded; use this flag to include them')
 
 pluginHook('cli:flags:add:schema', addFlag)
@@ -220,7 +220,7 @@ const {
   classicIds = false,
   dynamicJson = false,
   disableDefaultMutations = false,
-  ignoreRbac = false,
+  ignoreRbac = true,
   includeExtensionResources = false,
   exportSchemaJson: exportJsonSchemaPath,
   exportSchemaGraphql: exportGqlSchemaPath,

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -20,19 +20,21 @@ export type PostGraphileOptions = {
   // feature requires an event trigger to be added to the database by a
   // superuser. When enabled PostGraphile will try to add this trigger, if you
   // did not connect as a superuser you will get a warning and the trigger
-  // won’t be added.
+  // won’t be added. The trigger will not be removed, to remove it run:
+  //
+  //   `drop schema postgraphile_watch cascade;`
   /* @middlewareOnly */
   watchPg?: boolean,
   // The default Postgres role to use. If no role was provided in a provided
   // JWT token, this role will be used.
   pgDefaultRole?: string,
-  // Setting this to `true` enables dynamic JSON which will allow you to use
-  // any JSON as input and get any arbitrary JSON as output. By default JSON
-  // types are just a JSON string.
+  // By default, JSON and JSONB fields are presented as strings (JSON encoded)
+  // from the GraphQL schema. Setting this to `true` (recommended) enables raw
+  // JSON input and output, saving the need to parse / stringify JSON manually.
   dynamicJson?: boolean,
   // If none of your `RETURNS SETOF compound_type` functions mix NULLs with the
   // results then you may set this true to reduce the nullables in the GraphQL
-  // schema
+  // schema.
   setofFunctionsContainNulls?: boolean,
   // Enables classic ids for Relay support. Instead of using the field name
   // `nodeId` for globally unique ids, PostGraphile will instead use the field
@@ -43,42 +45,45 @@ export type PostGraphileOptions = {
   // types & fields. Database mutation will only be possible through Postgres
   // functions.
   disableDefaultMutations?: boolean,
-  // By default, PostGraphile excludes fields, queries and mutations that the
-  // user isn't permitted to access; set this option true to skip these checks
-  // and expose everything.
+  // Set false (recommended) to exclude fields, queries and mutations that the
+  // user isn't permitted to access from the generated GraphQL schema; set this
+  // option true to skip these checks and create GraphQL fields and types for
+  // everything.
+  // The default is `true`, in v5 the default will change to `false`.
   ignoreRBAC?: boolean,
   // By default, tables and functions that come from extensions are excluded
   // from the generated GraphQL schema as general applications don't need them
   // to be exposed to the end user. You can use this flag to include them in
-  // the generated schema. It's recommended that you expose a schema other than
-  // `public` so that the schema is not polluted with extension resources
-  // anyway.
+  // the generated schema (not recommended).
   includeExtensionResources?: boolean,
   // Enables adding a `stack` field to the error response.  Can be either the
   // boolean `true` (which results in a single stack string) or the string
   // `json` (which causes the stack to become an array with elements for each
-  // line of the stack).
+  // line of the stack). Recommended in development, not recommended in
+  // production.
   showErrorStack?: boolean,
-  // Enables ability to modify errors before sending them down to the client
-  // optionally can send down custom responses
+  // Extends the error response with additional details from the Postgres
+  // error.  Can be any combination of `['hint', 'detail', 'errcode']`.
+  // Default is `[]`.
+  extendedErrors?: Array<string>,
+  // Enables ability to modify errors before sending them down to the client.
+  // Optionally can send down custom responses. If you use this then
+  // `showErrorStack` and `extendedError` may have no
+  // effect.
   /* @middlewareOnly */
   handleErrors?: ((
     errors: Array<GraphQLError>,
     req: IncomingMessage,
     res: ServerResponse,
   ) => Array<GraphQLErrorExtended>);
-  // Extends the error response with additional details from the Postgres
-  // error.  Can be any combination of `['hint', 'detail', 'errcode']`.
-  // Default is `[]`.
-  extendedErrors?: Array<string>,
-  // an array of [Graphile Build](/graphile-build/plugins/) plugins to load
-  // after the default plugins
+  // An array of [Graphile Build](/graphile-build/plugins/) plugins to load
+  // after the default plugins.
   appendPlugins?: Array<(builder: mixed) => {}>,
-  // an array of [Graphile Build](/graphile-build/plugins/) plugins to load
-  // before the default plugins (you probably don't want this)
+  // An array of [Graphile Build](/graphile-build/plugins/) plugins to load
+  // before the default plugins (you probably don't want this).
   prependPlugins?: Array<(builder: mixed) => {}>,
-  // the full array of [Graphile Build](/graphile-build/plugins/) plugins to
-  // use for schema generation (you almost definitely don't want this!)
+  // The full array of [Graphile Build](/graphile-build/plugins/) plugins to
+  // use for schema generation (you almost definitely don't want this!).
   replaceAllPlugins?: Array<(builder: mixed) => {}>,
   // A file path string. Reads cached values from local cache file to improve
   // startup time (you may want to do this in production).
@@ -148,14 +153,15 @@ export type PostGraphileOptions = {
   jwtAudiences?: Array<string>,
   // Some one-to-one relations were previously detected as one-to-many - should
   // we export 'only' the old relation shapes, both new and old but mark the
-  // old ones as 'deprecated', or 'omit' the old relation shapes entirely
+  // old ones as 'deprecated' (default), or 'omit' (recommended) the old
+  // relation shapes entirely.
   legacyRelations?: 'only' | 'deprecated' | 'omit',
   // ONLY use this option if you require the v3 typenames 'Json' and 'Uuid'
-  // over 'JSON' and 'UUID'
+  // over 'JSON' and 'UUID'.
   legacyJsonUuid?: boolean,
   // Turns off GraphQL query logging. By default PostGraphile will log every
   // GraphQL query it processes along with some other information. Set this to
-  // `true` to disable that feature.
+  // `true` (recommended in production) to disable that feature.
   /* @middlewareOnly */
   disableQueryLog?: boolean,
   // A plain object specifying custom config values to set in the PostgreSQL
@@ -177,7 +183,7 @@ export type PostGraphileOptions = {
   pluginHook?: PluginHookFn,
   // Should we use relay pagination, or simple collections?
   // "omit" (default) - relay connections only,
-  // "only" - simple collections only (no Relay connections),
+  // "only" (not recommended) - simple collections only (no Relay connections),
   // "both" - both
   simpleCollections?: 'omit' | 'both' | 'only',
 }


### PR DESCRIPTION
Because it turns out some people use PostGraphile in interesting ways (e.g. defining and/or granting permissions after the server starts) this would be too much of a breaking change.

RBAC will be ignored by default in v5, so it's recommended you explicitly use `--ignore-rbac` or `--no-ignore-rbac` depending on your preference to make your v5 transition easier.