### PR TITLE
feat(http): add externalUrlBase setting

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -128,14 +128,18 @@ export interface PostGraphileOptions {
   // `true`). Defaults to `/graphiql`.
   /* @middlewareOnly */
   graphiqlRoute?: string;
-  // Always set this to true; it's only false by default to avoid a breaking
-  // change. Tells us to use `req.originalUrl` rather than `req.url` when
-  // processing `graphqlRoute` / `graphiqlRoute` which is necessary for asset
-  // loading to work if you mount postgraphile under a path (e.g.
-  // `app.use('/path/to', postgraphile(...))`), which is not officially
-  // supported.  Will be true by default in v5.
+  // If you are using watch mode, or have enabled GraphiQL, and you either
+  // mount PostGraphile under a path, or use PostGraphile behind some kind of
+  // proxy that puts PostGraphile under a subpath (or both!) then you must
+  // specify this setting so that PostGraphile can figure out it's external
+  // URL.
+  // (e.g. if you do `app.use('/path/to', postgraphile(...))`), which is not
+  // officially supported, then you should pass `externalUrlBase: '/path/to'`.)
+  // This setting should never end in a slash (`/`). To specify that the
+  // external URL is the expected one, either omit this setting or set it to the
+  // empty string `''`.
   /* @middlewareOnly */
-  absoluteRoutes?: boolean;
+  externalUrlBase?: string;
   // Set this to `true` to enable the GraphiQL interface.
   /* @middlewareOnly */
   graphiql?: boolean;

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -96,7 +96,6 @@ const serverCreators = new Map([
     'express',
     (handler, _options, subpath) => {
       const app = express();
-      app.use(handler);
       if (subpath) {
         app.use(subpath, handler);
       } else {
@@ -134,9 +133,7 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
           {},
           subpath
             ? {
-                graphqlRoute: `${subpath}/graphql`,
-                graphiqlRoute: `${subpath}/graphiql`,
-                absoluteRoutes: true,
+                externalUrlBase: subpath,
               }
             : null,
           defaultOptions,
@@ -148,30 +145,37 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
     );
 
   describe(name + (subpath ? ` (@${subpath})` : ''), () => {
-    test('will 404 for route other than that specified', async () => {
+    test('will 404 for route other than that specified 1', async () => {
       const server1 = createServer();
       await request(server1)
         .post('/x')
         .expect(404);
-      if (subpath) {
-        const server2 = createServer({ graphqlRoute: '/graphql' });
+    });
+
+    if (subpath) {
+      test('will 404 for route other than that specified 2', async () => {
+        const server2 = createServer({ graphqlRoute: `${subpath}/graphql` });
         await request(server2)
           .post(`${subpath}/graphql`)
           .expect(404);
-        const server3 = createServer({ graphqlRoute: `${subpath}/graphql` });
+      });
+      test('will 404 for route other than that specified 3', async () => {
+        const server3 = createServer({ graphqlRoute: `/graphql` });
         await request(server3)
           .post(`/graphql`)
           .expect(404);
-      }
+      });
+    }
 
-      const server4 = createServer({ graphqlRoute: `${subpath}/x` });
+    test('will 404 for route other than that specified 4', async () => {
+      const server4 = createServer({ graphqlRoute: `/x` });
       await request(server4)
         .post(`${subpath}/graphql`)
         .expect(404);
     });
 
     test('will respond to queries on a different route', async () => {
-      const server = createServer({ graphqlRoute: `${subpath}/x` });
+      const server = createServer({ graphqlRoute: `/x` });
       await request(server)
         .post(`${subpath}/x`)
         .send({ query: '{hello}' })
@@ -181,8 +185,8 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
     });
 
     if (subpath) {
-      test('will respond to queries on a different route with absoluteRoutes=false', async () => {
-        const server = createServer({ graphqlRoute: `/x`, absoluteRoutes: false });
+      test("will respond to queries on a different route with externalUrlBase = ''", async () => {
+        const server = createServer({ graphqlRoute: `/x`, externalUrlBase: '' });
         await request(server)
           .post(`${subpath}/x`)
           .send({ query: '{hello}' })
@@ -768,9 +772,9 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
     });
 
     test('will render GraphiQL on another route if desired', async () => {
-      const server1 = createServer({ graphiqlRoute: `${subpath}/x` });
-      const server2 = createServer({ graphiql: true, graphiqlRoute: `${subpath}/x` });
-      const server3 = createServer({ graphiql: false, graphiqlRoute: `${subpath}/x` });
+      const server1 = createServer({ graphiqlRoute: `/x` });
+      const server2 = createServer({ graphiql: true, graphiqlRoute: `/x` });
+      const server3 = createServer({ graphiql: false, graphiqlRoute: `/x` });
       await request(server1)
         .get(`${subpath}/x`)
         .expect(404);

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -196,6 +196,16 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
       });
     }
 
+    test("infers externalUrlBase when it's not specified", async () => {
+      const server = createServer({ externalUrlBase: undefined });
+      await request(server)
+        .post(`${subpath}/graphql`)
+        .send({ query: '{hello}' })
+        .expect(200)
+        .expect('Content-Type', /json/)
+        .expect({ data: { hello: 'world' } });
+    });
+
     test('will always respond with CORS to an OPTIONS request when enabled', async () => {
       const server = createServer({ enableCors: true });
       await request(server)

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -781,6 +781,20 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
         .expect('Content-Type', 'text/html; charset=utf-8');
     });
 
+    test('will set X-GraphQL-Event-Stream if watch enabled', async () => {
+      const server1 = createServer();
+      const server2 = createServer({ watchPg: true });
+      const res1 = await request(server1)
+        .post(`${subpath}/graphql`)
+        .send({ query: '{hello}' });
+      expect(res1.headers['x-graphql-event-stream']).toBeFalsy();
+      await request(server2)
+        .post(`${subpath}/graphql`)
+        .send({ query: '{hello}' })
+        .expect(200)
+        .expect('X-GraphQL-Event-Stream', `${subpath}/graphql/stream`);
+    });
+
     test('will render GraphiQL on another route if desired', async () => {
       const server1 = createServer({ graphiqlRoute: `/x` });
       const server2 = createServer({ graphiql: true, graphiqlRoute: `/x` });

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -516,7 +516,7 @@ export default function createPostGraphileHttpRequestHandler(
     if (options.watchPg) {
       // Inform GraphiQL and other clients that they can subscribe to events
       // (such as the schema being updated) at the following URL
-      res.setHeader('X-GraphQL-Event-Stream', `${graphqlRoute}/stream`);
+      res.setHeader('X-GraphQL-Event-Stream', `${externalUrlBase}${graphqlRoute}/stream`);
     }
 
     // Don’t execute our GraphQL stuffs for `OPTIONS` requests.

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -23,7 +23,7 @@ import { Context as KoaContext } from 'koa';
 import chalk = require('chalk');
 import Debugger = require('debug'); // tslint:disable-line variable-name
 import httpError = require('http-errors');
-import parseUrlModule = require('parseurl');
+import parseUrl = require('parseurl');
 import finalHandler = require('finalhandler');
 import bodyParser = require('body-parser');
 import LRU = require('lru-cache');
@@ -151,6 +151,18 @@ export default function createPostGraphileHttpRequestHandler(
     pgDefaultRole,
     queryCacheMaxSize = 50 * MEGABYTE,
   } = options;
+  if (options.absoluteRoutes) {
+    throw new Error(
+      'Sorry - the `absoluteRoutes` setting has been replaced with `externalUrlBase` which solves the issue in a cleaner way. Please update your settings. Thank you for testing a PostGraphile pre-release 🙏',
+    );
+  }
+
+  // Using let because we might override it on the first request.
+  let externalUrlBase = options.externalUrlBase;
+  if (externalUrlBase && externalUrlBase.endsWith('/')) {
+    throw new Error('externalUrlBase must not end with a slash (`/`)');
+  }
+
   const pluginHook = pluginHookFromOptions(options);
 
   if (pgDefaultRole && typeof pgSettings === 'function') {
@@ -177,7 +189,6 @@ export default function createPostGraphileHttpRequestHandler(
   // Gets the route names for our GraphQL endpoint, and our GraphiQL endpoint.
   const graphqlRoute = options.graphqlRoute || '/graphql';
   const graphiqlRoute = options.graphiql === true ? options.graphiqlRoute || '/graphiql' : null;
-  const parseUrl = options.absoluteRoutes ? parseUrlModule.original : parseUrlModule;
 
   // Throw an error of the GraphQL and GraphiQL routes are the same.
   if (graphqlRoute === graphiqlRoute)
@@ -263,17 +274,8 @@ export default function createPostGraphileHttpRequestHandler(
       });
     });
 
-  // Takes the original GraphiQL HTML file and replaces the default config object.
-  const graphiqlHtml = origGraphiqlHtml
-    ? origGraphiqlHtml.replace(
-        /<\/head>/,
-        `  <script>window.POSTGRAPHILE_CONFIG=${safeJSONStringify({
-          graphqlUrl: graphqlRoute,
-          streamUrl: options.watchPg ? `${graphqlRoute}/stream` : null,
-          enhanceGraphiql: options.enhanceGraphiql,
-        })};</script>\n  </head>`,
-      )
-    : null;
+  // We only need to calculate the graphiql HTML once; but we need to receive the first request to do so.
+  let graphiqlHtml: string | null;
 
   const withPostGraphileContextFromReqRes = withPostGraphileContextFromReqResGenerator(options);
 
@@ -350,6 +352,8 @@ export default function createPostGraphileHttpRequestHandler(
     }
   };
 
+  let isFirstRequest = true;
+
   /**
    * The actual request handler. It’s an async function so it will return a
    * promise when complete. If the function doesn’t handle anything, it calls
@@ -381,6 +385,36 @@ export default function createPostGraphileHttpRequestHandler(
     if (options.enableCors || isPostGraphileDevelopmentMode) addCORSHeaders(res);
 
     const { pathname = '' } = parseUrl(req) || {};
+
+    // Certain things depend on externalUrlBase, which we guess if the user
+    // doesn't supply it, so we calculate them on the first request.
+    if (isFirstRequest) {
+      isFirstRequest = false;
+
+      if (externalUrlBase == null) {
+        // User hasn't specified externalUrlBase; let's try and guess it
+        const { pathname: originalPathname = '' } = parseUrl.original(req) || {};
+        if (originalPathname !== pathname && originalPathname.endsWith(pathname)) {
+          // We were mounted on a subpath (e.g. `app.use('/path/to', postgraphile(...))`).
+          // Figure out our externalUrlBase for ourselves.
+          externalUrlBase = originalPathname.substr(0, originalPathname.length - pathname.length);
+        }
+        // Make sure we have a string, at least
+        externalUrlBase = externalUrlBase || '';
+      }
+
+      // Takes the original GraphiQL HTML file and replaces the default config object.
+      graphiqlHtml = origGraphiqlHtml
+        ? origGraphiqlHtml.replace(
+            /<\/head>/,
+            `  <script>window.POSTGRAPHILE_CONFIG=${safeJSONStringify({
+              graphqlUrl: `${externalUrlBase}${graphqlRoute}`,
+              streamUrl: options.watchPg ? `${externalUrlBase}${graphqlRoute}/stream` : null,
+              enhanceGraphiql: options.enhanceGraphiql,
+            })};</script>\n  </head>`,
+          )
+        : null;
+    }
     const isGraphqlRoute = pathname === graphqlRoute;
 
     // ========================================================================


### PR DESCRIPTION
Fixes #753 

Removes `absoluteRoutes` which was never officially released. This setting will now throw an error, to let people know we've found a better way.

Auto-sniffs if we're being mounted in Node at a subpath, e.g. using express, so doesn't need the user to do anything in that case.

Typically useful if you run PostGraphile behind a proxy that changes the external URL.