### PR TITLE
feat(http): support mounting on subroutes

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "jest": "^18.1.0",
     "koa": "^2.5.1",
     "koa-compress": "^3.0.0",
+    "koa-mount": "^4.0.0",
     "nodemon": "^1.11.0",
     "pg-minify": "~0.5.3",
     "prettier": "^1.13.7",

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "http-errors": "^1.5.1",
     "jsonwebtoken": "^8.0.0",
     "lru-cache": ">=4 <5",
-    "parseurl": "^1.3.1",
+    "parseurl": "^1.3.2",
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
@@ -106,14 +106,23 @@
     "transform": {
       ".*": "<rootDir>/resources/jest-preprocessor.js"
     },
-    "moduleFileExtensions": ["ts", "js"],
-    "setupFiles": ["<rootDir>/resources/jest-setup.js"],
+    "moduleFileExtensions": [
+      "ts",
+      "js"
+    ],
+    "setupFiles": [
+      "<rootDir>/resources/jest-setup.js"
+    ],
     "browser": false,
     "testEnvironment": "node",
-    "testPathDirs": ["<rootDir>/src"],
+    "testPathDirs": [
+      "<rootDir>/src"
+    ],
     "testRegex": "/__tests__/[^.]+-test.(t|j)s$"
   },
-  "files": ["build"],
+  "files": [
+    "build"
+  ],
   "engines": {
     "node": ">=8.6"
   }

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -6,7 +6,7 @@ import { buildClientSchema, introspectionQuery, isType, GraphQLObjectType } from
 const {
   POSTGRAPHILE_CONFIG = {
     graphqlUrl: 'http://localhost:5000/graphql',
-    streamUrl: 'http://localhost:5000/_postgraphile/stream',
+    streamUrl: 'http://localhost:5000/graphql/stream',
     enhanceGraphiql: true,
   },
 } = window;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -147,7 +147,7 @@ export interface PostGraphileOptions {
   // [Experimental] Enable the middleware to process multiple GraphQL queries
   // in one request.
   /* @middlewareOnly */
-  enableQueryBatching?: string;
+  enableQueryBatching?: boolean;
   // The secret for your JSON web tokens. This will be used to verify tokens in
   // the `Authorization` header, and signing JWT tokens you return in
   // procedures.

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -151,8 +151,8 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
         .post('/x')
         .expect(404);
       if (subpath) {
-        const server1 = createServer({ graphqlRoute: '/graphql' });
-        await request(server1)
+        const server2 = createServer({ graphqlRoute: '/graphql' });
+        await request(server2)
           .post(`${subpath}/graphql`)
           .expect(404);
         const server3 = createServer({ graphqlRoute: `${subpath}/graphql` });
@@ -161,8 +161,8 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
           .expect(404);
       }
 
-      const server2 = createServer({ graphqlRoute: `${subpath}/x` });
-      await request(server2)
+      const server4 = createServer({ graphqlRoute: `${subpath}/x` });
+      await request(server4)
         .post(`${subpath}/graphql`)
         .expect(404);
     });

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -144,7 +144,7 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
       subpath,
     );
 
