### PR TITLE
fix(server): throw when encountering `undefined` positional arguments

### DIFF
--- a/src/postgraphile/__tests__/postgraphile-test.js
+++ b/src/postgraphile/__tests__/postgraphile-test.js
@@ -30,7 +30,6 @@ test('will use a connected client from the pool, the default schema, and options
   createPostGraphileHttpRequestHandler.mockClear();
   const pgPool = new Pool();
   const options = Symbol('options');
-  const pgClient = { release: jest.fn() };
   await postgraphile(pgPool, options);
   expect(createPostGraphileSchema.mock.calls).toEqual([[pgPool, ['public'], options]]);
 });
@@ -82,4 +81,10 @@ test('will watch Postgres schemas when `watchPg` is true', async () => {
 test('will not error if jwtSecret is provided without jwtPgTypeIdentifier', async () => {
   const pgPool = new Pool();
   expect(() => postgraphile(pgPool, [], { jwtSecret: 'test' })).not.toThrow();
+});
+
+test('will throw on undefined positional arguments', async () => {
+  const pgPool = new Pool();
+  expect(() => postgraphile(pgPool, undefined)).toThrow();
+  expect(() => postgraphile(undefined, 'public')).toThrow();
 });

--- a/src/postgraphile/__tests__/postgraphile-test.js
+++ b/src/postgraphile/__tests__/postgraphile-test.js
@@ -85,6 +85,7 @@ test('will not error if jwtSecret is provided without jwtPgTypeIdentifier', asyn
 
 test('will throw on undefined positional arguments', async () => {
   const pgPool = new Pool();
+  expect(() => postgraphile(undefined)).toThrow();
   expect(() => postgraphile(pgPool, undefined)).toThrow();
   expect(() => postgraphile(undefined, 'public')).toThrow();
 });

--- a/src/postgraphile/__tests__/postgraphile-test.js
+++ b/src/postgraphile/__tests__/postgraphile-test.js
@@ -20,7 +20,7 @@ test('will use a connected client from the pool, the schemas, and options to cre
   createPostGraphileHttpRequestHandler.mockClear();
   const pgPool = new Pool();
   const schemas = [Symbol('schemas')];
-  const options = Symbol('options');
+  const options = { $options: Symbol('options') };
   await postgraphile(pgPool, schemas, options);
   expect(createPostGraphileSchema.mock.calls).toEqual([[pgPool, schemas, options]]);
 });
@@ -29,7 +29,7 @@ test('will use a connected client from the pool, the default schema, and options
   createPostGraphileSchema.mockClear();
   createPostGraphileHttpRequestHandler.mockClear();
   const pgPool = new Pool();
-  const options = Symbol('options');
+  const options = { $options: Symbol('options') };
   await postgraphile(pgPool, options);
   expect(createPostGraphileSchema.mock.calls).toEqual([[pgPool, ['public'], options]]);
 });
@@ -85,6 +85,15 @@ test('will not error if jwtSecret is provided without jwtPgTypeIdentifier', asyn
 
 test('will throw on undefined positional arguments', async () => {
   const pgPool = new Pool();
+  const options = { $options: Symbol('options') };
+
+  createPostGraphileSchema.mockClear();
+  expect(() => postgraphile(pgPool, null, options)).not.toThrow();
+  expect(() => postgraphile(pgPool, options)).not.toThrow();
+  expect(createPostGraphileSchema.mock.calls).toEqual([
+    [pgPool, ['public'], options],
+    [pgPool, ['public'], options],
+  ]);
 
   expect(() => postgraphile(null)).not.toThrow();
   expect(() => postgraphile(pgPool, null)).not.toThrow();

--- a/src/postgraphile/__tests__/postgraphile-test.js
+++ b/src/postgraphile/__tests__/postgraphile-test.js
@@ -85,6 +85,11 @@ test('will not error if jwtSecret is provided without jwtPgTypeIdentifier', asyn
 
 test('will throw on undefined positional arguments', async () => {
   const pgPool = new Pool();
+
+  expect(() => postgraphile(null)).not.toThrow();
+  expect(() => postgraphile(pgPool, null)).not.toThrow();
+  expect(() => postgraphile(null, 'public')).not.toThrow();
+
   expect(() => postgraphile(undefined)).toThrow();
   expect(() => postgraphile(pgPool, undefined)).toThrow();
   expect(() => postgraphile(undefined, 'public')).toThrow();

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -121,20 +121,20 @@ export default function postgraphile(
     schema = schemaOrOptions;
     incomingOptions = maybeOptions || {};
   }
-  // If the second argument is the incomingOptions so set `schema` to the
-  // default and `incomingOptions` to the second argument.
+  // If the second argument is null or an object then use default `schema`
+  // and set incomingOptions to second or third argument (or default).
   else if (typeof schemaOrOptions === 'object') {
     schema = 'public';
     incomingOptions = schemaOrOptions || maybeOptions || {};
   }
-  // Otherwise the second argument is undefined, use defaults for both `schema` and
-  // `incomingOptions`.
+  // Otherwise if the second argument is present it's invalid: throw an error.
+  else if (arguments.length > 1) {
+    throw new Error(
+      'The second argument to postgraphile was invalid... did you mean to set a schema?',
+    );
+  }
+  // No schema or options specified, use defaults.
   else {
-    if (arguments.length > 1) {
-      throw new Error(
-        'The second argument to postgraphile was `undefined`... did you mean to set a schema?',
-      );
-    }
     schema = 'public';
     incomingOptions = {};
   }

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -123,9 +123,9 @@ export default function postgraphile(
   }
   // If the second argument is the incomingOptions so set `schema` to the
   // default and `incomingOptions` to the second argument.
-  else if (typeof schemaOrOptions !== 'undefined') {
+  else if (typeof schemaOrOptions === 'object') {
     schema = 'public';
-    incomingOptions = schemaOrOptions || {};
+    incomingOptions = schemaOrOptions || maybeOptions || {};
   }
   // Otherwise the second argument is undefined, use defaults for both `schema` and
   // `incomingOptions`.

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -137,7 +137,7 @@ export default function postgraphile(
     incomingOptions = {};
   }
 
-  if (typeof poolOrConfig === 'undefined' && arguments.length > 1) {
+  if (typeof poolOrConfig === 'undefined' && arguments.length >= 1) {
     throw new Error('The first argument to postgraphile was `undefined`... did you mean to set pool options?');
   }
 

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -131,14 +131,18 @@ export default function postgraphile(
   // `incomingOptions`.
   else {
     if (arguments.length > 1) {
-      throw new Error('The second argument to postgraphile was `undefined`... did you mean to set a schema?');
+      throw new Error(
+        'The second argument to postgraphile was `undefined`... did you mean to set a schema?',
+      );
     }
     schema = 'public';
     incomingOptions = {};
   }
 
   if (typeof poolOrConfig === 'undefined' && arguments.length >= 1) {
-    throw new Error('The first argument to postgraphile was `undefined`... did you mean to set pool options?');
+    throw new Error(
+      'The first argument to postgraphile was `undefined`... did you mean to set pool options?',
+    );
   }
 
   // Do some things with `poolOrConfig` so that in the end, we actually get a

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -125,7 +125,7 @@ export default function postgraphile(
   // default and `incomingOptions` to the second argument.
   else if (typeof schemaOrOptions !== 'undefined') {
     schema = 'public';
-    incomingOptions = schemaOrOptions;
+    incomingOptions = schemaOrOptions || {};
   }
   // Otherwise the second argument is undefined, use defaults for both `schema` and
   // `incomingOptions`.


### PR DESCRIPTION
Fixes #951 

**Note:** I had to manually run `yarn add graphql postgraphile-core` in order to get the tests running on my local machine. For whatever reason these dependencies were not installed with just `yarn`.