### PR TITLE
feat(server): websockets support

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "dev": "./scripts/dev",
     "lint": "./scripts/lint",
     "make-assets": "./scripts/make-assets",
-    "prettier": "prettier 'src/**/*.[tj]s'",
+    "prettier": "prettier 'src/**/*.[tj]s' 'postgraphiql/src/**/*.[tj]s'",
     "prettier:fix": "yarn prettier --write",
     "prettier:check": "yarn prettier --list-different",
     "test": "./scripts/test",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,9 @@
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
     "postgraphile-core": "4.3.1",
-    "tslib": "^1.5.0"
+    "subscriptions-transport-ws": "^0.9.15",
+    "tslib": "^1.5.0",
+    "ws": "^6.1.3"
   },
   "devDependencies": {
     "@babel/core": "7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.3-0",
+  "version": "4.3.3-1",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.2",
+  "version": "4.3.3-0",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/jsonwebtoken": "<7.2.1",
     "@types/koa": "^2.0.44",
     "@types/pg": "^7.4.10",
+    "@types/ws": "^6.0.1",
     "body-parser": "^1.15.2",
     "chalk": "^1.1.3",
     "commander": "^2.19.0",

--- a/postgraphiql/package.json
+++ b/postgraphiql/package.json
@@ -7,8 +7,8 @@
     "graphiql": "npm:@benjie/graphiql@0.12.1-a701b68f61a315280ba3e292275757f37e004ad5",
     "graphiql-explorer": "^0.3.6",
     "graphql": "^14.0.2",
-    "react": "^15.3.2",
-    "react-dom": "^15.3.2",
+    "react": "^16.8.1",
+    "react-dom": "^16.8.1",
     "react-scripts": "^2.1.3"
   },
   "browserslist": [

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -74,6 +74,13 @@ class ExplorerWrapper extends React.PureComponent {
   }
 }
 
