### PR TITLE
fix(postgraphile): check pgConfig constructor's function, not its name

### DIFF
--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -198,6 +198,16 @@ function hasPoolConstructor(obj: mixed): boolean {
   );
 }
 
+function constructorName(obj: mixed): string | null {
+  return (
+    (obj &&
+      typeof obj.constructor === 'function' &&
+      obj.constructor.name &&
+      String(obj.constructor.name)) ||
+    null
+  );
+}
+
 // tslint:disable-next-line no-any
 function toPgPool(poolOrConfig: any): Pool {
   if (quacksLikePgPool(poolOrConfig)) {
@@ -218,11 +228,13 @@ function toPgPool(poolOrConfig: any): Pool {
 
 // tslint:disable-next-line no-any
 function quacksLikePgPool(pgConfig: any): pgConfig is Pool {
-  if (pgConfig instanceof Pool || pgConfig instanceof EventEmitter) return true;
+  if (pgConfig instanceof Pool) return true;
+  if (hasPoolConstructor(pgConfig)) return true;
 
   // A diagnosis of exclusion
   if (!pgConfig || typeof pgConfig !== 'object') return false;
-  if (!hasPoolConstructor(pgConfig)) return false;
+  if (constructorName(pgConfig) !== 'Pool' && constructorName(pgConfig) !== 'BoundPool')
+    return false;
   if (!pgConfig['Client']) return false;
   if (!pgConfig['options']) return false;
   if (typeof pgConfig['connect'] !== 'function') return false;

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -192,10 +192,7 @@ function handleFatalError(error: Error, when: string): never {
 
 function hasPoolConstructor(obj: mixed): boolean {
   return (
-    (obj &&
-      typeof obj.constructor === 'function' &&
-      obj.constructor === (Pool as any).super_
-    ) ||
+    (obj && typeof obj.constructor === 'function' && obj.constructor === (Pool as any).super_) ||
     false
   );
 }
@@ -220,7 +217,7 @@ function toPgPool(poolOrConfig: any): Pool {
 
 // tslint:disable-next-line no-any
 function quacksLikePgPool(pgConfig: any): pgConfig is Pool {
-  if ((pgConfig instanceof Pool) || (pgConfig instanceof EventEmitter)) return true;
+  if (pgConfig instanceof Pool || pgConfig instanceof EventEmitter) return true;
 
   // A diagnosis of exclusion
   if (!pgConfig || typeof pgConfig !== 'object') return false;

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -190,13 +190,13 @@ function handleFatalError(error: Error, when: string): never {
   return null as never;
 }
 
-function constructorName(obj: mixed): string | null {
+function hasPoolConstructor(obj: mixed): boolean {
   return (
     (obj &&
       typeof obj.constructor === 'function' &&
-      obj.constructor.name &&
-      String(obj.constructor.name)) ||
-    null
+      obj.constructor === (Pool as any).super_
+    ) ||
+    false
   );
 }
 
@@ -220,12 +220,11 @@ function toPgPool(poolOrConfig: any): Pool {
 
 // tslint:disable-next-line no-any
 function quacksLikePgPool(pgConfig: any): pgConfig is Pool {
-  if (pgConfig instanceof Pool) return true;
+  if ((pgConfig instanceof Pool) || (pgConfig instanceof EventEmitter)) return true;
 
   // A diagnosis of exclusion
   if (!pgConfig || typeof pgConfig !== 'object') return false;
-  if (constructorName(pgConfig) !== 'Pool' && constructorName(pgConfig) !== 'BoundPool')
-    return false;
+  if (!hasPoolConstructor(pgConfig)) return false;
   if (!pgConfig['Client']) return false;
   if (!pgConfig['options']) return false;
   if (typeof pgConfig['connect'] !== 'function') return false;

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -192,6 +192,7 @@ function handleFatalError(error: Error, when: string): never {
 
 function hasPoolConstructor(obj: mixed): boolean {
   return (
+    // tslint:disable-next-line no-any
     (obj && typeof obj.constructor === 'function' && obj.constructor === (Pool as any).super_) ||
     false
   );


### PR DESCRIPTION
This is a bug that occurs when you plug in a pg.Pool into the postgraphile middleware while using webpack's uglify. The "quacksLikePgPool" check fails in 2 places and the postgraphile middleware never runs.

First, ```(pgConfig instanceof Pool)``` at https://github.com/graphile/postgraphile/blob/577c1e6df08ebe47e8880665ce99580cf7d375a7/src/postgraphile/postgraphile.ts#L223 is always false, as far as I can tell. Right now the passing comparison would be ```(pgConfig instanceof Pool.super_)```. I included both checks for the sake of future-proofing when node-postgres decides to change how it handles subclasses. https://github.com/brianc/node-postgres/issues/1612 and https://github.com/brianc/node-postgres/pull/1541

Second, the check `(constructorName(pgConfig) !== 'Pool' && constructorName(pgConfig) !== 'BoundPool')` will always fail when we use the uglify plugin for webpack, because uglify eliminates subclass names. https://github.com/webpack-contrib/uglifyjs-webpack-plugin/issues/269. The Uglify team does not consider this a bug, and recommends comparing constructor functions rather than names.

> @anatoly314 writing `this.constructor.name === 'Parent'` is evil, because you don't test if the `constructor` of ` this` the same as the of of `Parent`, you only test if the names are equal. The `this.constructor === Parent` does not test for the name but for the actual function, and thats the only correct way to do a reliable test.

So instead of comparing constructor names in quacksLikePgPool ```(constructorName(pgConfig) !== 'Pool' && constructorName(pgConfig) !== 'BoundPool')``` at https://github.com/graphile/postgraphile/blob/577c1e6df08ebe47e8880665ce99580cf7d375a7/src/postgraphile/postgraphile.ts#L227,  I proposed a change to compare the actual constructor function ```obj.constructor === Pool.super_```. Typescript does not recognize that `super_` is a property of `Pool`, so I casted it as an `any` type.

Basically, this fix will give users the options of plugging in a pg.Pool into the middleware while using uglify.