### PR TITLE
chore(tests): enforce current behaviour when settings are provided by both JWT and pgSettings

### DIFF
--- a/src/postgraphile/__tests__/withPostGraphileContext-test.js
+++ b/src/postgraphile/__tests__/withPostGraphileContext-test.js
@@ -573,6 +573,60 @@ test('will set a role provided in the JWT', async () => {
   ]);
 });
 
+test('if same settings are set by pgSettings and JWT, JWT will "win", except for the "role" because of legacy', async () => {
+  const pgClient = { query: jest.fn(), release: jest.fn() };
+  const pgPool = { connect: jest.fn(() => pgClient) };
+  await withPostGraphileContext(
+    {
+      pgPool,
+      jwtToken: jwt.sign(
+        { aud: 'postgraphile', a: 1, b: 2, c: 3, role: 'test_jwt_role' },
+        'secret',
+        {
+          noTimestamp: true,
+        },
+      ),
+      jwtSecret: 'secret',
+      pgSettings: {
+        'jwt.claims.a': 99,
+        'jwt.claims.b': 98,
+        'jwt.claims.c': 97,
+        'jwt.claims.d': 96,
+        role: 'ugh_legacy_override',
+        'jwt.claims.role': 'some_other_role_again',
+      }
+    },
+    () => {},
+  );
+  expect(pgClient.query.mock.calls).toEqual([
+    ['begin'],
+    [
+      {
+        text:
+          'select set_config($1, $2, true), set_config($3, $4, true), set_config($5, $6, true), set_config($7, $8, true), set_config($9, $10, true), set_config($11, $12, true), set_config($13, $14, true)',
+        values: [
+          'jwt.claims.d',
+          '96',
+          'role',
+          'ugh_legacy_override',
+          'jwt.claims.aud',
+          'postgraphile',
+          'jwt.claims.a',
+          '1',
+          'jwt.claims.b',
+          '2',
+          'jwt.claims.c',
+          '3',
+          'jwt.claims.role',
+          'test_jwt_role',
+        ],
+      },
+    ],
+    ['commit'],
+  ]);
+});
+
+
 test('will set a role provided in the JWT superceding the default role', async () => {
   const pgClient = { query: jest.fn(), release: jest.fn() };
   const pgPool = { connect: jest.fn(() => pgClient) };

--- a/src/postgraphile/__tests__/withPostGraphileContext-test.js
+++ b/src/postgraphile/__tests__/withPostGraphileContext-test.js
@@ -594,7 +594,7 @@ test('if same settings are set by pgSettings and JWT, JWT will "win", except for
         'jwt.claims.d': 96,
         role: 'ugh_legacy_override',
         'jwt.claims.role': 'some_other_role_again',
-      }
+      },
     },
     () => {},
   );
@@ -625,7 +625,6 @@ test('if same settings are set by pgSettings and JWT, JWT will "win", except for
     ['commit'],
   ]);
 });
-
 
 test('will set a role provided in the JWT superceding the default role', async () => {
   const pgClient = { query: jest.fn(), release: jest.fn() };

--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -273,7 +273,7 @@ async function getSettingsForPgClientTransaction({
 
   // Set the custom provided settings before jwt claims and role are set
   // this prevents an accidentional overwriting
-  if (typeof pgSettings === 'object') {
+  if (pgSettings && typeof pgSettings === 'object') {
     for (const key in pgSettings) {
       if (pgSettings.hasOwnProperty(key) && isPgSettingValid(pgSettings[key])) {
         if (key === 'role') {

--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -94,7 +94,9 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
   const pgClient = await pgPool.connect();
 
   // Enhance our Postgres client with debugging stuffs.
-  if (debugPg.enabled || debugPgError.enabled) debugPgClient(pgClient);
+  if ((debugPg.enabled || debugPgError.enabled) && !pgClient[$$pgClientOrigQuery]) {
+    debugPgClient(pgClient);
+  }
 
   // Begin our transaction, if necessary.
   if (needTransaction) {


### PR DESCRIPTION
The rules are this:

If it's the `role` setting then the first of these will win:

1. Role from pgSettings
2. Role from JWT
3. Role from `pgDefaultRole`

Otherwise, the first of these will win:

1. JWT
2. pgSettings

I'll probably change this in v5.