### PR TITLE
fix(hooks): ensure hooked options passed to createPostGraphileHttpRequestHandler

### DIFF
--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -61,7 +61,9 @@ const withDefaultPostGraphileContext: WithPostGraphileContextFn = async (
       const definition = queryDocumentAst.definitions[i];
       if (definition.kind === Kind.OPERATION_DEFINITION) {
         if (!operationName && operation) {
-          throw new Error('Multiple unnamed operations present in GraphQL query.');
+          throw new Error(
+            'Multiple operations present in GraphQL query, you must specify an `operationName` so we know which one to execute.',
+          );
         } else if (!operationName || (definition.name && definition.name.value === operationName)) {
           operation = definition;
         }


### PR DESCRIPTION
Previously options passed to `createPostGraphileHttpRequestHandler` when using PostGraphile as a library had not gone through options mangling so changes to them from plugins were not available in all areas.

(`pluginHook` is still alpha-quality.)