### PR TITLE
fix(debug): be more careful when monkey-patching

### DIFF
--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -368,27 +368,37 @@ function debugPgClient(pgClient: PoolClient): PoolClient {
         debugPgErrorObject(debugPgNotice, msg);
       });
     }
+    const logError = (error: PgNotice | Error) => {
+      if (error.name && error['severity']) {
+        debugPgErrorObject(debugPgError, error as PgNotice);
+      } else {
+        debugPgError('%O', error);
+      }
+    };
 
     if (debugPg.enabled || debugPgError.enabled) {
       // tslint:disable-next-line only-arrow-functions
       pgClient.query = function(...args: Array<any>): any {
-        // Debug just the query text. We don’t want to debug variables because
-        // there may be passwords in there.
-        debugPg('%s', formatSQLForDebugging(args[0] && args[0].text ? args[0].text : args[0]));
+        const [a, b, c] = args;
+        // If we understand it (and it uses the promises API), log it out
+        if (
+          (typeof a === 'string' && !c && (!b || Array.isArray(b))) ||
+          (typeof a === 'object' && !b && !c)
+        ) {
+          // Debug just the query text. We don’t want to debug variables because
+          // there may be passwords in there.
+          debugPg('%s', formatSQLForDebugging(a && a.text ? a.text : a));
 
-        // tslint:disable-next-line no-invalid-this
-        const promiseResult = pgClient[$$pgClientOrigQuery].apply(this, args);
+          const promiseResult = pgClient[$$pgClientOrigQuery].apply(this, args);
 
-        // Report the error with our Postgres debugger.
-        promiseResult.catch((error: PgNotice | Error) => {
-          if (error.name && error['severity']) {
-            debugPgErrorObject(debugPgError, error as PgNotice);
-          } else {
-            debugPgError('%O', error);
-          }
-        });
+          // Report the error with our Postgres debugger.
+          promiseResult.catch(logError);
 
-        return promiseResult;
+          return promiseResult;
+        } else {
+          // We don't understand it (e.g. `pgPool.query`), just let it happen.
+          return pgClient[$$pgClientOrigQuery].apply(this, args);
+        }
       };
     }
   }


### PR DESCRIPTION
Previously a call to `pgPool.query` (in the user's code) would throw an error when some `DEBUG` variables were set:

```
/usr/src/app/node_modules/postgraphile/build/postgraphile/withPostGraphileContext.js:250
                promiseResult.catch((error) => {
                              ^

TypeError: Cannot read property 'catch' of undefined
    at Client.pgClient.query (/usr/src/app/node_modules/postgraphile/build/postgraphile/withPostGraphileContext.js:250:31)
    at PendingItem.connect [as callback] (/usr/src/app/node_modules/pg-pool/index.js:294:14)
    at Pool._pulseQueue (/usr/src/app/node_modules/pg-pool/index.js:142:21)
    at process.nextTick (/usr/src/app/node_modules/pg-pool/index.js:178:37)
    at _combinedTickCallback (internal/process/next_tick.js:132:7)
    at process._tickDomainCallback (internal/process/next_tick.js:219:9)
error Command failed with exit code 1.
```

This PR means we're more careful with what we can handle, everything else gets passed through without debugging.