### PR TITLE
fix(CLI): disabling JWT audience verification now possible

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -12,7 +12,7 @@ export BROWSER=none
 # Run Nodemon and watch the PostGraphile source code for changes.
 if [ "$1" = "--" ]; then
   shift
-  $npm_bin/ts-node --disableWarnings src/postgraphile/cli.ts $* &
+  $npm_bin/ts-node --disableWarnings src/postgraphile/cli.ts "$@" &
 else
   $npm_bin/nodemon \
     --watch src \

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -252,7 +252,7 @@ program
   .option(
     '-A, --jwt-verify-audience <string>',
     "a comma separated list of JWT audiences that will be accepted; defaults to 'postgraphile'. To disable audience verification, set to ''.",
-    (option: string) => option.split(','),
+    (option: string) => option.split(',').filter(_ => _),
   )
   .option(
     '--jwt-verify-clock-tolerance <number>',


### PR DESCRIPTION
`postgraphile -A ''` should disable audience verification, but it didn't. Thanks for spotting the error, Daniel V 👍