### PR TITLE
fix: examples -> forum -> current_user function -> fix error invalid input syntax for integer: ""

### DIFF
--- a/examples/forum/schema.sql
+++ b/examples/forum/schema.sql
@@ -182,7 +182,7 @@ comment on function forum_example.authenticate(text, text) is 'Creates a JWT tok
 create function forum_example.current_person() returns forum_example.person as $$
   select *
   from forum_example.person
-  where id = current_setting('jwt.claims.person_id', true)::integer
+  where id = nullif(current_setting('jwt.claims.person_id', true), '')::integer
 $$ language sql stable;
 
 comment on function forum_example.current_person() is 'Gets the person who was identified by our JWT.';


### PR DESCRIPTION

to prevent error 

```
invalid input syntax for integer: "": {"response":{"errors":[{"message":"invalid input syntax for integer: \"\"","locations":[{"line":3,"column":9}],"path":["currentUser"]}],"data":{"currentUser":null},"status":200},"request":{"query":"\n      query {\n        currentUser {\n          emails\n          rowId\n        }\n      }\n    ","variables":{}}}

```