-  describe(name + (subpath ? ` (@${subpath})` : '') , () => {
+  describe(name + (subpath ? ` (@${subpath})` : ''), () => {
     test('will 404 for route other than that specified', async () => {
       const server1 = createServer();
       await request(server1)

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -379,7 +379,7 @@ export default function createPostGraphileHttpRequestHandler(
     // on port 5783.
     if (options.enableCors || isPostGraphileDevelopmentMode) addCORSHeaders(res);
 
-    const { pathname = '' } = parseUrl(req) || {};
+    const { pathname = '' } = parseUrl.original(req) || {};
     const isGraphqlRoute = pathname === graphqlRoute;
 
     // ========================================================================

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -268,7 +268,7 @@ export default function createPostGraphileHttpRequestHandler(
         /<\/head>/,
         `  <script>window.POSTGRAPHILE_CONFIG=${safeJSONStringify({
           graphqlUrl: graphqlRoute,
-          streamUrl: options.watchPg ? '/_postgraphile/stream' : null,
+          streamUrl: options.watchPg ? `${graphqlRoute}/stream` : null,
           enhanceGraphiql: options.enhanceGraphiql,
         })};</script>\n  </head>`,
       )
@@ -422,7 +422,7 @@ export default function createPostGraphileHttpRequestHandler(
       // ======================================================================
 
       // Setup an event stream so we can broadcast events to graphiql, etc.
-      if (pathname === '/_postgraphile/stream') {
+      if (pathname === `${graphqlRoute}/stream` || pathname === '/_postgraphile/stream') {
         if (!options.watchPg || req.headers.accept !== 'text/event-stream') {
           res.statusCode = 405;
           res.end();
@@ -481,7 +481,7 @@ export default function createPostGraphileHttpRequestHandler(
     if (options.watchPg) {
       // Inform GraphiQL and other clients that they can subscribe to events
       // (such as the schema being updated) at the following URL
-      res.setHeader('X-GraphQL-Event-Stream', '/_postgraphile/stream');
+      res.setHeader('X-GraphQL-Event-Stream', `${graphqlRoute}/stream`);
     }
 
     // Don’t execute our GraphQL stuffs for `OPTIONS` requests.

--- a/src/postgraphile/http/koaMiddleware.ts
+++ b/src/postgraphile/http/koaMiddleware.ts
@@ -29,6 +29,9 @@ export const middleware = async (
     }
   };
 
+  // In case you're using koa-mount or similar
+  ctx.req['originalUrl'] = ctx.request.originalUrl;
+
   // Execute our request handler. If an error is thrown, we don’t call
   // `next` with an error. Instead we return the promise and let `koa`
   // handle the error.

--- a/yarn.lock
+++ b/yarn.lock
@@ -5355,7 +5355,7 @@ parse5@^1.5.1:
   resolved "https://registry.yarnpkg.com/parse5/-/parse5-1.5.1.tgz#9b7f3b0de32be78dc2401b17573ccaf0f6f59d94"
   integrity sha1-m387DeMr543CQBsXVzzK8Pb1nZQ=
 
-parseurl@^1.3.1, parseurl@^1.3.2, parseurl@~1.3.2:
+parseurl@^1.3.2, parseurl@~1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/parseurl/-/parseurl-1.3.2.tgz#fc289d4ed8993119460c156253262cdc8de65bf3"
   integrity sha1-/CidTtiZMRlGDBViUyYs3I3mW/M=

--- a/yarn.lock
+++ b/yarn.lock
@@ -2315,6 +2315,13 @@ debug@^3.1.0:
   dependencies:
     ms "2.0.0"
 
+debug@^4.0.1:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
+  integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
 decamelize@^1.0.0, decamelize@^1.1.1:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/decamelize/-/decamelize-1.2.0.tgz#f6534d15148269b20352e7bee26f501f9a191290"
@@ -4360,6 +4367,14 @@ koa-is-json@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/koa-is-json/-/koa-is-json-1.0.0.tgz#273c07edcdcb8df6a2c1ab7d59ee76491451ec14"
   integrity sha1-JzwH7c3Ljfaiwat9We52SRRR7BQ=
+
+koa-mount@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/koa-mount/-/koa-mount-4.0.0.tgz#e0265e58198e1a14ef889514c607254ff386329c"
+  integrity sha512-rm71jaA/P+6HeCpoRhmCv8KVBIi0tfGuO/dMKicbQnQW/YJntJ6MnnspkodoA4QstMVEZArsCphmd0bJEtoMjQ==
+  dependencies:
+    debug "^4.0.1"
+    koa-compose "^4.1.0"
 
 koa@^2.5.1:
   version "2.5.2"


### PR DESCRIPTION
- Gets rid of `/_postgraphile/*` (backwards compatible for `/_postgraphile/stream` in case you hard-coded that (don't!))
- Stream URL now at `/graphql/stream`; but don't hard-code that - we set it in the `X-GraphQL-Event-Stream` header which you should use instead
- Switches to using `originalUrl` rather than `url` when processing the request
- `graphqlRoute` and `graphiqlRoute` are treated as *absolute* paths - i.e. `app.use('/path/to', postgraphile())` will **not** work, you need to do: `app.use('/path/to', postgraphile({graphqlRoute: '/path/to/graphql'}))`
- Even works with Koa/koa-mount
- Fixes incorrect type for `enableQueryBatching`