+const l = window.location;
+const websocketUrl = POSTGRAPHILE_CONFIG.graphqlUrl.match(/^https?:/)
+  ? POSTGRAPHILE_CONFIG.graphqlUrl.replace(/^http/, 'ws')
+  : `ws${l.protocol === 'https:' ? 's' : ''}://${l.hostname}${
+      l.port !== 80 && l.port !== 443 ? ':' + l.port : ''
+    }${POSTGRAPHILE_CONFIG.graphqlUrl}`;
+
 /**
  * The standard GraphiQL interface wrapped with some PostGraphile extensions.
  * Including a JWT setter and live schema udpate capabilities.
@@ -93,7 +100,7 @@ class PostGraphiQL extends React.PureComponent {
   };
 
   subscriptionsClient = POSTGRAPHILE_CONFIG.subscriptions
-    ? new SubscriptionClient(POSTGRAPHILE_CONFIG.graphqlUrl.replace(/^http/, 'ws'), {
+    ? new SubscriptionClient(websocketUrl, {
         reconnect: true,
       })
     : null;

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -456,29 +456,44 @@ class PostGraphiQL extends React.PureComponent {
   };
 
   renderSocketStatus() {
-    const { haveActiveSubscription, socketStatus, error } = this.state;
+    const { socketStatus, error } = this.state;
     if (socketStatus === null) {
       return null;
     }
     const icon =
       {
         connecting: '🤔',
-        connected: '😀',
-        disconnected: '☹️',
         reconnecting: '😓',
+        connected: '😀',
         reconnected: '😅',
+        disconnected: '☹️',
       }[socketStatus] || '😐';
+    const tick = (
+      <path fill="transparent" stroke="white" d="M30,50 L45,65 L70,30" strokeWidth="8" />
+    );
+    const cross = (
+      <path fill="transparent" stroke="white" d="M30,30 L70,70 M30,70 L70,30" strokeWidth="8" />
+    );
+    const decoration =
+      {
+        connecting: null,
+        reconnecting: null,
+        connected: tick,
+        reconnected: tick,
+        disconnected: cross,
+      }[socketStatus] || null;
     const color =
       {
         connected: 'green',
         reconnected: 'green',
-        connecting: 'amber',
-        reconnecting: 'amber',
+        connecting: 'orange',
+        reconnecting: 'orange',
         disconnected: 'red',
       }[socketStatus] || 'gray';
     const svg = (
       <svg width="25" height="25" viewBox="0 0 100 100" style={{ marginTop: 4 }}>
         <circle fill={color} cx="50" cy="50" r="45" />
+        {decoration}
       </svg>
     );
     return (

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -225,6 +225,7 @@ class PostGraphiQL extends React.PureComponent {
     } catch (e) {
       // Do nothing
     }
+    return extraHeaders;
   }
 
   /**

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -182,7 +182,7 @@ class PostGraphiQL extends React.PureComponent {
         'error',
         error => {
           // tslint:disable-next-line no-console
-          console.error('PostGraphile: Failed to connect to event stream');
+          console.error('PostGraphile: Failed to connect to event stream', error);
           this.setState({ error: new Error('Failed to connect to event stream') });
         },
         false,

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -471,6 +471,19 @@ class PostGraphiQL extends React.PureComponent {
         reconnecting: '😓',
         reconnected: '😅',
       }[socketStatus] || '😐';
+    const color =
+      {
+        connected: 'green',
+        reconnected: 'green',
+        connecting: 'amber',
+        reconnecting: 'amber',
+        disconnected: 'red',
+      }[socketStatus] || 'gray';
+    const svg = (
+      <svg width="25" height="25" viewBox="0 0 100 100" style={{ marginTop: 4 }}>
+        <circle fill={color} cx="50" cy="50" r="45" />
+      </svg>
+    );
     return (
       <>
         {error ? (
@@ -490,7 +503,7 @@ class PostGraphiQL extends React.PureComponent {
           onClick={this.cancelSubscription}
         >
           <span aria-label={socketStatus} role="img">
-            {icon}
+            {svg || icon}
           </span>
         </div>
       </>

--- a/postgraphiql/src/components/postgraphiql.css
+++ b/postgraphiql/src/components/postgraphiql.css
@@ -54,3 +54,7 @@
 .resultWrap {
   width: 5rem;
 }
+
+.postgraphiql-container .toolbar {
+  align-items: center;
+}

--- a/postgraphiql/yarn.lock
+++ b/postgraphiql/yarn.lock
@@ -1343,7 +1343,7 @@ arrify@^1.0.0, arrify@^1.0.1:
   resolved "https://registry.yarnpkg.com/arrify/-/arrify-1.0.1.tgz#898508da2226f380df904728456849c1501a4b0d"
   integrity sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
 
-asap@~2.0.3, asap@~2.0.6:
+asap@~2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
   integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
@@ -2500,11 +2500,6 @@ core-js@2.5.7, core-js@^2.4.0, core-js@^2.5.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.5.7.tgz#f972608ff0cead68b841a16a932d0b183791814e"
   integrity sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-util-is@1.0.2, core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -2560,15 +2555,6 @@ create-hmac@^1.1.0, create-hmac@^1.1.2, create-hmac@^1.1.4:
     ripemd160 "^2.0.0"
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
-
-create-react-class@^15.6.0:
-  version "15.6.3"
-  resolved "https://registry.yarnpkg.com/create-react-class/-/create-react-class-15.6.3.tgz#2d73237fb3f970ae6ebe011a9e66f46dbca80036"
-  integrity sha512-M+/3Q6E6DLO6Yx3OwrWjwHBnvfXXYA7W+dFjt/ZDBemHO1DDZhsalX/NUtnTYclN6GfnBDRh4qRHjcDHmlJBJg==
-  dependencies:
-    fbjs "^0.8.9"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
 
 cross-fetch@2.2.2:
   version "2.2.2"
@@ -3232,13 +3218,6 @@ encodeurl@~1.0.2:
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
 
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
-
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/end-of-stream/-/end-of-stream-1.4.1.tgz#ed29634d19baba463b6ce6b80a37213eab71ec43"
@@ -3810,19 +3789,6 @@ fb-watchman@^2.0.0:
   integrity sha1-VOmr99+i8mzZsWNsWIwa/AXeXVg=
   dependencies:
     bser "^2.0.0"
-
-fbjs@^0.8.9:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
 
 figgy-pudding@^3.5.1:
   version "3.5.1"
@@ -4731,7 +4697,7 @@ iconv-lite@0.4.23:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@^0.4.4:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5233,7 +5199,7 @@ is-root@2.0.0:
   resolved "https://registry.yarnpkg.com/is-root/-/is-root-2.0.0.tgz#838d1e82318144e5a6f77819d90207645acc7019"
   integrity sha512-F/pJIk8QD6OX5DNhRB7hWamLsUilmkDGho48KbgZ6xg/lmAZXHxzXQ91jzB3yRSw5kdQGGGc4yz8HYhTYIMWPg==
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -5305,14 +5271,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -6615,14 +6573,6 @@ node-fetch@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.1.2.tgz#ab884e8e7e57e38a944753cec706f788d1768bb5"
   integrity sha1-q4hOjn5X44qUR1POxwb3iNF2i7U=
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.7.5:
   version "0.7.5"
@@ -7974,13 +7924,6 @@ promise@8.0.2:
   dependencies:
     asap "~2.0.6"
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^0.1.9:
   version "0.1.14"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-0.1.14.tgz#a8e15c612c5c9ec8f8111847df3337c9cbd443b2"
@@ -7989,7 +7932,7 @@ prompts@^0.1.9:
     kleur "^2.0.1"
     sisteransi "^0.1.1"
 
-prop-types@^15.5.10, prop-types@^15.6.2:
+prop-types@^15.6.2:
   version "15.6.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.2.tgz#05d5ca77b4453e985d60fc7ff8c859094a497102"
   integrity sha512-3pboPvLiWD7dkI3qf3KbUe6hKFKa52w+AE0VCqECtf+QHAKgOL37tTaNCnuX1nAAQ4ZhyP+kYVKf8rLmJ/feDQ==
@@ -8199,15 +8142,15 @@ react-dev-utils@^7.0.1:
     strip-ansi "4.0.0"
     text-table "0.2.0"
 
-react-dom@^15.3.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.6.2.tgz#41cfadf693b757faf2708443a1d1fd5a02bef730"
-  integrity sha1-Qc+t9pO3V/rycIRDodH9WgK+9zA=
+react-dom@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.8.1.tgz#ec860f98853d09d39bafd3a6f1e12389d283dbb4"
+  integrity sha512-N74IZUrPt6UiDjXaO7UbDDFXeUXnVhZzeRLy/6iqqN1ipfjrhR60Bp5NuBK+rv3GMdqdIuwIl22u1SYwf330bg==
   dependencies:
-    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.1"
 
 react-error-overlay@^5.1.2:
   version "5.1.2"
@@ -8269,16 +8212,15 @@ react-scripts@^2.1.3:
   optionalDependencies:
     fsevents "1.2.4"
 
-react@^15.3.2:
-  version "15.6.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.6.2.tgz#dba0434ab439cfe82f108f0f511663908179aa72"
-  integrity sha1-26BDSrQ5z+gvEI8PURZjkIF5qnI=
+react@^16.8.1:
+  version "16.8.1"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.8.1.tgz#ae11831f6cb2a05d58603a976afc8a558e852c4a"
+  integrity sha512-wLw5CFGPdo7p/AgteFz7GblI2JPOos0+biSoxf1FPsGxWQZdN/pj6oToJs1crn61DL3Ln7mN86uZ4j74p31ELQ==
   dependencies:
-    create-react-class "^15.6.0"
-    fbjs "^0.8.9"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
-    prop-types "^15.5.10"
+    object-assign "^4.1.1"
+    prop-types "^15.6.2"
+    scheduler "^0.13.1"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -8748,6 +8690,14 @@ saxes@^3.1.4:
   dependencies:
     xmlchars "^1.3.1"
 
+scheduler@^0.13.1:
+  version "0.13.1"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.13.1.tgz#1a217df1bfaabaf4f1b92a9127d5d732d85a9591"
+  integrity sha512-VJKOkiKIN2/6NOoexuypwSrybx13MY7NSy9RNt8wPvZDMRT1CW6qlpF5jXRToXNHz3uWzbm2elNpZfXfGPqP9A==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^0.4.4, schema-utils@^0.4.5:
   version "0.4.7"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-0.4.7.tgz#ba74f597d2be2ea880131746ee17d0a093c68187"
@@ -8854,7 +8804,7 @@ set-value@^2.0.0:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -9629,11 +9579,6 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-ua-parser-js@^0.7.18:
-  version "0.7.19"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.19.tgz#94151be4c0a7fb1d001af7022fdaca4642659e4b"
-  integrity sha512-T3PVJ6uz8i0HzPxOF9SWzWAlfN/DavlpQqepn22xgve/5QecC+XMCAtmUNnY7C9StehaV6exjUCI801lOI7QlQ==
-
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/uc.micro/-/uc.micro-1.0.5.tgz#0c65f15f815aa08b560a61ce8b4db7ffc3f45376"
@@ -10055,7 +10000,7 @@ whatwg-fetch@2.0.4:
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-2.0.4.tgz#dde6a5df315f9d39991aa17621853d720b85566f"
   integrity sha512-dcQ1GWpOD/eEQ97k66aiEVpNnapVj90/+R+SXTPYGHpYBBypfKJEQjLrvMZ7YXbKm21gXd4NcuxUTjiv1YtLng==
 
-whatwg-fetch@3.0.0, whatwg-fetch@>=0.10.0:
+whatwg-fetch@3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
   integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -381,6 +381,7 @@ const overridesFromOptions = {};
 const {
   demo: isDemo = false,
   connection: pgConnectionString,
+  subscriptions,
   watch: watchPg,
   schema: dbSchema,
   host: hostname = 'localhost',
@@ -557,6 +558,7 @@ const postgraphileOptions = pluginHook(
     jwtRole,
     jwtVerifyOptions,
     pgDefaultRole,
+    subscriptions,
     watchPg,
     showErrorStack,
     extendedErrors,

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -404,6 +404,7 @@ export default function createPostGraphileHttpRequestHandler(
               graphqlUrl: `${externalUrlBase}${graphqlRoute}`,
               streamUrl: options.watchPg ? `${externalUrlBase}${graphqlRoute}/stream` : null,
               enhanceGraphiql: options.enhanceGraphiql,
+              subscriptions: !!options.subscriptions,
             })};</script>\n  </head>`,
           )
         : null;

--- a/src/postgraphile/http/setupServerSentEvents.ts
+++ b/src/postgraphile/http/setupServerSentEvents.ts
@@ -1,7 +1,7 @@
 /* tslint:disable:no-any */
 import { PassThrough } from 'stream';
 import { IncomingMessage, ServerResponse } from 'http';
