### PR TITLE
chore(lint): apply `prettier` against the codebase

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "koa-compress": "^3.0.0",
     "nodemon": "^1.11.0",
     "pg-minify": "~0.5.3",
+    "prettier": "1.13.7",
     "react": "^15.3.2",
     "react-dom": "^15.3.2",
     "react-scripts": "1.1.1",
@@ -85,6 +86,7 @@
     "supertest": "^2.0.1",
     "ts-node": "^2.0.0",
     "tslint": "^5.10.0",
+    "tslint-config-prettier": "1.14.0",
     "typescript": "^2.9.2"
   },
   "jest": {

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,6 @@
 module.exports = {
-  printWidth: 120,
+  printWidth: 100,
   semi: false,
   singleQuote: true,
-  trailingComma: "es5",
+  trailingComma: "all",
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  printWidth: 120,
+  semi: false,
+  singleQuote: true,
+  trailingComma: "es5",
+}

--- a/src/__tests__/utils/createTestInParallel.ts
+++ b/src/__tests__/utils/createTestInParallel.ts
@@ -5,7 +5,10 @@
  *
  * This function will break the timing numbers in the Jest console.
  */
-export default function createTestInParallel(): (name: string, fn: () => void | Promise<void>) => void {
+export default function createTestInParallel(): (
+  name: string,
+  fn: () => void | Promise<void>,
+) => void {
   // All of the test functions. We collect them in a single array so that we can
   // call them all at once.
   const testFns: Array<() => void | Promise<void>> = []

--- a/src/__tests__/utils/withPgClient.ts
+++ b/src/__tests__/utils/withPgClient.ts
@@ -7,7 +7,9 @@ import kitchenSinkSchemaSql from './kitchenSinkSchemaSql'
  * client. The client will be connected from the pool at the start of the test,
  * and released back at the end. All changes will be rolled back.
  */
-export default function withPgClient <T>(fn: (client: PoolClient) => T | Promise<T>): () => Promise<T> {
+export default function withPgClient<T>(
+  fn: (client: PoolClient) => T | Promise<T>,
+): () => Promise<T> {
   return async (): Promise<T> => {
     let result: T | undefined
 
@@ -18,11 +20,10 @@ export default function withPgClient <T>(fn: (client: PoolClient) => T | Promise
     // is resolved correctly.
     //
     // @see https://github.com/brianc/node-postgres/issues/1142
-    if ((client as object)['errno'])
-      throw client
+    if ((client as object)['errno']) throw client
 
     await client.query('begin')
-    await client.query('set local timezone to \'+04:00\'')
+    await client.query("set local timezone to '+04:00'")
 
     // Run our kichen sink schema Sql, if there is an error we should report it
     try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,9 @@
-/* eslint-disable */// Because we use tslint
-import { postgraphile, createPostGraphileSchema, watchPostGraphileSchema, withPostGraphileContext } from './postgraphile'
+import {
+  postgraphile,
+  createPostGraphileSchema,
+  watchPostGraphileSchema,
+  withPostGraphileContext,
+} from './postgraphile'
 import { makePluginHook, PostGraphilePlugin } from './postgraphile/pluginHook'
 
 export default postgraphile
@@ -11,7 +15,6 @@ export {
   withPostGraphileContext,
   makePluginHook,
   PostGraphilePlugin,
-
   // Backwards compatability
   postgraphile as postgraphql,
   createPostGraphileSchema as createPostGraphQLSchema,

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -7,7 +7,6 @@ import { Pool } from 'pg'
 import jwt = require('jsonwebtoken')
 
 export namespace PostGraphile {
-
   /**
    * A narrower type than `any` that won’t swallow errors from assumptions about
    * code.
@@ -41,48 +40,48 @@ export namespace PostGraphile {
     //
     //   `drop schema postgraphile_watch cascade;`
     /* @middlewareOnly */
-    watchPg?: boolean,
+    watchPg?: boolean
     // The default Postgres role to use. If no role was provided in a provided
     // JWT token, this role will be used.
-    pgDefaultRole?: string,
+    pgDefaultRole?: string
     // By default, JSON and JSONB fields are presented as strings (JSON encoded)
     // from the GraphQL schema. Setting this to `true` (recommended) enables raw
     // JSON input and output, saving the need to parse / stringify JSON manually.
-    dynamicJson?: boolean,
+    dynamicJson?: boolean
     // If none of your `RETURNS SETOF compound_type` functions mix NULLs with the
     // results then you may set this true to reduce the nullables in the GraphQL
     // schema.
-    setofFunctionsContainNulls?: boolean,
+    setofFunctionsContainNulls?: boolean
     // Enables classic ids for Relay support. Instead of using the field name
     // `nodeId` for globally unique ids, PostGraphile will instead use the field
     // name `id` for its globally unique ids. This means that table `id` columns
     // will also get renamed to `rowId`.
-    classicIds?: boolean,
+    classicIds?: boolean
     // Setting this to `true` will prevent the creation of the default mutation
     // types & fields. Database mutation will only be possible through Postgres
     // functions.
-    disableDefaultMutations?: boolean,
+    disableDefaultMutations?: boolean
     // Set false (recommended) to exclude fields, queries and mutations that the
     // user isn't permitted to access from the generated GraphQL schema; set this
     // option true to skip these checks and create GraphQL fields and types for
     // everything.
     // The default is `true`, in v5 the default will change to `false`.
-    ignoreRBAC?: boolean,
+    ignoreRBAC?: boolean
     // By default, tables and functions that come from extensions are excluded
     // from the generated GraphQL schema as general applications don't need them
     // to be exposed to the end user. You can use this flag to include them in
     // the generated schema (not recommended).
-    includeExtensionResources?: boolean,
+    includeExtensionResources?: boolean
     // Enables adding a `stack` field to the error response.  Can be either the
     // boolean `true` (which results in a single stack string) or the string
     // `json` (which causes the stack to become an array with elements for each
     // line of the stack). Recommended in development, not recommended in
     // production.
-    showErrorStack?: boolean | 'json',
+    showErrorStack?: boolean | 'json'
     // Extends the error response with additional details from the Postgres
     // error.  Can be any combination of `['hint', 'detail', 'errcode']`.
     // Default is `[]`.
-    extendedErrors?: Array<string>,
+    extendedErrors?: Array<string>
     // Enables ability to modify errors before sending them down to the client.
     // Optionally can send down custom responses. If you use this then
     // `showErrorStack` and `extendedError` may have no
@@ -95,147 +94,149 @@ export namespace PostGraphile {
     ) => Array<GraphQLErrorExtended>)
     // An array of [Graphile Build](/graphile-build/plugins/) plugins to load
     // after the default plugins.
-    appendPlugins?: Array<(builder: mixed) => {}>,
+    appendPlugins?: Array<(builder: mixed) => {}>
     // An array of [Graphile Build](/graphile-build/plugins/) plugins to load
     // before the default plugins (you probably don't want this).
-    prependPlugins?: Array<(builder: mixed) => {}>,
+    prependPlugins?: Array<(builder: mixed) => {}>
     // The full array of [Graphile Build](/graphile-build/plugins/) plugins to
     // use for schema generation (you almost definitely don't want this!).
-    replaceAllPlugins?: Array<(builder: mixed) => {}>,
+    replaceAllPlugins?: Array<(builder: mixed) => {}>
     // A file path string. Reads cached values from local cache file to improve
     // startup time (you may want to do this in production).
-    readCache?: string,
+    readCache?: string
     // A file path string. Writes computed values to local cache file so startup
     // can be faster (do this during the build phase).
-    writeCache?: string,
+    writeCache?: string
     // Enables saving the detected schema, in JSON format, to the given location.
     // The directories must exist already, if the file exists it will be
     // overwritten.
     /* @middlewareOnly */
-    exportJsonSchemaPath?: string,
+    exportJsonSchemaPath?: string
     // Enables saving the detected schema, in GraphQL schema format, to the given
     // location. The directories must exist already, if the file exists it will
     // be overwritten.
     /* @middlewareOnly */
-    exportGqlSchemaPath?: string,
+    exportGqlSchemaPath?: string
     // The endpoint the GraphQL executer will listen on. Defaults to `/graphql`.
     /* @middlewareOnly */
-    graphqlRoute?: string,
+    graphqlRoute?: string
     // The endpoint the GraphiQL query interface will listen on (**NOTE:**
     // GraphiQL will not be enabled unless the `graphiql` option is set to
     // `true`). Defaults to `/graphiql`.
     /* @middlewareOnly */
-    graphiqlRoute?: string,
+    graphiqlRoute?: string
     // Set this to `true` to enable the GraphiQL interface.
     /* @middlewareOnly */
-    graphiql?: boolean,
+    graphiql?: boolean
     // Enables some generous CORS settings for the GraphQL endpoint. There are
     // some costs associated when enabling this, if at all possible try to put
     // your API behind a reverse proxy.
     /* @middlewareOnly */
-    enableCors?: boolean,
+    enableCors?: boolean
     // Set the maximum size of JSON bodies that can be parsed (default 100kB).
     // The size can be given as a human-readable string, such as '200kB' or '5MB'
     // (case insensitive).
     /* @middlewareOnly */
-    bodySizeLimit?: string,
+    bodySizeLimit?: string
     // [Experimental] Enable the middleware to process multiple GraphQL queries
     // in one request
     /* @middlewareOnly */
-    enableQueryBatching?: string,
+    enableQueryBatching?: string
     // The secret for your JSON web tokens. This will be used to verify tokens in
     // the `Authorization` header, and signing JWT tokens you return in
     // procedures.
-    jwtSecret?: string,
+    jwtSecret?: string
     // Options with which to perform JWT verification - see
     // https://github.com/auth0/node-jsonwebtoken#jwtverifytoken-secretorpublickey-options-callback
     // If 'audience' property is unspecified, it will default to
     // ['postgraphile']; to prevent audience verification set it explicitly to
     // null.
     /* @middlewareOnly */
-    jwtVerifyOptions?: jwt.VerifyOptions,
+    jwtVerifyOptions?: jwt.VerifyOptions
     // A comma separated list of strings that give a path in the jwt from which
     // to extract the postgres role. If none is provided it will use the key
     // `role` on the root of the jwt.
     /* @middlewareOnly */
-    jwtRole?: Array<string>,
+    jwtRole?: Array<string>
     // The Postgres type identifier for the compound type which will be signed as
     // a JWT token if ever found as the return type of a procedure. Can be of the
     // form: `my_schema.my_type`. You may use quotes as needed:
     // `"my-special-schema".my_type`.
-    jwtPgTypeIdentifier?: string,
+    jwtPgTypeIdentifier?: string
     // [DEPRECATED] The audience to use when verifing the JWT token. Deprecated,
     // use `jwtVerifyOptions.audience` instead.
     /* @middlewareOnly */
-    jwtAudiences?: Array<string>,
+    jwtAudiences?: Array<string>
     // Some one-to-one relations were previously detected as one-to-many - should
     // we export 'only' the old relation shapes, both new and old but mark the
     // old ones as 'deprecated' (default), or 'omit' (recommended) the old
     // relation shapes entirely.
-    legacyRelations?: 'only' | 'deprecated' | 'omit',
+    legacyRelations?: 'only' | 'deprecated' | 'omit'
     // ONLY use this option if you require the v3 typenames 'Json' and 'Uuid'
     // over 'JSON' and 'UUID'.
-    legacyJsonUuid?: boolean,
+    legacyJsonUuid?: boolean
     // Turns off GraphQL query logging. By default PostGraphile will log every
     // GraphQL query it processes along with some other information. Set this to
     // `true` (recommended in production) to disable that feature.
     /* @middlewareOnly */
-    disableQueryLog?: boolean,
+    disableQueryLog?: boolean
     // A plain object specifying custom config values to set in the PostgreSQL
     // transaction (accessed via `current_setting('my.custom.setting')`) or a
     // function which will return the same (or a Promise to the same) based on
     // the incoming web request (e.g. to extract session data)
     /* @middlewareOnly */
-    pgSettings?: { [key: string]: mixed } | ((req: IncomingMessage) => Promise<{ [key: string]: mixed }>),
+    pgSettings?:
+      | { [key: string]: mixed }
+      | ((req: IncomingMessage) => Promise<{ [key: string]: mixed }>)
     // Some graphile-build plugins may need additional information available on
     // the `context` argument to the resolver - you can use this function to
     // provide such information based on the incoming request - you can even use
     // this to change the response [experimental], e.g. setting cookies
     /* @middlewareOnly */
-    additionalGraphQLContextFromRequest?: (req: IncomingMessage, res: ServerResponse) => Promise<{}>,
+    additionalGraphQLContextFromRequest?: (req: IncomingMessage, res: ServerResponse) => Promise<{}>
     // [experimental] Plugin hook function, enables functionality within
     // PostGraphile to be expanded with plugins. Generate with
     // `makePluginHook(plugins)` passing a list of plugin objects.
     /* @middlewareOnly */
-    pluginHook?: PluginHookFn,
+    pluginHook?: PluginHookFn
     // Should we use relay pagination, or simple collections?
     // "omit" (default) - relay connections only,
     // "only" (not recommended) - simple collections only (no Relay connections),
     // "both" - both
-    simpleCollections?: 'omit' | 'both' | 'only',
+    simpleCollections?: 'omit' | 'both' | 'only'
     // Max query cache size in MBs of queries. Default, 50MB
     /* @middlewareOnly */
     queryCacheMaxSize?: number
     // allow arbitrary extensions for consumption by plugins
-    [propName: string]: any,
+    [propName: string]: any
   }
 
   export interface GraphQLFormattedErrorExtended {
     // This is ugly, really I just want `string | void` but apparently TypeScript doesn't support that.
-    [s: string]: Array<GraphQLErrorLocation> | Array<string | number> | string | void,
-    message: string,
-    locations: Array<GraphQLErrorLocation> | void,
-    path: Array<string | number> | void,
+    [s: string]: Array<GraphQLErrorLocation> | Array<string | number> | string | void
+    message: string
+    locations: Array<GraphQLErrorLocation> | void
+    path: Array<string | number> | void
   }
 
   export interface GraphQLErrorLocation {
-    line: number,
-    column: number,
+    line: number
+    column: number
   }
 
   export type GraphQLErrorExtended = GraphQLError & {
-    hint: string,
-    detail: string,
-    code: string,
+    hint: string
+    detail: string
+    code: string
   }
 
   // Used by `createPostGraphileHttpRequestHandler`
   export interface ICreateRequestHandler extends PostGraphile.PostGraphileOptions {
     // The actual GraphQL schema we will use.
-    getGqlSchema: () => Promise<GraphQLSchema>,
+    getGqlSchema: () => Promise<GraphQLSchema>
     // A Postgres client pool we use to connect Postgres clients.
-    pgPool: Pool,
-    _emitter: EventEmitter,
+    pgPool: Pool
+    _emitter: EventEmitter
   }
 
   /**
@@ -243,11 +244,15 @@ export namespace PostGraphile {
    */
   export interface HttpRequestHandler {
     (req: IncomingMessage, res: ServerResponse, next?: (error?: mixed) => void): Promise<void>
-    (ctx: { req: IncomingMessage, res: ServerResponse }, next: () => void): Promise<void>
+    (ctx: { req: IncomingMessage; res: ServerResponse }, next: () => void): Promise<void>
     formatError: (e: GraphQLError) => GraphQLFormattedErrorExtended
     getGraphQLSchema: () => Promise<GraphQLSchema>
     pgPool: Pool
-    withPostGraphileContextFromReqRes: (req: IncomingMessage, res: ServerResponse, moreOptions: any, fn: (ctx: mixed) => any) => Promise<any>
+    withPostGraphileContextFromReqRes: (
+      req: IncomingMessage,
+      res: ServerResponse,
+      moreOptions: any,
+      fn: (ctx: mixed) => any,
+    ) => Promise<any>
   }
-
 }

--- a/src/postgraphile/__tests__/postgraphile-test.js
+++ b/src/postgraphile/__tests__/postgraphile-test.js
@@ -22,9 +22,7 @@ test('will use a connected client from the pool, the schemas, and options to cre
   const schemas = [Symbol('schemas')]
   const options = Symbol('options')
   await postgraphile(pgPool, schemas, options)
-  expect(createPostGraphileSchema.mock.calls).toEqual([
-    [pgPool, schemas, options],
-  ])
+  expect(createPostGraphileSchema.mock.calls).toEqual([[pgPool, schemas, options]])
 })
 
 test('will use a connected client from the pool, the default schema, and options to create a GraphQL schema', async () => {
@@ -34,9 +32,7 @@ test('will use a connected client from the pool, the default schema, and options
   const options = Symbol('options')
   const pgClient = { release: jest.fn() }
   await postgraphile(pgPool, options)
-  expect(createPostGraphileSchema.mock.calls).toEqual([
-    [pgPool, ['public'], options],
-  ])
+  expect(createPostGraphileSchema.mock.calls).toEqual([[pgPool, ['public'], options]])
 })
 
 test('will use a created GraphQL schema to create the HTTP request handler and pass down options', async () => {
@@ -49,24 +45,19 @@ test('will use a created GraphQL schema to create the HTTP request handler and p
   await postgraphile(pgPool, [], options)
   expect(createPostGraphileHttpRequestHandler.mock.calls.length).toBe(1)
   expect(createPostGraphileHttpRequestHandler.mock.calls[0].length).toBe(1)
-  expect(
-    Object.keys(createPostGraphileHttpRequestHandler.mock.calls[0][0]),
-  ).toEqual(['a', 'b', 'c', 'getGqlSchema', 'pgPool', '_emitter'])
-  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].pgPool).toBe(
-    pgPool,
-  )
-  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].a).toBe(
-    options.a,
-  )
-  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].b).toBe(
-    options.b,
-  )
-  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].c).toBe(
-    options.c,
-  )
-  expect(
-    await createPostGraphileHttpRequestHandler.mock.calls[0][0].getGqlSchema(),
-  ).toBe(gqlSchema)
+  expect(Object.keys(createPostGraphileHttpRequestHandler.mock.calls[0][0])).toEqual([
+    'a',
+    'b',
+    'c',
+    'getGqlSchema',
+    'pgPool',
+    '_emitter',
+  ])
+  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].pgPool).toBe(pgPool)
+  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].a).toBe(options.a)
+  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].b).toBe(options.b)
+  expect(createPostGraphileHttpRequestHandler.mock.calls[0][0].c).toBe(options.c)
+  expect(await createPostGraphileHttpRequestHandler.mock.calls[0][0].getGqlSchema()).toBe(gqlSchema)
 })
 
 test('will watch Postgres schemas when `watchPg` is true', async () => {
@@ -76,9 +67,7 @@ test('will watch Postgres schemas when `watchPg` is true', async () => {
   const pgSchemas = [Symbol('a'), Symbol('b'), Symbol('c')]
   await postgraphile(pgPool, pgSchemas, { watchPg: false })
   await postgraphile(pgPool, pgSchemas, { watchPg: true })
-  expect(createPostGraphileSchema.mock.calls).toEqual([
-    [pgPool, pgSchemas, { watchPg: false }],
-  ])
+  expect(createPostGraphileSchema.mock.calls).toEqual([[pgPool, pgSchemas, { watchPg: false }]])
 
   expect(watchPostGraphileSchema.mock.calls.length).toBe(1)
   expect(watchPostGraphileSchema.mock.calls[0].length).toBe(4)

--- a/src/postgraphile/__tests__/postgraphileIntegrationQueries-test.js
+++ b/src/postgraphile/__tests__/postgraphileIntegrationQueries-test.js
@@ -58,14 +58,10 @@ beforeAll(() => {
         queryFileNames.map(async fileName => {
           // Read the query from the file system.
           const query = await new Promise((resolve, reject) => {
-            readFile(
-              resolvePath(queriesDir, fileName),
-              'utf8',
-              (error, data) => {
-                if (error) reject(error)
-                else resolve(data)
-              },
-            )
+            readFile(resolvePath(queriesDir, fileName), 'utf8', (error, data) => {
+              if (error) reject(error)
+              else resolve(data)
+            })
           })
           // Get the appropriate GraphQL schema for this fixture. We want to test
           // some specific fixtures against a schema configured slightly

--- a/src/postgraphile/__tests__/postgraphileIntegrationSchema-test.js
+++ b/src/postgraphile/__tests__/postgraphileIntegrationSchema-test.js
@@ -19,8 +19,7 @@ const testFixtures = [
   },
   {
     name: 'prints a schema with Relay 1 style ids',
-    createSchema: client =>
-      createPostGraphileSchema(client, 'c', { classicIds: true }),
+    createSchema: client => createPostGraphileSchema(client, 'c', { classicIds: true }),
   },
   {
     name: 'prints a schema with a JWT generating mutation',

--- a/src/postgraphile/__tests__/withPostGraphileContext-test.js
+++ b/src/postgraphile/__tests__/withPostGraphileContext-test.js
@@ -45,12 +45,7 @@ test('will record queries run inside the transaction', async () => {
     client[$$pgClient].query(query1)
     client[$$pgClient].query(query2)
   })
-  expect(pgClient.query.mock.calls).toEqual([
-    ['begin'],
-    [query1],
-    [query2],
-    ['commit'],
-  ])
+  expect(pgClient.query.mock.calls).toEqual([['begin'], [query1], [query2], ['commit']])
 })
 
 test('will return the value from the callback', async () => {
@@ -64,9 +59,7 @@ test('will return the asynchronous value from the callback', async () => {
   const value = Symbol()
   const pgClient = { query: jest.fn(), release: jest.fn() }
   const pgPool = { connect: jest.fn(() => pgClient) }
-  expect(
-    await withPostGraphileContext({ pgPool }, () => Promise.resolve(value)),
-  ).toBe(value)
+  expect(await withPostGraphileContext({ pgPool }, () => Promise.resolve(value))).toBe(value)
 })
 
 test('will throw an error if there was a `jwtToken`, but no `jwtSecret`', async () => {
@@ -85,10 +78,7 @@ test('will throw an error for a malformed `jwtToken`', async () => {
   const pgClient = { query: jest.fn(), release: jest.fn() }
   const pgPool = { connect: jest.fn(() => pgClient) }
   await expectHttpError(
-    withPostGraphileContext(
-      { pgPool, jwtToken: 'asd', jwtSecret: 'secret' },
-      () => {},
-    ),
+    withPostGraphileContext({ pgPool, jwtToken: 'asd', jwtSecret: 'secret' }, () => {}),
     403,
     'jwt malformed',
   )
@@ -240,8 +230,7 @@ test('will add extra settings as available', async () => {
     ['begin'],
     [
       {
-        text:
-          'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true)',
+        text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true)',
         values: [
           'foo.bar',
           'test1',
@@ -283,7 +272,7 @@ test('undefined and null extra settings are ignored while 0 is converted to a st
     [
       {
         text:
-        'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true), set_config($13, $14, true), set_config($15, $16, true)',
+          'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true), set_config($13, $14, true), set_config($15, $16, true)',
         values: [
           'foo.bar',
           'test1',
@@ -430,7 +419,9 @@ test('will set a role provided in the JWT', async () => {
       jwtToken: jwt.sign(
         { aud: 'postgraphile', a: 1, b: 2, c: 3, role: 'test_jwt_role' },
         'secret',
-        { noTimestamp: true },
+        {
+          noTimestamp: true,
+        },
       ),
       jwtSecret: 'secret',
     },
@@ -471,7 +462,9 @@ test('will set a role provided in the JWT superceding the default role', async (
       jwtToken: jwt.sign(
         { aud: 'postgraphile', a: 1, b: 2, c: 3, role: 'test_jwt_role' },
         'secret',
-        { noTimestamp: true },
+        {
+          noTimestamp: true,
+        },
       ),
       jwtSecret: 'secret',
       pgDefaultRole: 'test_default_role',
@@ -622,7 +615,7 @@ describe('jwtVerifyOptions', () => {
         () => {},
       ),
       403,
-      'Provide either \'jwtAudiences\' or \'jwtVerifyOptions.audience\' but not both',
+      "Provide either 'jwtAudiences' or 'jwtVerifyOptions.audience' but not both",
     )
     // Never set up the transaction due to error
     expect(pgClient.query.mock.calls).toEqual([])
@@ -641,7 +634,7 @@ describe('jwtVerifyOptions', () => {
         () => {},
       ),
       403,
-      'Provide either \'jwtAudiences\' or \'jwtVerifyOptions.audience\' but not both',
+      "Provide either 'jwtAudiences' or 'jwtVerifyOptions.audience' but not both",
     )
     // Never set up the transaction due to error
     expect(pgClient.query.mock.calls).toEqual([])
@@ -666,12 +659,7 @@ describe('jwtVerifyOptions', () => {
       [
         {
           text: 'select set_config($1, $2, true), set_config($3, $4, true)',
-          values: [
-            'jwt.claims.aud',
-            'my-audience',
-            'jwt.claims.sub',
-            'my-subject',
-          ],
+          values: ['jwt.claims.aud', 'my-audience', 'jwt.claims.sub', 'my-subject'],
         },
       ],
       ['commit'],
@@ -696,12 +684,7 @@ describe('jwtVerifyOptions', () => {
       [
         {
           text: 'select set_config($1, $2, true), set_config($3, $4, true)',
-          values: [
-            'jwt.claims.aud',
-            'my-audience',
-            'jwt.claims.sub',
-            'my-subject',
-          ],
+          values: ['jwt.claims.aud', 'my-audience', 'jwt.claims.sub', 'my-subject'],
         },
       ],
       ['commit'],
@@ -726,12 +709,7 @@ describe('jwtVerifyOptions', () => {
       [
         {
           text: 'select set_config($1, $2, true), set_config($3, $4, true)',
-          values: [
-            'jwt.claims.aud',
-            'my-audience',
-            'jwt.claims.sub',
-            'my-subject',
-          ],
+          values: ['jwt.claims.aud', 'my-audience', 'jwt.claims.sub', 'my-subject'],
         },
       ],
       ['commit'],
@@ -756,12 +734,7 @@ describe('jwtVerifyOptions', () => {
       [
         {
           text: 'select set_config($1, $2, true), set_config($3, $4, true)',
-          values: [
-            'jwt.claims.aud',
-            'my-audience',
-            'jwt.claims.sub',
-            'my-subject',
-          ],
+          values: ['jwt.claims.aud', 'my-audience', 'jwt.claims.sub', 'my-subject'],
         },
       ],
       ['commit'],
@@ -833,10 +806,7 @@ describe('jwtVerifyOptions', () => {
         {
           pgPool,
           jwtSecret: 'secret',
-          jwtToken: jwt.sign(
-            { aud: 'postgraphile', iss: 'alpha:nasa' },
-            'secret',
-          ),
+          jwtToken: jwt.sign({ aud: 'postgraphile', iss: 'alpha:nasa' }, 'secret'),
           jwtVerifyOptions: { issuer: ['alpha:aliens', 'alpha:ufo'] },
         },
         () => {},
@@ -848,7 +818,7 @@ describe('jwtVerifyOptions', () => {
     expect(pgClient.query.mock.calls).toEqual([])
   })
 
-  test('will default to an audience of [\'postgraphile\'] if no audience params are provided', async () => {
+  test("will default to an audience of ['postgraphile'] if no audience params are provided", async () => {
     await expectHttpError(
       withPostGraphileContext(
         {

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -32,9 +32,11 @@ const DEMO_PG_URL = null
 
 const manifest = JSON.parse(readFileSync(resolvePath(__dirname, '../../package.json')).toString())
 
-function extractPlugins(rawArgv: Array<string>): {
-  argv: Array<string>,
-  plugins: Array<PostGraphilePlugin>,
+function extractPlugins(
+  rawArgv: Array<string>,
+): {
+  argv: Array<string>
+  plugins: Array<PostGraphilePlugin>
 } {
   let argv
   let pluginStrings = []
@@ -42,7 +44,7 @@ function extractPlugins(rawArgv: Array<string>): {
     pluginStrings = rawArgv[3].split(',')
     argv = [...rawArgv.slice(0, 2), ...rawArgv.slice(4)]
   } else {
-    pluginStrings = config && config['options'] && config['options']['plugins'] || []
+    pluginStrings = (config && config['options'] && config['options']['plugins']) || []
     argv = rawArgv
   }
   const plugins = pluginStrings.map((pluginString: string) => {
@@ -65,91 +67,219 @@ program
   .version(manifest.version)
   .usage('[options...]')
   .description(manifest.description)
-  // .option('-d, --demo', 'run PostGraphile using the demo database connection')
+// .option('-d, --demo', 'run PostGraphile using the demo database connection')
 
-export type AddFlagFn = (optionString: string, description: string, parse?: (option: string) => mixed) => AddFlagFn
+export type AddFlagFn = (
+  optionString: string,
+  description: string,
+  parse?: (option: string) => mixed,
+) => AddFlagFn
 
-function addFlag(optionString: string, description: string, parse?: (option: string) => mixed): AddFlagFn {
+function addFlag(
+  optionString: string,
+  description: string,
+  parse?: (option: string) => mixed,
+): AddFlagFn {
   program.option(optionString, description, parse)
   return addFlag
 }
 
 // Standard options
 program
-  .option('--plugins <string>', 'a list of postgraphile plugins (not Graphile-Build plugins) to load, MUST be the first option')
-  .option('-c, --connection <string>', 'the Postgres connection. if not provided it will be inferred from your environment, example: postgres://user:password@domain:port/db')
-  .option('-s, --schema <string>', 'a Postgres schema to be introspected. Use commas to define multiple schemas', (option: string) => option.split(','))
-  .option('-w, --watch', 'watches the Postgres schema for changes and reruns introspection if a change was detected')
+  .option(
+    '--plugins <string>',
+    'a list of postgraphile plugins (not Graphile-Build plugins) to load, MUST be the first option',
+  )
+  .option(
+    '-c, --connection <string>',
+    'the Postgres connection. if not provided it will be inferred from your environment, example: postgres://user:password@domain:port/db',
+  )
+  .option(
+    '-s, --schema <string>',
+    'a Postgres schema to be introspected. Use commas to define multiple schemas',
+    (option: string) => option.split(','),
+  )
+  .option(
+    '-w, --watch',
+    'watches the Postgres schema for changes and reruns introspection if a change was detected',
+  )
   .option('-n, --host <string>', 'the hostname to be used. Defaults to `localhost`')
   .option('-p, --port <number>', 'the port to be used. Defaults to 5000', parseFloat)
-  .option('-m, --max-pool-size <number>', 'the maximum number of clients to keep in the Postgres pool. defaults to 10', parseFloat)
-  .option('-r, --default-role <string>', 'the default Postgres role to use when a request is made. supercedes the role used to connect to the database')
+  .option(
+    '-m, --max-pool-size <number>',
+    'the maximum number of clients to keep in the Postgres pool. defaults to 10',
+    parseFloat,
+  )
+  .option(
+    '-r, --default-role <string>',
+    'the default Postgres role to use when a request is made. supercedes the role used to connect to the database',
+  )
 
 pluginHook('cli:flags:add:standard', addFlag)
 
 // Schema configuration
 program
-  .option('-j, --dynamic-json', '[RECOMMENDED] enable dynamic JSON in GraphQL inputs and outputs. PostGraphile uses stringified JSON by default')
-  .option('-N, --no-setof-functions-contain-nulls', '[RECOMMENDED] if none of your `RETURNS SETOF compound_type` functions mix NULLs with the results then you may enable this to reduce the nullables in the GraphQL schema')
+  .option(
+    '-j, --dynamic-json',
+    '[RECOMMENDED] enable dynamic JSON in GraphQL inputs and outputs. PostGraphile uses stringified JSON by default',
+  )
+  .option(
+    '-N, --no-setof-functions-contain-nulls',
+    '[RECOMMENDED] if none of your `RETURNS SETOF compound_type` functions mix NULLs with the results then you may enable this to reduce the nullables in the GraphQL schema',
+  )
   .option('-a, --classic-ids', 'use classic global id field name. required to support Relay 1')
-  .option('-M, --disable-default-mutations', 'disable default mutations, mutation will only be possible through Postgres functions')
-  .option('--simple-collections [omit|both|only]', '"omit" (default) - relay connections only, "only" - simple collections only (no Relay connections), "both" - both')
-  .option('--no-ignore-rbac', '[RECOMMENDED] set this to excludes fields, queries and mutations that the user isn\'t permitted to access; this will be the default in v5')
-  .option('--include-extension-resources', 'by default, tables and functions that come from extensions are excluded; use this flag to include them (not recommended)')
+  .option(
+    '-M, --disable-default-mutations',
+    'disable default mutations, mutation will only be possible through Postgres functions',
+  )
+  .option(
+    '--simple-collections [omit|both|only]',
+    '"omit" (default) - relay connections only, "only" - simple collections only (no Relay connections), "both" - both',
+  )
+  .option(
+    '--no-ignore-rbac',
+    "[RECOMMENDED] set this to excludes fields, queries and mutations that the user isn't permitted to access; this will be the default in v5",
+  )
+  .option(
+    '--include-extension-resources',
+    'by default, tables and functions that come from extensions are excluded; use this flag to include them (not recommended)',
+  )
 
 pluginHook('cli:flags:add:schema', addFlag)
 
 // Error enhancements
 program
-  .option('--show-error-stack', 'show JavaScript error stacks in the GraphQL result errors (recommended in development)')
-  .option('--extended-errors <string>', 'a comma separated list of extended Postgres error fields to display in the GraphQL result. Recommended in development: \'hint,detail,errcode\'. Default: none', (option: string) => option.split(',').filter(_ => _))
+  .option(
+    '--show-error-stack',
+    'show JavaScript error stacks in the GraphQL result errors (recommended in development)',
+  )
+  .option(
+    '--extended-errors <string>',
+    "a comma separated list of extended Postgres error fields to display in the GraphQL result. Recommended in development: 'hint,detail,errcode'. Default: none",
+    (option: string) => option.split(',').filter(_ => _),
+  )
 
 pluginHook('cli:flags:add:errorHandling', addFlag)
 
 // Plugin-related options
 program
-  .option('--append-plugins <string>', 'a comma-separated list of plugins to append to the list of GraphQL schema plugins')
-  .option('--prepend-plugins <string>', 'a comma-separated list of plugins to prepend to the list of GraphQL schema plugins')
+  .option(
+    '--append-plugins <string>',
+    'a comma-separated list of plugins to append to the list of GraphQL schema plugins',
+  )
+  .option(
+    '--prepend-plugins <string>',
+    'a comma-separated list of plugins to prepend to the list of GraphQL schema plugins',
+  )
 
 pluginHook('cli:flags:add:plugins', addFlag)
 
 // Things that relate to -X
 program
-  .option('--read-cache <path>', '[experimental] reads cached values from local cache file to improve startup time (you may want to do this in production)')
-  .option('--write-cache <path>', '[experimental] writes computed values to local cache file so startup can be faster (do this during the build phase)')
-  .option('--export-schema-json <path>', 'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
-  .option('--export-schema-graphql <path>', 'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.')
-  .option('-X, --no-server', '[experimental] for when you just want to use --write-cache or --export-schema-* and not actually run a server (e.g. CI)')
+  .option(
+    '--read-cache <path>',
+    '[experimental] reads cached values from local cache file to improve startup time (you may want to do this in production)',
+  )
+  .option(
+    '--write-cache <path>',
+    '[experimental] writes computed values to local cache file so startup can be faster (do this during the build phase)',
+  )
+  .option(
+    '--export-schema-json <path>',
+    'enables exporting the detected schema, in JSON format, to the given location. The directories must exist already, if the file exists it will be overwritten.',
+  )
+  .option(
+    '--export-schema-graphql <path>',
+    'enables exporting the detected schema, in GraphQL schema format, to the given location. The directories must exist already, if the file exists it will be overwritten.',
+  )
+  .option(
+    '-X, --no-server',
+    '[experimental] for when you just want to use --write-cache or --export-schema-* and not actually run a server (e.g. CI)',
+  )
 
 pluginHook('cli:flags:add:noServer', addFlag)
 
 // Webserver configuration
 program
-  .option('-q, --graphql <path>', 'the route to mount the GraphQL server on. defaults to `/graphql`')
-  .option('-i, --graphiql <path>', 'the route to mount the GraphiQL interface on. defaults to `/graphiql`')
-  .option('-b, --disable-graphiql', 'disables the GraphiQL interface. overrides the GraphiQL route option')
-  .option('-o, --cors', 'enable generous CORS settings; disabled by default, if possible use a proxy instead')
-  .option('-l, --body-size-limit <string>', 'set the maximum size of JSON bodies that can be parsed (default 100kB) The size can be given as a human-readable string, such as \'200kB\' or \'5MB\' (case insensitive).')
+  .option(
+    '-q, --graphql <path>',
+    'the route to mount the GraphQL server on. defaults to `/graphql`',
+  )
+  .option(
+    '-i, --graphiql <path>',
+    'the route to mount the GraphiQL interface on. defaults to `/graphiql`',
+  )
+  .option(
+    '-b, --disable-graphiql',
+    'disables the GraphiQL interface. overrides the GraphiQL route option',
+  )
+  .option(
+    '-o, --cors',
+    'enable generous CORS settings; disabled by default, if possible use a proxy instead',
+  )
+  .option(
+    '-l, --body-size-limit <string>',
+    "set the maximum size of JSON bodies that can be parsed (default 100kB) The size can be given as a human-readable string, such as '200kB' or '5MB' (case insensitive).",
+  )
   .option('--timeout <number>', 'set the timeout value in milliseconds for sockets', parseFloat)
-  .option('--cluster-workers <count>', '[experimental] spawn <count> workers to increase throughput', parseFloat)
-  .option('--enable-query-batching', '[experimental] enable the server to process multiple GraphQL queries in one request')
+  .option(
+    '--cluster-workers <count>',
+    '[experimental] spawn <count> workers to increase throughput',
+    parseFloat,
+  )
+  .option(
+    '--enable-query-batching',
+    '[experimental] enable the server to process multiple GraphQL queries in one request',
+  )
   .option('--disable-query-log', 'disable logging queries to console (recommended in production)')
 
 pluginHook('cli:flags:add:webserver', addFlag)
 
 // JWT-related options
 program
-  .option('-e, --jwt-secret <string>', 'the secret to be used when creating and verifying JWTs. if none is provided auth will be disabled')
-  .option('--jwt-verify-algorithms <string>', 'a comma separated list of the names of the allowed jwt token algorithms', (option: string) => option.split(','))
-  .option('-A, --jwt-verify-audience <string>', 'a comma separated list of JWT audiences that will be accepted; defaults to \'postgraphile\'. To disable audience verification, set to \'\'.', (option: string) => option.split(','))
-  .option('--jwt-verify-clock-tolerance <number>', 'number of seconds to tolerate when checking the nbf and exp claims, to deal with small clock differences among different servers', parseFloat)
+  .option(
+    '-e, --jwt-secret <string>',
+    'the secret to be used when creating and verifying JWTs. if none is provided auth will be disabled',
+  )
+  .option(
+    '--jwt-verify-algorithms <string>',
+    'a comma separated list of the names of the allowed jwt token algorithms',
+    (option: string) => option.split(','),
+  )
+  .option(
+    '-A, --jwt-verify-audience <string>',
+    "a comma separated list of JWT audiences that will be accepted; defaults to 'postgraphile'. To disable audience verification, set to ''.",
+    (option: string) => option.split(','),
+  )
+  .option(
+    '--jwt-verify-clock-tolerance <number>',
+    'number of seconds to tolerate when checking the nbf and exp claims, to deal with small clock differences among different servers',
+    parseFloat,
+  )
   .option('--jwt-verify-id <string>', 'the name of the allowed jwt token id')
-  .option('--jwt-verify-ignore-expiration', 'if `true` do not validate the expiration of the token defaults to `false`')
-  .option('--jwt-verify-ignore-not-before', 'if `true` do not validate the notBefore of the token defaults to `false`')
-  .option('--jwt-verify-issuer <string>', 'a comma separated list of the names of the allowed jwt token issuer', (option: string) => option.split(','))
+  .option(
+    '--jwt-verify-ignore-expiration',
+    'if `true` do not validate the expiration of the token defaults to `false`',
+  )
+  .option(
+    '--jwt-verify-ignore-not-before',
+    'if `true` do not validate the notBefore of the token defaults to `false`',
+  )
+  .option(
+    '--jwt-verify-issuer <string>',
+    'a comma separated list of the names of the allowed jwt token issuer',
+    (option: string) => option.split(','),
+  )
   .option('--jwt-verify-subject <string>', 'the name of the allowed jwt token subject')
-  .option('--jwt-role <string>', 'a comma seperated list of strings that create a path in the jwt from which to extract the postgres role. if none is provided it will use the key `role` on the root of the jwt.', (option: string) => option.split(','))
-  .option('-t, --jwt-token-identifier <identifier>', 'the Postgres identifier for a composite type that will be used to create JWT tokens')
+  .option(
+    '--jwt-role <string>',
+    'a comma seperated list of strings that create a path in the jwt from which to extract the postgres role. if none is provided it will use the key `role` on the root of the jwt.',
+    (option: string) => option.split(','),
+  )
+  .option(
+    '-t, --jwt-token-identifier <identifier>',
+    'the Postgres identifier for a composite type that will be used to create JWT tokens',
+  )
 
 pluginHook('cli:flags:add:jwt', addFlag)
 
@@ -160,14 +290,24 @@ pluginHook('cli:flags:add', addFlag)
 program
   .option('--token <identifier>', 'DEPRECATED: use --jwt-token-identifier instead')
   .option('--secret <string>', 'DEPRECATED: Use --jwt-secret instead')
-  .option('--jwt-audiences <string>', 'DEPRECATED Use --jwt-verify-audience instead', (option: string) => option.split(','))
+  .option(
+    '--jwt-audiences <string>',
+    'DEPRECATED Use --jwt-verify-audience instead',
+    (option: string) => option.split(','),
+  )
 
 pluginHook('cli:flags:add:deprecated', addFlag)
 
 // Awkward application workarounds / legacy support
 program
-  .option('--legacy-relations <omit|deprecated|only>', 'some one-to-one relations were previously detected as one-to-many - should we export \'only\' the old relation shapes, both new and old but mark the old ones as \'deprecated\', or \'omit\' the old relation shapes entirely')
-  .option('--legacy-json-uuid', `ONLY use this option if you require the v3 typenames 'Json' and 'Uuid' over 'JSON' and 'UUID'`)
+  .option(
+    '--legacy-relations <omit|deprecated|only>',
+    "some one-to-one relations were previously detected as one-to-many - should we export 'only' the old relation shapes, both new and old but mark the old ones as 'deprecated', or 'omit' the old relation shapes entirely",
+  )
+  .option(
+    '--legacy-json-uuid',
+    `ONLY use this option if you require the v3 typenames 'Json' and 'Uuid' over 'JSON' and 'UUID'`,
+  )
 
 pluginHook('cli:flags:add:workarounds', addFlag)
 
@@ -244,12 +384,14 @@ const {
   legacyJsonUuid,
   disableQueryLog,
   simpleCollections,
-// tslint:disable-next-line no-any
-} = {...config['options'], ...program} as any
+  // tslint:disable-next-line no-any
+} = { ...config['options'], ...program } as any
 
 let legacyRelations: 'omit' | 'deprecated' | 'only'
 if (['omit', 'only', 'deprecated'].indexOf(rawLegacyRelations) < 0) {
-  throw new Error(`Invalid argument to '--legacy-relations' - expected on of 'omit', 'deprecated', 'only'; but received '${rawLegacyRelations}'`)
+  throw new Error(
+    `Invalid argument to '--legacy-relations' - expected on of 'omit', 'deprecated', 'only'; but received '${rawLegacyRelations}'`,
+  )
 } else {
   legacyRelations = rawLegacyRelations
 }
@@ -267,14 +409,15 @@ const pgConfig: PoolConfig = {
   // config. If we don’t have a connection string use some environment
   // variables or final defaults. Other environment variables should be
   // detected and used by `pg`.
-  ...(pgConnectionString || process.env.DATABASE_URL || isDemo ?
-    parsePgConnectionString(pgConnectionString || process.env.DATABASE_URL || DEMO_PG_URL) : {
-      host: process.env.PGHOST || 'localhost',
-      port: (process.env.PGPORT ? parseInt(process.env.PGPORT, 10) : null) || 5432,
-      database: process.env.PGDATABASE,
-      user: process.env.PGUSER,
-      password: process.env.PGPASSWORD,
-    }),
+  ...(pgConnectionString || process.env.DATABASE_URL || isDemo
+    ? parsePgConnectionString(pgConnectionString || process.env.DATABASE_URL || DEMO_PG_URL)
+    : {
+        host: process.env.PGHOST || 'localhost',
+        port: (process.env.PGPORT ? parseInt(process.env.PGPORT, 10) : null) || 5432,
+        database: process.env.PGDATABASE,
+        user: process.env.PGUSER,
+        password: process.env.PGPASSWORD,
+      }),
   // Add the max pool size to our config.
   max: maxPoolSize,
 }
@@ -314,7 +457,9 @@ const loadPlugins = (rawNames: mixed) => {
     } else if (plugin === root && typeof plugin.default === 'function') {
       return plugin.default // ES6 workaround
     } else {
-      throw new Error(`No plugin found matching spec '${name}' - expected function, found '${typeof plugin}'`)
+      throw new Error(
+        `No plugin found matching spec '${name}' - expected function, found '${typeof plugin}'`,
+      )
     }
   })
 }
@@ -324,15 +469,12 @@ if (jwtAudiences != null && jwtVerifyAudience != null) {
 }
 
 function trimNulls(obj: object): object {
-  return Object.keys(obj).reduce(
-    (memo, key) => {
-      if (obj[key] != null) {
-        memo[key] = obj[key]
-      }
-      return memo
-    },
-    {},
-  )
+  return Object.keys(obj).reduce((memo, key) => {
+    if (obj[key] != null) {
+      memo[key] = obj[key]
+    }
+    return memo
+  }, {})
 }
 
 const jwtVerifyOptions: jwt.VerifyOptions = trimNulls({
@@ -347,57 +489,60 @@ const jwtVerifyOptions: jwt.VerifyOptions = trimNulls({
 })
 
 // The options to pass through to the schema builder, or the middleware
-const postgraphileOptions = pluginHook('cli:library:options', {...config['options'],
-  classicIds,
-  dynamicJson,
-  disableDefaultMutations,
-  ignoreRBAC: ignoreRbac,
-  includeExtensionResources,
-  graphqlRoute,
-  graphiqlRoute,
-  graphiql: !disableGraphiql,
-  jwtPgTypeIdentifier: jwtPgTypeIdentifier || deprecatedJwtPgTypeIdentifier,
-  jwtSecret: jwtSecret || deprecatedJwtSecret,
-  jwtAudiences,
-  jwtRole,
-  jwtVerifyOptions,
-  pgDefaultRole,
-  watchPg,
-  showErrorStack,
-  extendedErrors,
-  disableQueryLog,
-  enableCors,
-  exportJsonSchemaPath,
-  exportGqlSchemaPath,
-  bodySizeLimit,
-  appendPlugins: loadPlugins(appendPluginNames),
-  prependPlugins: loadPlugins(prependPluginNames),
-  readCache,
-  writeCache,
-  legacyRelations,
-  setofFunctionsContainNulls,
-  legacyJsonUuid,
-  enableQueryBatching,
-  pluginHook,
-  simpleCollections}, { config, cliOptions: program })
+const postgraphileOptions = pluginHook(
+  'cli:library:options',
+  {
+    ...config['options'],
+    classicIds,
+    dynamicJson,
+    disableDefaultMutations,
+    ignoreRBAC: ignoreRbac,
+    includeExtensionResources,
+    graphqlRoute,
+    graphiqlRoute,
+    graphiql: !disableGraphiql,
+    jwtPgTypeIdentifier: jwtPgTypeIdentifier || deprecatedJwtPgTypeIdentifier,
+    jwtSecret: jwtSecret || deprecatedJwtSecret,
+    jwtAudiences,
+    jwtRole,
+    jwtVerifyOptions,
+    pgDefaultRole,
+    watchPg,
+    showErrorStack,
+    extendedErrors,
+    disableQueryLog,
+    enableCors,
+    exportJsonSchemaPath,
+    exportGqlSchemaPath,
+    bodySizeLimit,
+    appendPlugins: loadPlugins(appendPluginNames),
+    prependPlugins: loadPlugins(prependPluginNames),
+    readCache,
+    writeCache,
+    legacyRelations,
+    setofFunctionsContainNulls,
+    legacyJsonUuid,
+    enableQueryBatching,
+    pluginHook,
+    simpleCollections,
+  },
+  { config, cliOptions: program },
+)
 
 if (noServer) {
   // No need for a server, let's just spin up the schema builder
-  (async () => {
+  ;(async () => {
     const pgPool = new Pool(pgConfig)
     const { getGraphQLSchema } = getPostgraphileSchemaBuilder(pgPool, schemas, postgraphileOptions)
     await getGraphQLSchema()
     if (!watchPg) {
       await pgPool.end()
     }
-  })().then(
-    null,
-    e => {
-      console.error('Error occurred!')
-      console.error(e)
-      process.exit(1)
-    },
-  )
+  })().then(null, e => {
+    console.error('Error occurred!')
+    console.error(e)
+    process.exit(1)
+  })
 } else {
   function killAllWorkers(signal = 'SIGTERM'): void {
     for (const id in cluster.workers) {
@@ -416,10 +561,14 @@ if (noServer) {
         const fallbackTimeout = setTimeout(() => {
           const remainingCount = Object.keys(cluster.workers).length
           if (remainingCount > 0) {
-            console.log(`  [cluster] ${remainingCount} workers did not die fast enough, sending SIGKILL`)
+            console.log(
+              `  [cluster] ${remainingCount} workers did not die fast enough, sending SIGKILL`,
+            )
             killAllWorkers('SIGKILL')
             const ultraFallbackTimeout = setTimeout(() => {
-              console.log(`  [cluster] really should have exited automatically, but haven't - exiting`)
+              console.log(
+                `  [cluster] really should have exited automatically, but haven't - exiting`,
+              )
               process.exit(3)
             }, 5000)
             ultraFallbackTimeout.unref()
@@ -435,7 +584,9 @@ if (noServer) {
     }
 
     cluster.on('exit', (worker, code, signal) => {
-      console.log(`  [cluster] worker pid=${worker.process.pid} exited (code=${code}, signal=${signal})`)
+      console.log(
+        `  [cluster] worker pid=${worker.process.pid} exited (code=${code}, signal=${signal})`,
+      )
       shutdown()
     })
 
@@ -448,33 +599,68 @@ if (noServer) {
   } else {
     // Create’s our PostGraphile server
     const rawMiddleware = postgraphile(pgConfig, schemas, postgraphileOptions)
-    const middleware = pluginHook('cli:server:middleware', rawMiddleware, { options: postgraphileOptions })
+    const middleware = pluginHook('cli:server:middleware', rawMiddleware, {
+      options: postgraphileOptions,
+    })
     const server = createServer(middleware)
     if (serverTimeout) {
       server.timeout = serverTimeout
     }
 
-    pluginHook('cli:server:created', server, { options: postgraphileOptions, middleware })
+    pluginHook('cli:server:created', server, {
+      options: postgraphileOptions,
+      middleware,
+    })
 
     // Start our server by listening to a specific port and host name. Also log
     // some instructions and other interesting information.
     server.listen(port, hostname, () => {
-      const self = cluster.isMaster ? 'server' : `worker ${process.env.POSTGRAPHILE_WORKER_NUMBER} (pid=${process.pid})`
+      const self = cluster.isMaster
+        ? 'server'
+        : `worker ${process.env.POSTGRAPHILE_WORKER_NUMBER} (pid=${process.pid})`
       if (cluster.isMaster || process.env.POSTGRAPHILE_WORKER_NUMBER === '1') {
         console.log('')
-        console.log(`PostGraphile ${self} listening on port ${chalk.underline(server.address().port.toString())} 🚀`)
+        console.log(
+          `PostGraphile ${self} listening on port ${chalk.underline(
+            server.address().port.toString(),
+          )} 🚀`,
+        )
         console.log('')
-        console.log(`  ‣ Connected to Postgres instance ${chalk.underline.blue(isDemo ? 'postgraphile_demo' : `postgres://${pgConfig.host}:${pgConfig.port || 5432}${pgConfig.database != null ? `/${pgConfig.database}` : ''}`)}`)
-        console.log(`  ‣ Introspected Postgres schema(s) ${schemas.map(schema => chalk.magenta(schema)).join(', ')}`)
-        console.log(`  ‣ GraphQL endpoint served at ${chalk.underline(`http://${hostname}:${port}${graphqlRoute}`)}`)
+        console.log(
+          `  ‣ Connected to Postgres instance ${chalk.underline.blue(
+            isDemo
+              ? 'postgraphile_demo'
+              : `postgres://${pgConfig.host}:${pgConfig.port || 5432}${
+                  pgConfig.database != null ? `/${pgConfig.database}` : ''
+                }`,
+          )}`,
+        )
+        console.log(
+          `  ‣ Introspected Postgres schema(s) ${schemas
+            .map(schema => chalk.magenta(schema))
+            .join(', ')}`,
+        )
+        console.log(
+          `  ‣ GraphQL endpoint served at ${chalk.underline(
+            `http://${hostname}:${port}${graphqlRoute}`,
+          )}`,
+        )
 
         if (!disableGraphiql)
-          console.log(`  ‣ GraphiQL endpoint served at ${chalk.underline(`http://${hostname}:${port}${graphiqlRoute}`)}`)
+          console.log(
+            `  ‣ GraphiQL endpoint served at ${chalk.underline(
+              `http://${hostname}:${port}${graphiqlRoute}`,
+            )}`,
+          )
 
         console.log('')
         console.log(chalk.gray('* * *'))
       } else {
-        console.log(`PostGraphile ${self} listening on port ${chalk.underline(server.address().port.toString())} 🚀`)
+        console.log(
+          `PostGraphile ${self} listening on port ${chalk.underline(
+            server.address().port.toString(),
+          )} 🚀`,
+        )
       }
       console.log('')
     })

--- a/src/postgraphile/extendedFormatError.ts
+++ b/src/postgraphile/extendedFormatError.ts
@@ -7,7 +7,7 @@ import mixed = PostGraphile.mixed
 /**
  * Extracts the requested fields from a pg error object, handling 'code' -> 'errcode' mapping.
  */
-function pickPgError(err: mixed, inFields: string | Array<string>): {[s: string]: string | void} {
+function pickPgError(err: mixed, inFields: string | Array<string>): { [s: string]: string | void } {
   const result: mixed = {}
   let fields
   if (Array.isArray(inFields)) {
@@ -37,7 +37,10 @@ function pickPgError(err: mixed, inFields: string | Array<string>): {[s: string]
  * extract additional error codes from the postgres error, such as 'hint',
  * 'detail', 'errcode', 'where', etc. - see `extendedErrors` option.
  */
-export function extendedFormatError(error: GraphQLError, fields: Array<string>): GraphQLFormattedErrorExtended {
+export function extendedFormatError(
+  error: GraphQLError,
+  fields: Array<string>,
+): GraphQLFormattedErrorExtended {
   if (!error) {
     throw new Error('Received null or undefined error.')
   }

--- a/src/postgraphile/graphiql/src/index.js
+++ b/src/postgraphile/graphiql/src/index.js
@@ -4,7 +4,4 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import PostGraphiQL from './components/PostGraphiQL'
 
-ReactDOM.render(
-  <PostGraphiQL/>,
-  document.getElementById('root'),
-)
+ReactDOM.render(<PostGraphiQL />, document.getElementById('root'))

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -40,8 +40,7 @@ const gqlSchema = new GraphQLSchema({
       },
       query: {
         type: GraphQLString,
-        resolve: (source, args, context) =>
-          context[$$pgClient].query('EXECUTE'),
+        resolve: (source, args, context) => context[$$pgClient].query('EXECUTE'),
       },
       testError: {
         type: GraphQLString,
@@ -118,9 +117,7 @@ serverCreators.set('koa', (handler, options = {}) => {
 for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
   const createServer = (handlerOptions, serverOptions) =>
     createServerFromHandler(
-      createPostGraphileHttpRequestHandler(
-        Object.assign({}, defaultOptions, handlerOptions),
-      ),
+      createPostGraphileHttpRequestHandler(Object.assign({}, defaultOptions, handlerOptions)),
       serverOptions,
     )
 
@@ -310,11 +307,8 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         ['begin'],
         [
           {
-            'text': 'select set_config($1, $2, true)',
-            'values': [
-              'role',
-              'bob',
-            ],
+            text: 'select set_config($1, $2, true)',
+            values: ['role', 'bob'],
           },
         ],
         ['EXECUTE'],
@@ -373,7 +367,10 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
             "array": {"n": 7, "a":"fred", "c":21}
           }
         */
-        .set('Authorization', 'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwb3N0Z3JhcGhpbGUiLCJyb2xlIjoiam9obmRvZSIsImlhdCI6MTUxNjIzOTAyMiwidXNlcl9pZCI6MjkzNDA4NSwibnVtYmVyIjoyNywiYm9vbF90cnVlIjp0cnVlLCJib29sX2ZhbHNlIjpmYWxzZSwibnVsbCI6bnVsbCwiYXJyYXkiOnsibiI6NywiYSI6ImZyZWQiLCJjIjoyMX19.MjMRJynCi1ZwiYiLduRxOQeK2FjWtT8IvSVc1_IanEg')
+        .set(
+          'Authorization',
+          'Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJhdWQiOiJwb3N0Z3JhcGhpbGUiLCJyb2xlIjoiam9obmRvZSIsImlhdCI6MTUxNjIzOTAyMiwidXNlcl9pZCI6MjkzNDA4NSwibnVtYmVyIjoyNywiYm9vbF90cnVlIjp0cnVlLCJib29sX2ZhbHNlIjpmYWxzZSwibnVsbCI6bnVsbCwiYXJyYXkiOnsibiI6NywiYSI6ImZyZWQiLCJjIjoyMX19.MjMRJynCi1ZwiYiLduRxOQeK2FjWtT8IvSVc1_IanEg',
+        )
         .send({ query: '{query}' })
         .expect(200)
         .expect('Content-Type', /json/)
@@ -383,17 +380,27 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         ['begin'],
         [
           {
-            text: 'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true), set_config($13, $14, true), set_config($15, $16, true), set_config($17, $18, true)',
+            text:
+              'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true), set_config($13, $14, true), set_config($15, $16, true), set_config($17, $18, true)',
             values: [
-              'role', 'johndoe',
-              'jwt.claims.aud', 'postgraphile',
-              'jwt.claims.role', 'johndoe',
-              'jwt.claims.iat', '1516239022',
-              'jwt.claims.user_id', '2934085',
-              'jwt.claims.number', '27',
-              'jwt.claims.bool_true', 'true',
-              'jwt.claims.bool_false', 'false',
-              'jwt.claims.array', JSON.stringify({'n': 7, 'a': 'fred', 'c': 21}),
+              'role',
+              'johndoe',
+              'jwt.claims.aud',
+              'postgraphile',
+              'jwt.claims.role',
+              'johndoe',
+              'jwt.claims.iat',
+              '1516239022',
+              'jwt.claims.user_id',
+              '2934085',
+              'jwt.claims.number',
+              '27',
+              'jwt.claims.bool_true',
+              'true',
+              'jwt.claims.bool_false',
+              'false',
+              'jwt.claims.array',
+              JSON.stringify({ n: 7, a: 'fred', c: 21 }),
             ],
           },
         ],
@@ -466,7 +473,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         .send({ query: '{hello}', variables: 2 })
         .expect(400)
         .expect({
-          errors: [{ message: 'Variables must be an object, not \'number\'.' }],
+          errors: [{ message: "Variables must be an object, not 'number'." }],
         })
     })
 
@@ -477,9 +484,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         .send({ query: '{hello}', operationName: 2 })
         .expect(400)
         .expect({
-          errors: [
-            { message: 'Operation name must be a string, not \'number\'.' },
-          ],
+          errors: [{ message: "Operation name must be a string, not 'number'." }],
         })
     })
 
@@ -537,7 +542,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       pgClient.query.mockClear()
       pgClient.release.mockClear()
       const server = createServer({
-        handleErrors: (errors) => {
+        handleErrors: errors => {
           return errors.map(error => {
             error.message = 'my custom error message'
             error.hint = 'my custom error hint'
@@ -634,24 +639,10 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
       await request(server)
         .get('/_postgraphile/graphiql/../../../../etc/passwd')
         .expect(403)
-      expect(
-        sendFile.mock.calls.map(([res, filepath, options]) => [
-          filepath,
-          options,
-        ]),
-      ).toEqual([
-        [
-          'anything.css',
-          { index: false, dotfiles: 'ignore', root: graphiqlDirectory },
-        ],
-        [
-          'something.js',
-          { index: false, dotfiles: 'ignore', root: graphiqlDirectory },
-        ],
-        [
-          'very/deeply/nested',
-          { index: false, dotfiles: 'ignore', root: graphiqlDirectory },
-        ],
+      expect(sendFile.mock.calls.map(([res, filepath, options]) => [filepath, options])).toEqual([
+        ['anything.css', { index: false, dotfiles: 'ignore', root: graphiqlDirectory }],
+        ['something.js', { index: false, dotfiles: 'ignore', root: graphiqlDirectory }],
+        ['very/deeply/nested', { index: false, dotfiles: 'ignore', root: graphiqlDirectory }],
       ])
     })
 
@@ -801,9 +792,7 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
     })
 
     test('will call additionalGraphQLContextFromRequest if provided and add the response to the context', async () => {
-      const helloResolver = jest.fn(
-        (source, args, context) => context.additional,
-      )
+      const helloResolver = jest.fn((source, args, context) => context.additional)
       const contextCheckGqlSchema = new GraphQLSchema({
         query: new GraphQLObjectType({
           name: 'Query',
@@ -830,12 +819,12 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         .expect('Content-Type', /json/)
         .expect({ data: { hello: 'foo' } })
       expect(additionalGraphQLContextFromRequest).toHaveBeenCalledTimes(1)
-      expect(
-        additionalGraphQLContextFromRequest.mock.calls[0][0],
-      ).toBeInstanceOf(http.IncomingMessage)
-      expect(
-        additionalGraphQLContextFromRequest.mock.calls[0][1],
-      ).toBeInstanceOf(http.ServerResponse)
+      expect(additionalGraphQLContextFromRequest.mock.calls[0][0]).toBeInstanceOf(
+        http.IncomingMessage,
+      )
+      expect(additionalGraphQLContextFromRequest.mock.calls[0][1]).toBeInstanceOf(
+        http.ServerResponse,
+      )
     })
 
     if (name === 'koa') {
@@ -844,9 +833,11 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
           { graphiql: true },
           {
             onPreCreate: app => {
-              app.use(compress({
-                threshold: 0,
-              }))
+              app.use(
+                compress({
+                  threshold: 0,
+                }),
+              )
             },
           },
         )
@@ -862,16 +853,8 @@ for (const [name, createServerFromHandler] of Array.from(serverCreators)) {
         await request(server)
           .get('/_postgraphile/graphiql/anything.css')
           .expect(200)
-        expect(
-          sendFile.mock.calls.map(([res, filepath, options]) => [
-            filepath,
-            options,
-          ]),
-        ).toEqual([
-          [
-            'anything.css',
-            { index: false, dotfiles: 'ignore', root: graphiqlDirectory },
-          ],
+        expect(sendFile.mock.calls.map(([res, filepath, options]) => [filepath, options])).toEqual([
+          ['anything.css', { index: false, dotfiles: 'ignore', root: graphiqlDirectory }],
         ])
       })
     }

--- a/src/postgraphile/http/koaMiddleware.ts
+++ b/src/postgraphile/http/koaMiddleware.ts
@@ -7,19 +7,23 @@ export const isKoaApp = (a: any, b: any) => a.req && a.res && typeof b === 'func
 export const middleware = async (
   ctx: KoaContext,
   next: (err?: Error) => Promise<void>,
-  requestHandler: (req: IncomingMessage, res: ServerResponse, next: (err?: Error) => Promise<any>) => Promise<any>,
+  requestHandler: (
+    req: IncomingMessage,
+    res: ServerResponse,
+    next: (err?: Error) => Promise<any>,
+  ) => Promise<any>,
 ) => {
   // Hack the req object so we can get back to ctx
-  (ctx.req as object)['_koaCtx'] = ctx
+  ;(ctx.req as object)['_koaCtx'] = ctx
 
   // Hack the end function to instead write the response body.
   // (This shouldn't be called by any PostGraphile code.)
-  const oldEnd = ctx.res.end;
-  (ctx.res as object)['end'] = (body: any, cb: () => void) => {
+  const oldEnd = ctx.res.end
+  ;(ctx.res as object)['end'] = (body: any, cb: () => void) => {
     // Setting ctx.response.body changes koa's status implicitly, unless it
     // already has one set:
     ctx.status = ctx.res.statusCode
-    ctx.response.body = (body === undefined) ? '' : body
+    ctx.response.body = body === undefined ? '' : body
     if (typeof cb === 'function') {
       cb()
     }
@@ -32,7 +36,7 @@ export const middleware = async (
   try {
     result = await requestHandler(ctx.req, ctx.res, next)
   } finally {
-    (ctx.res as object)['end'] = oldEnd
+    ;(ctx.res as object)['end'] = oldEnd
     if (ctx.res.statusCode && ctx.res.statusCode !== 200) {
       ctx.response.status = ctx.res.statusCode
     }

--- a/src/postgraphile/http/setupServerSentEvents.ts
+++ b/src/postgraphile/http/setupServerSentEvents.ts
@@ -4,7 +4,11 @@ import { IncomingMessage, ServerResponse } from 'http'
 import { PostGraphile } from '../../interfaces'
 import ICreateRequestHandler = PostGraphile.ICreateRequestHandler
 
-export default function setupServerSentEvents(req: IncomingMessage, res: ServerResponse, options: ICreateRequestHandler): void {
+export default function setupServerSentEvents(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: ICreateRequestHandler,
+): void {
   const { _emitter } = options
 
   // Making sure these options are set.

--- a/src/postgraphile/index.ts
+++ b/src/postgraphile/index.ts
@@ -2,9 +2,4 @@ import postgraphile from './postgraphile'
 import { createPostGraphileSchema, watchPostGraphileSchema } from 'postgraphile-core'
 import withPostGraphileContext from './withPostGraphileContext'
 
-export {
-  postgraphile,
-  createPostGraphileSchema,
-  watchPostGraphileSchema,
-  withPostGraphileContext,
-}
+export { postgraphile, createPostGraphileSchema, watchPostGraphileSchema, withPostGraphileContext }

--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */// Because we use tslint
 import { AddFlagFn } from './cli'
 import { Server } from 'http'
 import { PostGraphile } from '../interfaces'
@@ -9,7 +8,7 @@ import PostGraphileOptions = PostGraphile.PostGraphileOptions
 export type HookFn<T> = (arg: T, context: {}) => T
 export type PluginHookFn = <T>(hookName: string, argument: T, context?: {}) => T
 export interface PostGraphilePlugin {
-  'pluginHook'?: HookFn<PluginHookFn>
+  pluginHook?: HookFn<PluginHookFn>
   'cli:flags:add:standard'?: HookFn<AddFlagFn>
   'cli:flags:add:schema'?: HookFn<AddFlagFn>
   'cli:flags:add:errorHandling'?: HookFn<AddFlagFn>
@@ -25,7 +24,7 @@ export interface PostGraphilePlugin {
   'cli:server:created'?: HookFn<Server>
 
   'postgraphile:options'?: HookFn<PostGraphileOptions>
-  'withPostGraphileContext'?: HookFn<WithPostGraphileContextFn>
+  withPostGraphileContext?: HookFn<WithPostGraphileContextFn>
 }
 type HookName = keyof PostGraphilePlugin
 
@@ -61,9 +60,9 @@ function contextIsSame(context1: {}, context2: {}): boolean {
 // arguments again.
 function memoizeHook<T>(hook: HookFn<T>): HookFn<T> {
   let lastCall: {
-    argument: T,
-    context: {},
-    result: T,
+    argument: T
+    context: {}
+    result: T
   } | null = null
   return (argument: T, context: {}): T => {
     if (lastCall && lastCall.argument === argument && contextIsSame(lastCall.context, context)) {
@@ -80,24 +79,21 @@ function memoizeHook<T>(hook: HookFn<T>): HookFn<T> {
   }
 }
 
-function makeHook<T>(
-  plugins: Array<PostGraphilePlugin>,
-  hookName: HookName,
-): HookFn<T> {
-  return memoizeHook<T>(plugins.reduce((previousHook: HookFn<T>, plugin: {}) => {
-    if (typeof plugin[hookName] === 'function') {
-      return (argument: T, context: {}) => {
-        return plugin[hookName](previousHook(argument, context), context)
+function makeHook<T>(plugins: Array<PostGraphilePlugin>, hookName: HookName): HookFn<T> {
+  return memoizeHook<T>(
+    plugins.reduce((previousHook: HookFn<T>, plugin: {}) => {
+      if (typeof plugin[hookName] === 'function') {
+        return (argument: T, context: {}) => {
+          return plugin[hookName](previousHook(argument, context), context)
+        }
+      } else {
+        return previousHook
       }
-    } else {
-      return previousHook
-    }
-  }, identityHook))
+    }, identityHook),
+  )
 }
 
-export function makePluginHook(
-  plugins: Array<PostGraphilePlugin>,
-): PluginHookFn {
+export function makePluginHook(plugins: Array<PostGraphilePlugin>): PluginHookFn {
   const hooks = {}
   const emptyObject = {} // caching this makes memoization faster when no context is needed
   function rawPluginHook<T>(hookName: HookName, argument: T, context: {} = emptyObject): T {

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -13,8 +13,8 @@ import mixed = PostGraphile.mixed
 import HttpRequestHandler = PostGraphile.HttpRequestHandler
 
 export interface PostgraphileSchemaBuilder {
-  _emitter: EventEmitter,
-  getGraphQLSchema: () => Promise<GraphQLSchema>,
+  _emitter: EventEmitter
+  getGraphQLSchema: () => Promise<GraphQLSchema>
 }
 
 /**
@@ -22,14 +22,23 @@ export interface PostgraphileSchemaBuilder {
  * database to get a GraphQL schema, and then using that to create the Http
  * request handler.
  */
-export function getPostgraphileSchemaBuilder(pgPool: Pool, schema: string | Array<string>, incomingOptions: PostGraphileOptions): PostgraphileSchemaBuilder {
+export function getPostgraphileSchemaBuilder(
+  pgPool: Pool,
+  schema: string | Array<string>,
+  incomingOptions: PostGraphileOptions,
+): PostgraphileSchemaBuilder {
   const pluginHook = pluginHookFromOptions(incomingOptions)
-  const options = pluginHook('postgraphile:options', incomingOptions, { pgPool, schema })
+  const options = pluginHook('postgraphile:options', incomingOptions, {
+    pgPool,
+    schema,
+  })
   // Check for a jwtSecret without a jwtPgTypeIdentifier
   // a secret without a token identifier prevents JWT creation
   if (options.jwtSecret && !options.jwtPgTypeIdentifier) {
     // tslint:disable-next-line no-console
-    console.warn('WARNING: jwtSecret provided, however jwtPgTypeIdentifier (token identifier) not provided.')
+    console.warn(
+      'WARNING: jwtSecret provided, however jwtPgTypeIdentifier (token identifier) not provided.',
+    )
   }
 
   if (options.handleErrors && (options.extendedErrors || options.showErrorStack)) {
@@ -63,7 +72,9 @@ export function getPostgraphileSchemaBuilder(pgPool: Pool, schema: string | Arra
           exportGqlSchema(gqlSchema)
         })
         if (!gqlSchema) {
-          throw new Error('Consistency error: watchPostGraphileSchema promises to call the callback before the promise resolves; but this hasn\'t happened')
+          throw new Error(
+            "Consistency error: watchPostGraphileSchema promises to call the callback before the promise resolves; but this hasn't happened",
+          )
         }
       } else {
         gqlSchema = await createPostGraphileSchema(pgPool, pgSchemas, options)
@@ -79,15 +90,21 @@ export function getPostgraphileSchemaBuilder(pgPool: Pool, schema: string | Arra
   async function exportGqlSchema(newGqlSchema: GraphQLSchema): Promise<void> {
     try {
       await exportPostGraphileSchema(newGqlSchema, options)
-    }
-    // If we fail to export our schema, log the error and exit the process.
-    catch (error) {
+    } catch (error) {
+      // If we fail to export our schema, log the error and exit the process.
       handleFatalError(error)
     }
   }
 }
-export default function postgraphile(poolOrConfig?: Pool | PoolConfig | string, schema?: string | Array<string>, options?: PostGraphileOptions): HttpRequestHandler
-export default function postgraphile(poolOrConfig?: Pool | PoolConfig | string, options?: PostGraphileOptions): HttpRequestHandler
+export default function postgraphile(
+  poolOrConfig?: Pool | PoolConfig | string,
+  schema?: string | Array<string>,
+  options?: PostGraphileOptions,
+): HttpRequestHandler
+export default function postgraphile(
+  poolOrConfig?: Pool | PoolConfig | string,
+  options?: PostGraphileOptions,
+): HttpRequestHandler
 export default function postgraphile(
   poolOrConfig?: Pool | PoolConfig | string,
   schemaOrOptions?: string | Array<string> | PostGraphileOptions,
@@ -122,20 +139,23 @@ export default function postgraphile(
     // If it is already a `Pool`, just use it.
     poolOrConfig instanceof Pool || quacksLikePgPool(poolOrConfig)
       ? (poolOrConfig as Pool)
-      : new Pool(typeof poolOrConfig === 'string'
-        // Otherwise if it is a string, let us parse it to get a config to
-        // create a `Pool`.
-        ? parsePgConnectionString(poolOrConfig)
-        // Finally, it must just be a config itself. If it is undefined, we
-        // will just use an empty config and let the defaults take over.
-        : poolOrConfig || {},
-      )
+      : new Pool(
+          typeof poolOrConfig === 'string'
+            ? // Otherwise if it is a string, let us parse it to get a config to
+              // create a `Pool`.
+              parsePgConnectionString(poolOrConfig)
+            : // Finally, it must just be a config itself. If it is undefined, we
+              // will just use an empty config and let the defaults take over.
+              poolOrConfig || {},
+        )
 
   const { getGraphQLSchema, _emitter } = getPostgraphileSchemaBuilder(pgPool, schema, options)
-  return createPostGraphileHttpRequestHandler({...options,
+  return createPostGraphileHttpRequestHandler({
+    ...options,
     getGqlSchema: getGraphQLSchema,
     pgPool,
-    _emitter})
+    _emitter,
+  })
 }
 
 function handleFatalError(error: Error): never {
@@ -149,14 +169,21 @@ function handleFatalError(error: Error): never {
 }
 
 function constructorName(obj: mixed): string | null {
-  return obj && typeof obj.constructor === 'function' && obj.constructor.name && String(obj.constructor.name) || null
+  return (
+    (obj &&
+      typeof obj.constructor === 'function' &&
+      obj.constructor.name &&
+      String(obj.constructor.name)) ||
+    null
+  )
 }
 
 // tslint:disable-next-line no-any
 function quacksLikePgPool(pgConfig: any): boolean {
   // A diagnosis of exclusion
   if (!pgConfig || typeof pgConfig !== 'object') return false
-  if (constructorName(pgConfig) !== 'Pool' && constructorName(pgConfig) !== 'BoundPool') return false
+  if (constructorName(pgConfig) !== 'Pool' && constructorName(pgConfig) !== 'BoundPool')
+    return false
   if (!pgConfig['Client']) return false
   if (!pgConfig['options']) return false
   if (typeof pgConfig['connect'] !== 'function') return false

--- a/src/postgraphile/schema/exportPostGraphileSchema.ts
+++ b/src/postgraphile/schema/exportPostGraphileSchema.ts
@@ -1,10 +1,7 @@
 import { writeFile } from 'fs'
 import { graphql, GraphQLSchema, introspectionQuery, printSchema } from 'graphql'
 
-async function writeFileAsync(
-  path: string,
-  contents: string,
-): Promise<void> {
+async function writeFileAsync(path: string, contents: string): Promise<void> {
   await new Promise((resolve, reject) => {
     writeFile(path, contents, error => {
       if (error) reject(error)
@@ -19,8 +16,8 @@ async function writeFileAsync(
 export default async function exportPostGraphileSchema(
   schema: GraphQLSchema,
   options: {
-    exportJsonSchemaPath?: string,
-    exportGqlSchemaPath?: string,
+    exportJsonSchemaPath?: string
+    exportGqlSchemaPath?: string
   } = {},
 ): Promise<void> {
   // JSON version

--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -1,4 +1,3 @@
-/* eslint-disable */// Because we use tslint
 import createDebugger = require('debug')
 import jwt = require('jsonwebtoken')
 import { Pool, PoolClient } from 'pg'
@@ -9,35 +8,36 @@ import { pluginHookFromOptions } from './pluginHook'
 import { PostGraphile } from '../interfaces'
 import mixed = PostGraphile.mixed
 
-const undefinedIfEmpty = (o?: Array<string> | string): undefined | Array<string> | string => o && o.length ? o : undefined
+const undefinedIfEmpty = (o?: Array<string> | string): undefined | Array<string> | string =>
+  o && o.length ? o : undefined
 
 export type WithPostGraphileContextFn = (
   options: {
-    pgPool: Pool,
-    jwtToken?: string,
-    jwtSecret?: string,
-    jwtAudiences?: Array<string>,
-    jwtRole: Array<string>,
-    jwtVerifyOptions?: jwt.VerifyOptions,
-    pgDefaultRole?: string,
-    pgSettings?: { [key: string]: mixed },
+    pgPool: Pool
+    jwtToken?: string
+    jwtSecret?: string
+    jwtAudiences?: Array<string>
+    jwtRole: Array<string>
+    jwtVerifyOptions?: jwt.VerifyOptions
+    pgDefaultRole?: string
+    pgSettings?: { [key: string]: mixed }
   },
   callback: (context: mixed) => Promise<ExecutionResult>,
 ) => Promise<ExecutionResult>
 
 const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
   options: {
-    pgPool: Pool,
-    jwtToken?: string,
-    jwtSecret?: string,
-    jwtAudiences?: Array<string>,
-    jwtRole: Array<string>,
-    jwtVerifyOptions?: jwt.VerifyOptions,
-    pgDefaultRole?: string,
-    pgSettings?: { [key: string]: mixed },
-    queryDocumentAst?: DocumentNode,
-    operationName?: string,
-    pgForceTransaction?: boolean,
+    pgPool: Pool
+    jwtToken?: string
+    jwtSecret?: string
+    jwtAudiences?: Array<string>
+    jwtRole: Array<string>
+    jwtVerifyOptions?: jwt.VerifyOptions
+    pgDefaultRole?: string
+    pgSettings?: { [key: string]: mixed }
+    queryDocumentAst?: DocumentNode
+    operationName?: string
+    pgForceTransaction?: boolean
   },
   callback: (context: mixed) => Promise<ExecutionResult>,
 ): Promise<ExecutionResult> => {
@@ -57,7 +57,8 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
 
   let operation: OperationDefinitionNode | void
   if (!pgForceTransaction && queryDocumentAst) {
-    for (let i = 0, l = queryDocumentAst.definitions.length; i < l; i++) { // tslint:disable-line
+    // tslint:disable-next-line
+    for (let i = 0, l = queryDocumentAst.definitions.length; i < l; i++) {
       const definition = queryDocumentAst.definitions[i]
       if (definition.kind === Kind.OPERATION_DEFINITION) {
         if (!operationName && operation) {
@@ -83,7 +84,10 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
   })
 
   // If we can avoid transactions, we get greater performance.
-  const needTransaction = pgForceTransaction || localSettings.length > 0 || (operationType !== 'query' && operationType !== 'subscription')
+  const needTransaction =
+    pgForceTransaction ||
+    localSettings.length > 0 ||
+    (operationType !== 'query' && operationType !== 'subscription')
 
   // Now we've caught as many errors as we can at this stage, let's create a DB connection.
 
@@ -101,11 +105,17 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
   try {
     // If there is at least one local setting, load it into the database.
     if (needTransaction && localSettings.length !== 0) {
-      const query = sql.compile(sql.query`select ${sql.join(localSettings.map(([key, value]) =>
-        // Make sure that the third config is always `true` so that we are only
-        // ever setting variables on the transaction.
-        sql.query`set_config(${sql.value(key)}, ${sql.value(value)}, true)`,
-      ), ', ')}`)
+      const query = sql.compile(
+        sql.query`select ${sql.join(
+          localSettings.map(
+            ([key, value]) =>
+              // Make sure that the third config is always `true` so that we are only
+              // ever setting variables on the transaction.
+              sql.query`set_config(${sql.value(key)}, ${sql.value(value)}, true)`,
+          ),
+          ', ',
+        )}`,
+      )
 
       await pgClient.query(query)
     }
@@ -114,10 +124,9 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
       [$$pgClient]: pgClient,
       pgRole,
     })
-  }
-  // Cleanup our Postgres client by ending the transaction and releasing
-  // the client back to the pool. Always do this even if the query fails.
-  finally {
+  } finally {
+    // Cleanup our Postgres client by ending the transaction and releasing
+    // the client back to the pool. Always do this even if the query fails.
     if (needTransaction) {
       await pgClient.query('commit')
     }
@@ -152,19 +161,21 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
  */
 const withPostGraphileContext: WithPostGraphileContextFn = async (
   options: {
-    pgPool: Pool,
-    jwtToken?: string,
-    jwtSecret?: string,
-    jwtAudiences?: Array<string>,
-    jwtRole: Array<string>,
-    jwtVerifyOptions?: jwt.VerifyOptions,
-    pgDefaultRole?: string,
-    pgSettings?: { [key: string]: mixed },
+    pgPool: Pool
+    jwtToken?: string
+    jwtSecret?: string
+    jwtAudiences?: Array<string>
+    jwtRole: Array<string>
+    jwtVerifyOptions?: jwt.VerifyOptions
+    pgDefaultRole?: string
+    pgSettings?: { [key: string]: mixed }
   },
   callback: (context: mixed) => Promise<ExecutionResult>,
 ): Promise<ExecutionResult> => {
   const pluginHook = pluginHookFromOptions(options)
-  const withContext = pluginHook('withPostGraphileContext', withDefaultPostGraphileContext, { options })
+  const withContext = pluginHook('withPostGraphileContext', withDefaultPostGraphileContext, {
+    options,
+  })
   return withContext(options, callback)
 }
 
@@ -188,14 +199,17 @@ async function getSettingsForPgClientTransaction({
   pgDefaultRole,
   pgSettings,
 }: {
-  jwtToken?: string,
-  jwtSecret?: string,
-  jwtAudiences?: Array<string>,
-  jwtRole: Array<string>,
-  jwtVerifyOptions?: jwt.VerifyOptions,
-  pgDefaultRole?: string,
-  pgSettings?: { [key: string]: mixed },
-}): Promise<{role: string | undefined, localSettings: Array<[string, string]>}> {
+  jwtToken?: string
+  jwtSecret?: string
+  jwtAudiences?: Array<string>
+  jwtRole: Array<string>
+  jwtVerifyOptions?: jwt.VerifyOptions
+  pgDefaultRole?: string
+  pgSettings?: { [key: string]: mixed }
+}): Promise<{
+  role: string | undefined
+  localSettings: Array<[string, string]>
+}> {
   // Setup our default role. Once we decode our token, the role may change.
   let role = pgDefaultRole
   let jwtClaims: { [claimName: string]: mixed } = {}
@@ -208,19 +222,18 @@ async function getSettingsForPgClientTransaction({
     try {
       // If a JWT token was defined, but a secret was not provided to the server
       // throw a 403 error.
-      if (typeof jwtSecret !== 'string')
-        throw new Error('Not allowed to provide a JWT token.')
+      if (typeof jwtSecret !== 'string') throw new Error('Not allowed to provide a JWT token.')
 
       if (jwtAudiences != null && jwtVerifyOptions && 'audience' in jwtVerifyOptions)
         throw new Error(`Provide either 'jwtAudiences' or 'jwtVerifyOptions.audience' but not both`)
 
       jwtClaims = jwt.verify(jwtToken, jwtSecret, {
         ...jwtVerifyOptions,
-        audience: jwtAudiences || (
-          jwtVerifyOptions && ('audience' in (jwtVerifyOptions as object))
-          ? undefinedIfEmpty(jwtVerifyOptions.audience)
-          : ['postgraphile']
-        ),
+        audience:
+          jwtAudiences ||
+          (jwtVerifyOptions && 'audience' in (jwtVerifyOptions as object)
+            ? undefinedIfEmpty(jwtVerifyOptions.audience)
+            : ['postgraphile']),
       })
 
       const roleClaim = getPath(jwtClaims, jwtRole)
@@ -229,20 +242,21 @@ async function getSettingsForPgClientTransaction({
       // default role.
       if (typeof roleClaim !== 'undefined') {
         if (typeof roleClaim !== 'string')
-          throw new Error(`JWT \`role\` claim must be a string. Instead found '${typeof jwtClaims['role']}'.`)
+          throw new Error(
+            `JWT \`role\` claim must be a string. Instead found '${typeof jwtClaims['role']}'.`,
+          )
 
         role = roleClaim
       }
-    }
-    catch (error) {
+    } catch (error) {
       // In case this error is thrown in an HTTP context, we want to add status code
       // Note. jwt.verify will add a name key to its errors. (https://github.com/auth0/node-jsonwebtoken#errors--codes)
       error.statusCode =
-        (('name' in error) && error.name === 'TokenExpiredError')
-        // The correct status code for an expired ( but otherwise acceptable token is 401 )
-        ? 401
-        // All other authentication errors should get a 403 status code.
-        : 403
+        'name' in error && error.name === 'TokenExpiredError'
+          ? // The correct status code for an expired ( but otherwise acceptable token is 401 )
+            401
+          : // All other authentication errors should get a 403 status code.
+            403
 
       throw error
     }
@@ -278,9 +292,8 @@ async function getSettingsForPgClientTransaction({
     if (jwtClaims.hasOwnProperty(key)) {
       const rawValue = jwtClaims[key]
       // Unsafe to pass raw object/array to pg.query -> set_config; instead JSONify
-      const value: mixed = rawValue != null && typeof rawValue === 'object'
-        ? JSON.stringify(rawValue)
-        : rawValue
+      const value: mixed =
+        rawValue != null && typeof rawValue === 'object' ? JSON.stringify(rawValue) : rawValue
       if (isPgSettingValid(value)) {
         localSettings.push([`jwt.claims.${key}`, String(value)])
       }
@@ -313,7 +326,7 @@ function debugPgClient(pgClient: PoolClient): PoolClient {
     pgClient[$$pgClientOrigQuery] = pgClient.query
 
     // tslint:disable-next-line only-arrow-functions
-    pgClient.query = function (...args: Array<any>): any {
+    pgClient.query = function(...args: Array<any>): any {
       // Debug just the query text. We don’t want to debug variables because
       // there may be passwords in there.
       debugPg(args[0] && args[0].text ? args[0].text : args[0])
@@ -345,7 +358,7 @@ function getPath(inObject: mixed, path: Array<string>): any {
   while (object && index < length) {
     object = object[path[index++]]
   }
-  return (index && index === length) ? object : undefined
+  return index && index === length ? object : undefined
 }
 
 /**
@@ -360,10 +373,16 @@ function isPgSettingValid(pgSetting: mixed): boolean {
     return false
   }
   const typeOfPgSetting = typeof pgSetting
-  if (typeOfPgSetting === 'string' || typeOfPgSetting === 'number' || typeOfPgSetting === 'boolean') {
+  if (
+    typeOfPgSetting === 'string' ||
+    typeOfPgSetting === 'number' ||
+    typeOfPgSetting === 'boolean'
+  ) {
     return true
   }
   // TODO: booleans!
-  throw new Error(`Error converting pgSetting: ${typeof pgSetting} needs to be of type string, number or boolean.`)
+  throw new Error(
+    `Error converting pgSetting: ${typeof pgSetting} needs to be of type string, number or boolean.`,
+  )
 }
 // tslint:enable no-any

--- a/src/postgres/inventory/pgClientFromContext.ts
+++ b/src/postgres/inventory/pgClientFromContext.ts
@@ -10,13 +10,11 @@ export const $$pgClient = 'pgClient'
  * client does not exist.
  */
 export default function getPgClientFromContext(context: mixed): PoolClient {
-  if (context == null || typeof context !== 'object')
-    throw new Error('Context must be an object.')
+  if (context == null || typeof context !== 'object') throw new Error('Context must be an object.')
 
   const client = context[$$pgClient]
 
-  if (client == null)
-    throw new Error('Postgres client does not exist on the context.')
+  if (client == null) throw new Error('Postgres client does not exist on the context.')
 
   if (!(client instanceof ClientBase))
     throw new Error('Postgres client on context is of the incorrect type.')

--- a/tslint.json
+++ b/tslint.json
@@ -31,14 +31,6 @@
     "no-mergeable-namespace": false,
     "no-require-imports": false,
     "object-literal-sort-keys": false,
-    "space-before-function-paren": [
-      true,
-      {
-        "anonymous": "always",
-        "named": "never",
-        "asyncArrow": "always"
-      }
-    ],
     "array-type": [
       true,
       "generic"
@@ -59,30 +51,11 @@
       "check-whitespace"
     ],
     "ordered-imports": false,
-    "quotemark": [
-      true,
-      "single"
-    ],
-    "semicolon": {
-      "options": [
-        "never"
-      ]
-    },
     "variable-name": [
       true,
       "ban-keywords",
       "check-format",
       "allow-leading-underscore"
-    ],
-    "whitespace": [
-      true,
-      "check-branch",
-      "check-decl",
-      "check-operator",
-      "check-module",
-      "check-separator",
-      "check-type",
-      "check-typecast"
     ],
     "no-namespace": false,
     "no-implicit-dependencies": [
@@ -182,14 +155,6 @@
     ],
     "one-variable-per-declaration": true,
     "ordered-imports": false,
-    "quotemark": [
-      true,
-      "single"
-    ],
-    "semicolon": [
-      true,
-      "never"
-    ],
     "variable-name": [
       true,
       "ban-keywords",

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,8 @@
 {
-  "extends": "tslint:latest",
+  "extends": [
+    "tslint:latest",
+    "tslint-config-prettier"
+  ],
   "rules": {
     "curly": false,
     "no-any": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6386,6 +6386,10 @@ preserve@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
 
+prettier@1.13.7:
+  version "1.13.7"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.13.7.tgz#850f3b8af784a49a6ea2d2eaa7ed1428a34b7281"
+
 pretty-bytes@^4.0.2:
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-4.0.2.tgz#b2bf82e7350d65c6c33aa95aaa5a4f6327f61cd9"
@@ -7765,6 +7769,10 @@ tsconfig@^6.0.0:
 tslib@^1.5.0, tslib@^1.8.0, tslib@^1.8.1:
   version "1.9.3"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.9.3.tgz#d7e4dd79245d85428c4d7e4822a79917954ca286"
+
+tslint-config-prettier@1.14.0:
+  version "1.14.0"
+  resolved "https://registry.yarnpkg.com/tslint-config-prettier/-/tslint-config-prettier-1.14.0.tgz#860b36634e53f4c70c64c51ff3ef7fd9bbab7676"
 
 tslint@^5.10.0:
   version "5.10.0"


### PR DESCRIPTION
Prettier has been configured to apply minimal changes to the codebase; I'll follow this up with a PR that enables semicolons (🎉)


If you're checking this diff, you probably want to do so using `git diff -w --word-diff-regex=[^[:space:]]` so that it ignores *all* whitespace changes.