### PR TITLE
Provide jwtClaims in resolver context when set via pgSettings

### DIFF
--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -309,6 +309,9 @@ async function getSettingsForPgClientTransaction({
       if (pgSettings.hasOwnProperty(key) && isPgSettingValid(pgSettings[key])) {
         if (key === 'role') {
           role = String(pgSettings[key]);
+        } else if (key.startsWith('jwt.claims.')) {
+          // strip 'jwt.claims.' part (11 symbols)
+          jwtClaims[key.substring(11)] = String(pgSettings[key]);
         } else {
           localSettings.push([key, String(pgSettings[key])]);
         }
@@ -339,7 +342,7 @@ async function getSettingsForPgClientTransaction({
   return {
     localSettings,
     role,
-    jwtClaims: jwtToken ? jwtClaims : null,
+    jwtClaims: jwtClaims,
   };
 }
 


### PR DESCRIPTION
If JWT token is parsed/validated via `pgSettings`, jwtClaims are not passed to the custom resolver context.

```js
makeExtendSchemaPlugin(
  build => ({
    typeDefs: gql`
      extend type Thing {
        isOwner: Boolean! @requires(columns: ["owner"])
      }
    `,
    resolvers: {
      Thing: {
        isOwner: async (row, _args, context) => {
          return row.owner === context.jwtClaims.user_id; // <-- // context.jwtClaims is null here
        }
      }
    }
  })
)
```

This PR fixes it.