### PR TITLE
add docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '3'
+services:
+  postgraphile:
+    build: .
+    entrypoint:
+      - postgraphile
+      - -n
+      - 0.0.0.0
+      - --connection
+      - postgres://postgres:postgres@localhost:5432/db
+    ports:
+      - "5000:5000"


### PR DESCRIPTION
I've added a simple docker-compose file to made a little bit easier to run the postgraphile container with all the configuration.

`docker-compose up -d` 

It would be great to be able to pass the configuration through environment variables.