-import { CreateRequestHandlerOptions } from './createPostGraphileHttpRequestHandler';
+import { CreateRequestHandlerOptions } from '../../interfaces';
 
 export default function setupServerSentEvents(
   req: IncomingMessage,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -3,7 +3,6 @@ import { HttpRequestHandler, mixed } from '../../interfaces';
 import { subscribe, ExecutionResult } from 'graphql';
 import { RequestHandler, Request, Response } from 'express';
 import * as WebSocket from 'ws';
-import { parse } from 'url';
 import { SubscriptionServer, ConnectionContext } from 'subscriptions-transport-ws';
 import parseUrl = require('parseurl');
 

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -1,0 +1,201 @@
+import { Server, ServerResponse } from 'http';
+import { HttpRequestHandler, mixed } from '../../interfaces';
+import { execute, subscribe, ExecutionResult } from 'graphql';
+import { RequestHandler, Request, Response } from 'express';
+import * as WebSocket from 'ws';
+import { parse } from 'url';
+import { SubscriptionServer, ConnectionContext } from 'subscriptions-transport-ws';
+
+interface Deferred<T> extends Promise<T> {
+  resolve: (input?: T | PromiseLike<T> | undefined) => void;
+  reject: (error: Error) => void;
+}
+
+function lowerCaseKeys(obj: object): object {
+  return Object.keys(obj).reduce((memo, key) => {
+    memo[key.toLowerCase()] = obj[key];
+    return memo;
+  }, {});
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve: (input?: T | PromiseLike<T> | undefined) => void;
+  let reject: (error: Error) => void;
+  const promise = new Promise<T>((_resolve, _reject) => {
+    resolve = _resolve;
+    reject = _reject;
+  });
+  // tslint:disable-next-line prefer-object-spread
+  return Object.assign(promise, {
+    // @ts-ignore This isn't used before being defined.
+    resolve,
+    // @ts-ignore This isn't used before being defined.
+    reject,
+  });
+}
+
+export async function enhanceHttpServerWithSubscriptions(
+  websocketServer: Server,
+  postgraphileMiddleware: HttpRequestHandler,
+) {
+  if (websocketServer['__postgraphileSubscriptionsEnabled']) {
+    return;
+  }
+  websocketServer['__postgraphileSubscriptionsEnabled'] = true;
+  const {
+    options,
+    getGraphQLSchema,
+    withPostGraphileContextFromReqRes,
+    handleErrors,
+  } = postgraphileMiddleware;
+  const graphqlRoute = options.graphqlRoute || '/graphql';
+
+  const schema = await getGraphQLSchema();
+
+  const contextKeepalivePromisesByOpId = {};
+
+  const contextKey = (ws: WebSocket, opId: string) => ws['postgraphileId'] + '|' + opId;
+
+  const releaseContextByOpId = (ws: WebSocket, opId: string) => {
+    const promise = contextKeepalivePromisesByOpId[contextKey(ws, opId)];
+    if (promise) {
+      promise.resolve();
+    }
+  };
+
+  const addContextForOpId = (context: mixed, ws: WebSocket, opId: string) => {
+    releaseContextByOpId(ws, opId);
+    const promise = deferred();
+    promise['context'] = context;
+    contextKeepalivePromisesByOpId[contextKey(ws, opId)] = promise;
+    return promise;
+  };
+
+  const applyMiddleware = async (
+    middlewares: Array<RequestHandler> = [],
+    req: Request,
+    res: Response,
+  ) => {
+    for (const middleware of middlewares) {
+      await new Promise((resolve, reject) => {
+        middleware(req, res, err => (err ? reject(err) : resolve()));
+      });
+    }
+  };
+
+  const reqResFromSocket = async (socket: WebSocket) => {
+    const req = socket['__postgraphileReq'];
+    if (!req) {
+      throw new Error('req could not be extracted');
+    }
+    let dummyRes = socket['__postgraphileRes'];
+    if (req.res) {
+      throw new Error(
+        "Please get in touch with Benjie; we weren't expecting req.res to be present but we want to reserve it for future usage.",
+      );
+    }
+    if (!dummyRes) {
+      dummyRes = new ServerResponse(req);
+      dummyRes.writeHead = (statusCode: number, statusMessage: never, headers: never) => {
+        if (statusMessage || headers) {
+          throw new Error(
+            'Passing more than the statusCode to writeHead is not supported with websockets currently',
+          );
+        }
+        if (statusCode && statusCode > 200) {
+          // tslint:disable-next-line no-console
+          console.error(
+            `Something used 'writeHead' to write a '${statusCode}' error for websockets - check the middleware you're passing!`,
+          );
+          socket.close();
+        }
+      };
+      await applyMiddleware(options.websocketMiddlewares || options.middlewares, req, dummyRes);
+      socket['__postgraphileRes'] = dummyRes;
+    }
+    return { req, res: dummyRes };
+  };
+
+  const getContext = (socket: WebSocket, opId: string) => {
+    return new Promise((resolve, reject) => {
+      reqResFromSocket(socket)
+        .then(({ req, res }) =>
+          withPostGraphileContextFromReqRes(req, res, { singleStatement: true }, context => {
+            const promise = addContextForOpId(context, socket, opId);
+            resolve(promise['context']);
+            return promise;
+          }),
+        )
+        .then(null, reject);
+    });
+  };
+
+  const wss = new WebSocket.Server({ noServer: true });
+
+  websocketServer.on('upgrade', (req, socket, head) => {
+    const url = req.originalUrl || req.url;
+    const path = parse(url).pathname;
+    if (path === graphqlRoute) {
+      wss.handleUpgrade(req, socket, head, ws => {
+        wss.emit('connection', ws, req);
+      });
+    }
+  });
+
+  SubscriptionServer.create(
+    {
+      schema,
+      execute,
+      subscribe,
+      onConnect(
+        connectionParams: object,
+        _socket: WebSocket,
+        connectionContext: ConnectionContext,
+      ) {
+        const { socket, request } = connectionContext;
+        if (!request) {
+          throw new Error('No request!');
+        }
+        request['connectionParams'] = connectionParams;
+        const normalizedConnectionParams = Object.keys(connectionParams).reduce((memo, key) => {
+          memo[key.toLowerCase()] = connectionParams[key];
+          return memo;
+        }, {});
+        request['normalizedConnectionParams'] = normalizedConnectionParams;
+        socket['__postgraphileReq'] = request;
+        if (!request.headers.authorization && normalizedConnectionParams['authorization']) {
+          request.headers.authorization = String(normalizedConnectionParams['authorization']);
+        }
+
+        socket['postgraphileHeaders'] = {
+          ...lowerCaseKeys(connectionParams),
+          ...request.headers,
+        };
+      },
+      // tslint:disable-next-line no-any
+      async onOperation(message: any, params: any, socket: WebSocket) {
+        const opId = message.id;
+        const context = await getContext(socket, opId);
+
+        // Override schema (for --watch)
+        params.schema = await getGraphQLSchema();
+
+        Object.assign(params.context, context);
+
+        const { req, res } = await reqResFromSocket(socket);
+        const formatResponse = (response: ExecutionResult) => {
+          if (response.errors) {
+            response.errors = handleErrors(response.errors, req, res);
+          }
+          return response;
+        };
+        params.formatResponse = formatResponse;
+        return params;
+      },
+      onOperationComplete(socket: WebSocket, opId: string) {
+        releaseContextByOpId(socket, opId);
+      },
+    },
+    wss,
+  );
+}

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -192,7 +192,14 @@ export async function enhanceHttpServerWithSubscriptions(
           return response;
         };
         params.formatResponse = formatResponse;
-        return params;
+        return options.pluginHook
+          ? options.pluginHook('postgraphile:ws:onOperation', params, {
+              message,
+              params,
+              socket,
+              options,
+            })
+          : params;
       },
       onOperationComplete(socket: WebSocket, opId: string) {
         releaseContextByOpId(socket, opId);

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -1,6 +1,6 @@
 import { Server, ServerResponse } from 'http';
 import { HttpRequestHandler, mixed } from '../../interfaces';
-import { execute, subscribe, ExecutionResult } from 'graphql';
+import { subscribe, ExecutionResult } from 'graphql';
 import { RequestHandler, Request, Response } from 'express';
 import * as WebSocket from 'ws';
 import { parse } from 'url';
@@ -145,7 +145,9 @@ export async function enhanceHttpServerWithSubscriptions(
   SubscriptionServer.create(
     {
       schema,
-      execute,
+      execute: () => {
+        throw new Error('Only subscriptions are allowed over websocket transport');
+      },
       subscribe,
       onConnect(
         connectionParams: object,

--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -4,6 +4,7 @@ import { HttpRequestHandler, PostGraphileOptions } from '../interfaces';
 import { WithPostGraphileContextFn } from './withPostGraphileContext';
 import { version } from '../../package.json';
 import * as graphql from 'graphql';
+import { ExecutionParams } from 'subscriptions-transport-ws';
 
 export type HookFn<T> = (arg: T, context: {}) => T;
 export type PluginHookFn = <TArgument, TContext = {}>(
@@ -51,6 +52,7 @@ export interface PostGraphilePlugin {
   'postgraphile:httpParamsList'?: HookFn<Array<object>>;
   'postgraphile:validationRules'?: HookFn<ReadonlyArray<typeof graphql.specifiedRules>>; // AVOID THIS where possible; use 'postgraphile:validationRules:static' instead.
   'postgraphile:middleware'?: HookFn<HttpRequestHandler>;
+  'postgraphile:ws:onOperation'?: HookFn<ExecutionParams>;
 
   withPostGraphileContext?: HookFn<WithPostGraphileContextFn>;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -869,6 +869,14 @@
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
 
+"@types/ws@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@types/ws/-/ws-6.0.1.tgz#ca7a3f3756aa12f62a0a62145ed14c6db25d5a28"
+  integrity sha512-EzH8k1gyZ4xih/MaZTXwT2xOkPiIMSrhQ9b8wrlX88L0T02eYsddatQlwVFlEPyEqV0ChpdpNnE51QPH6NVT4Q==
+  dependencies:
+    "@types/events" "*"
+    "@types/node" "*"
+
 "@webassemblyjs/ast@1.5.13":
   version "1.5.13"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.5.13.tgz#81155a570bd5803a30ec31436bc2c9c0ede38f25"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1286,6 +1286,11 @@ async-each@^1.0.0:
   resolved "https://registry.yarnpkg.com/async-each/-/async-each-1.0.1.tgz#19d386a1d9edc6e7c1c85d388aedbcc56d33602d"
   integrity sha1-GdOGodntxufByF04iu28xW0zYC0=
 
+async-limiter@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
+  integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
+
 async@^1.4.0, async@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
@@ -1491,6 +1496,11 @@ babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
   integrity sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==
+
+backo2@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/backo2/-/backo2-1.0.2.tgz#31ab1ac8b129363463e35b3ebb69f4dfcfba7947"
+  integrity sha1-MasayLEpNjRj41s+u2n038+6eUc=
 
 balanced-match@^1.0.0:
   version "1.0.0"
@@ -2744,6 +2754,11 @@ event-stream@~3.3.0:
     split "0.3"
     stream-combiner "~0.0.4"
     through "~2.3.1"
+
+eventemitter3@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.0.tgz#090b4d6cdbd645ed10bf750d4b5407942d7ba163"
+  integrity sha512-ivIvhpq/Y0uSjcHDcOIccjmYjGLcP09MFGE7ysAwkAvkXfpZlC985pH2/ui64DKazbTW/4kN3yqozUxlXzI6cA==
 
 events@^1.0.0:
   version "1.1.1"
@@ -4052,7 +4067,7 @@ istanbul-reports@^1.3.0:
   dependencies:
     handlebars "^4.0.3"
 
-iterall@^1.2.2:
+iterall@^1.2.1, iterall@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.2.2.tgz#92d70deb8028e0c39ff3164fdbf4d8b088130cd7"
   integrity sha512-yynBb1g+RFUPY64fTrFv7nsjRrENBQJaX2UL+2Szc9REFrSNm1rpSXHGzhmAy7a9uv3vlvgBlXnf9RqmPH1/DA==
@@ -6789,6 +6804,17 @@ style-loader@^0.23.0:
     loader-utils "^1.1.0"
     schema-utils "^0.4.5"
 
+subscriptions-transport-ws@^0.9.15:
+  version "0.9.15"
+  resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.15.tgz#68a8b7ba0037d8c489fb2f5a102d1494db297d0d"
+  integrity sha512-f9eBfWdHsePQV67QIX+VRhf++dn1adyC/PZHP6XI5AfKnZ4n0FW+v5omxwdHVpd4xq2ZijaHEcmlQrhBY79ZWQ==
+  dependencies:
+    backo2 "^1.0.2"
+    eventemitter3 "^3.1.0"
+    iterall "^1.2.1"
+    symbol-observable "^1.0.4"
+    ws "^5.2.0"
+
 superagent@^2.0.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/superagent/-/superagent-2.3.0.tgz#703529a0714e57e123959ddefbce193b2e50d115"
@@ -6831,6 +6857,11 @@ supports-color@^5.2.0, supports-color@^5.3.0, supports-color@^5.4.0:
   integrity sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==
   dependencies:
     has-flag "^3.0.0"
+
+symbol-observable@^1.0.4:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
+  integrity sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
 
 symbol-tree@^3.2.1:
   version "3.2.2"
@@ -7530,6 +7561,20 @@ write-file-atomic@^2.0.0:
     graceful-fs "^4.1.11"
     imurmurhash "^0.1.4"
     signal-exit "^3.0.2"
+
+ws@^5.2.0:
+  version "5.2.2"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
+  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  dependencies:
+    async-limiter "~1.0.0"
+
+ws@^6.1.3:
+  version "6.1.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-6.1.3.tgz#d2d2e5f0e3c700ef2de89080ebc0ac6e1bf3a72d"
+  integrity sha512-tbSxiT+qJI223AP4iLfQbkbxkwdFcneYinM2+x46Gx2wgvbaOMO36czfdfVUBRTHvzAMRhDd98sA5d/BuWbQdg==
+  dependencies:
+    async-limiter "~1.0.0"
 
 xdg-basedir@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
Enables people to experiment with their own subscription implementations without needing to use an alternative server.

![graphiql-subscriptions](https://user-images.githubusercontent.com/129910/52291990-9a641300-296b-11e9-9b5d-224d1107a446.gif)

- [x] Don't stop subscription for watch-mode / introspection
- [x] Don't allow non-subscriptions over websockets (by default)
- [x] Handle errors from subscriptions
- [x] Check headers work over queries and subscriptions