### PR TITLE
fix(graphql): respect GraphQL working draft changes to errors

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "koa-mount": "^4.0.0",
     "nodemon": "^1.11.0",
     "pg-minify": "~0.5.3",
-    "prettier": "^1.13.7",
+    "prettier": "^1.15.2",
     "source-map-support": "^0.4.6",
     "style-loader": "^0.23.0",
     "supertest": "^2.0.1",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -238,17 +238,22 @@ export interface PostGraphileOptions {
 }
 
 export interface GraphQLFormattedErrorExtended {
-  // This is ugly, really I just want `string | void` but apparently TypeScript doesn't support that.
-  [s: string]: ReadonlyArray<SourceLocation> | ReadonlyArray<string | number> | string | void;
   message: string;
   locations: ReadonlyArray<SourceLocation> | void;
   path: ReadonlyArray<string | number> | void;
+  extensions?: {
+    [s: string]: any;
+  };
 }
 
 export type GraphQLErrorExtended = GraphQLError & {
-  hint: string;
-  detail: string;
-  code: string;
+  extensions: {
+    exception: {
+      hint: string;
+      detail: string;
+      code: string;
+    };
+  };
 };
 
 /**

--- a/src/postgraphile/__tests__/postgraphileIntegrationQueries-test.js
+++ b/src/postgraphile/__tests__/postgraphileIntegrationQueries-test.js
@@ -70,8 +70,8 @@ beforeAll(() => {
             fileName === 'classic-ids.graphql'
               ? gqlSchemas.classicIds
               : fileName === 'dynamic-json.graphql'
-                ? gqlSchemas.dynamicJson
-                : gqlSchemas.normal;
+              ? gqlSchemas.dynamicJson
+              : gqlSchemas.normal;
           // Return the result of our GraphQL query.
           return await graphql(gqlSchema, query, null, {
             [$$pgClient]: pgClient,

--- a/src/postgraphile/extendedFormatError.ts
+++ b/src/postgraphile/extendedFormatError.ts
@@ -42,8 +42,19 @@ export function extendedFormatError(
     throw new Error('Received null or undefined error.');
   }
   const originalError = error.originalError as GraphQLErrorExtended;
+  const exceptionDetails = originalError && fields ? pickPgError(originalError, fields) : undefined;
   return {
-    ...(originalError && fields ? pickPgError(originalError, fields) : undefined),
+    // TODO:v5: remove this
+    ...exceptionDetails,
+
+    ...(exceptionDetails
+      ? {
+          // Reference: https://facebook.github.io/graphql/draft/#sec-Errors
+          extensions: {
+            exception: exceptionDetails,
+          },
+        }
+      : null),
     message: error.message,
     locations: error.locations,
     path: error.path,

--- a/src/postgraphile/extendedFormatError.ts
+++ b/src/postgraphile/extendedFormatError.ts
@@ -51,6 +51,7 @@ export function extendedFormatError(
       ? {
           // Reference: https://facebook.github.io/graphql/draft/#sec-Errors
           extensions: {
+            ...originalError.extensions,
             exception: exceptionDetails,
           },
         }

--- a/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
+++ b/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
@@ -3,6 +3,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {
@@ -40,6 +47,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {
@@ -77,6 +91,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {
@@ -114,6 +135,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {
@@ -151,6 +179,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {
@@ -188,6 +223,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {
@@ -225,6 +267,13 @@ Array [
   Object {
     "detail": "test detail",
     "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+    },
     "hint": "test hint",
     "locations": Array [
       Object {

--- a/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
+++ b/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
@@ -1,0 +1,258 @@
+exports[`connect (@/path/to/mount) will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`connect (@/path/to/mount) will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`connect will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`connect will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`express (@/path/to/mount) will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`express (@/path/to/mount) will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`express will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`express will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`http will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`http will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`koa (@/path/to/mount) will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`koa (@/path/to/mount) will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`koa will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`koa will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;

--- a/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
+++ b/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
@@ -9,6 +9,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -28,6 +29,9 @@ Array [
 exports[`connect (@/path/to/mount) will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,
@@ -53,6 +57,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -72,6 +77,9 @@ Array [
 exports[`connect will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,
@@ -97,6 +105,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -116,6 +125,9 @@ Array [
 exports[`express (@/path/to/mount) will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,
@@ -141,6 +153,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -160,6 +173,9 @@ Array [
 exports[`express will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,
@@ -185,6 +201,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -204,6 +221,9 @@ Array [
 exports[`http will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,
@@ -229,6 +249,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -248,6 +269,9 @@ Array [
 exports[`koa (@/path/to/mount) will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,
@@ -273,6 +297,7 @@ Array [
         "errcode": "12345",
         "hint": "test hint",
       },
+      "testingExtensions": true,
     },
     "hint": "test hint",
     "locations": Array [
@@ -292,6 +317,9 @@ Array [
 exports[`koa will report standard error when extendedErrors is not enabled 1`] = `
 Array [
   Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
     "locations": Array [
       Object {
         "column": 2,

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -715,14 +715,17 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
       const server = createServer({
         handleErrors: errors => {
           return errors.map(error => {
-            error.extensions = {
-              exception: {
-                message: 'my custom error message',
-                hint: 'my custom error hint',
-                detail: 'my custom error detail',
+            return {
+              ...error,
+              message: 'my custom error message',
+              extensions: {
+                ...error.extensions,
+                exception: {
+                  hint: 'my custom error hint',
+                  detail: 'my custom error detail',
+                },
               },
             };
-            return error;
           });
         },
       });

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -37,6 +37,7 @@ const gqlSchema = new GraphQLSchema({
         type: GraphQLString,
         resolve: () => {
           const err = new Error('test message');
+          err.extensions = { testingExtensions: true };
           err.detail = 'test detail';
           err.hint = 'test hint';
           err.code = '12345';
@@ -643,6 +644,9 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               message: 'test message',
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
+              extensions: {
+                testingExtensions: true,
+              },
             },
           ],
         });
@@ -665,6 +669,9 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               message: 'test message',
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
+              extensions: {
+                testingExtensions: true,
+              },
             },
           ],
         });
@@ -691,6 +698,7 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
               extensions: {
+                testingExtensions: true,
                 exception: {
                   hint: 'test hint',
                   detail: 'test detail',
@@ -742,6 +750,7 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
               extensions: {
+                testingExtensions: true,
                 exception: {
                   hint: 'my custom error hint',
                   detail: 'my custom error detail',
@@ -771,6 +780,9 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               message: 'test message',
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
+              extensions: {
+                testingExtensions: true,
+              },
             },
           ],
           data: { testError: null },

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -690,6 +690,15 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               message: 'test message',
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
+              extensions: {
+                exception: {
+                  hint: 'test hint',
+                  detail: 'test detail',
+                  errcode: '12345',
+                },
+              },
+
+              // TODO:v5: remove next 3 lines
               hint: 'test hint',
               detail: 'test detail',
               errcode: '12345',
@@ -706,9 +715,13 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
       const server = createServer({
         handleErrors: errors => {
           return errors.map(error => {
-            error.message = 'my custom error message';
-            error.hint = 'my custom error hint';
-            error.detail = 'my custom error detail';
+            error.extensions = {
+              exception: {
+                message: 'my custom error message',
+                hint: 'my custom error hint',
+                detail: 'my custom error detail',
+              },
+            };
             return error;
           });
         },
@@ -725,8 +738,12 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
               message: 'my custom error message',
               locations: [{ line: 1, column: 2 }],
               path: ['testError'],
-              hint: 'my custom error hint',
-              detail: 'my custom error detail',
+              extensions: {
+                exception: {
+                  hint: 'my custom error hint',
+                  detail: 'my custom error detail',
+                },
+              },
             },
           ],
         });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5642,10 +5642,10 @@ preserve@^0.2.0:
   resolved "https://registry.yarnpkg.com/preserve/-/preserve-0.2.0.tgz#815ed1f6ebc65926f865b310c0713bcb3315ce4b"
   integrity sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=
 
-prettier@^1.13.7:
-  version "1.14.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.14.2.tgz#0ac1c6e1a90baa22a62925f41963c841983282f9"
-  integrity sha512-McHPg0n1pIke+A/4VcaS2en+pTNjy4xF+Uuq86u/5dyDO59/TtFZtQ708QIRkEZ3qwKz3GVkVa6mpxK/CpB8Rg==
+prettier@^1.15.2:
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.15.2.tgz#d31abe22afa4351efa14c7f8b94b58bb7452205e"
+  integrity sha512-YgPLFFA0CdKL4Eg2IHtUSjzj/BWgszDHiNQAe0VAIBse34148whfdzLagRL+QiKS+YfK5ftB6X4v/MBw8yCoug==
 
 pretty-error@^2.0.2:
   version "2.1.1"


### PR DESCRIPTION
Updates PostGraphile to respect the latest GraphQL spec, using the `exceptions` property on errors:

https://facebook.github.io/graphql/draft/#sec-Errors

Note: we've kept all the old properties for backwards compatibility but these will be removed in version 5 so we strongly recommend you switch to using the new error.extensions.exception object rather than using error directly.

Fixes #896