### PR TITLE
feat(graphql): subscriptions and live queries enhancements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+src/assets/

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-alpha.3",
+  "version": "4.3.4-alpha.4",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.2-alpha.0",
+    "postgraphile-core": "4.3.2-alpha.3",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-rc.0",
+  "version": "4.3.4-alpha.0",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.1",
+    "postgraphile-core": "4.3.2-alpha.0",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-beta.1",
+  "version": "4.4.0-alpha.0",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.2-alpha.6",
+    "postgraphile-core": "4.3.2-beta.0",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-alpha.1",
+  "version": "4.3.4-alpha.2",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-alpha.5",
+  "version": "4.3.4-beta.0",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.2-alpha.4",
+    "postgraphile-core": "4.3.2-alpha.5",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.2-beta.0",
+    "postgraphile-core": "4.4.0-alpha.0",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-alpha.4",
+  "version": "4.3.4-alpha.5",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-beta.0",
+  "version": "4.3.4-beta.1",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.2-alpha.5",
+    "postgraphile-core": "4.3.2-alpha.6",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-alpha.2",
+  "version": "4.3.4-alpha.3",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^0.1.3",
     "pg-sql2": "^2.2.1",
-    "postgraphile-core": "4.3.2-alpha.3",
+    "postgraphile-core": "4.3.2-alpha.4",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "postgraphile",
-  "version": "4.3.4-alpha.0",
+  "version": "4.3.4-alpha.1",
   "description": "A GraphQL schema created by reflection over a PostgreSQL schema 🐘 (previously known as PostGraphQL)",
   "author": "Benjie Gillam <benjie@graphile.org> (https://twitter.com/benjie)",
   "license": "MIT",

--- a/sponsors.json
+++ b/sponsors.json
@@ -11,6 +11,8 @@
   "DOMONDA",
   "DOMONDA",
   "Dan Lynch",
+  "Daniel Einspanjer",
+  "Daniel Einspanjer",
   "Gardner Bickford",
   "Gustin Prudner",
   "Gustin Prudner",
@@ -21,6 +23,7 @@
   "Jimmy McBroom",
   "Joe Dennis",
   "Joe Dennis",
+  "Mark Lipscombe",
   "Matt Bretl",
   "Matthew Mullens",
   "Matthew Mullens",
@@ -30,6 +33,7 @@
   "MissionMode",
   "Mtpc",
   "Sam Levin",
+  "Simon Elliott",
   "Tim Field",
   "stlbucket"
 ]

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -46,8 +46,9 @@ export interface PostGraphileOptions {
   // Connection string to use to connect to the database as a privileged user (e.g. for setting up watch fixtures, logical decoding, etc).
   ownerConnectionString?: string;
   // [EXPERIMENTAL] Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)
-  /* @middlewareOnly */
   subscriptions?: boolean;
+  // [EXPERIMENTAL] Enables live-query support via GraphQL subscriptions (sends updated payload any time nested collections/records change)
+  live?: boolean;
   // The default Postgres role to use. If no role was provided in a provided
   // JWT token, this role will be used.
   pgDefaultRole?: string;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -43,6 +43,8 @@ export interface PostGraphileOptions {
   //   `DROP SCHEMA postgraphile_watch CASCADE;`
   /* @middlewareOnly */
   watchPg?: boolean;
+  // Connection string to use to connect to the database as a privileged user (e.g. for setting up watch fixtures, logical decoding, etc).
+  ownerConnectionString?: string;
   // [EXPERIMENTAL] Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)
   /* @middlewareOnly */
   subscriptions?: boolean;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -156,7 +156,7 @@ export interface PostGraphileOptions {
   // Set this to `true` to enable the GraphiQL interface.
   /* @middlewareOnly */
   graphiql?: boolean;
-  // Set this to `true` to add some enhancements to GraphiQL; intended for development usage only.
+  // Set this to `true` to add some enhancements to GraphiQL; intended for development usage only (automatically enables with `subscriptions` and `live`).
   /* @middlewareOnly */
   enhanceGraphiql?: boolean;
   // Enables some generous CORS settings for the GraphQL endpoint. There are

--- a/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationMutations-test.js.snap
+++ b/src/postgraphile/__tests__/__snapshots__/postgraphileIntegrationMutations-test.js.snap
@@ -467,8 +467,8 @@ Object {
     },
   },
   "errors": Array [
-    [GraphQLError: No values were deleted in collection 'posts' because no values were found.],
-    [GraphQLError: No values were deleted in collection 'posts' because no values were found.],
+    [GraphQLError: No values were deleted in collection 'posts' because no values you can delete were found matching these criteria.],
+    [GraphQLError: No values were deleted in collection 'posts' because no values you can delete were found matching these criteria.],
   ],
 }
 `;

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -100,6 +100,10 @@ program
     "the PostgreSQL database name or connection string. If omitted, inferred from environmental variables (see https://www.postgresql.org/docs/current/static/libpq-envars.html). Examples: 'db', 'postgres:///db', 'postgres://user:password@domain:port/db?ssl=1'",
   )
   .option(
+    '-C, --owner-connection <string>',
+    'as `--connection`, but for a privileged user (e.g. for setting up watch fixtures, logical decoding, etc); defaults to the value from `--connection`',
+  )
+  .option(
     '-s, --schema <string>',
     'a Postgres schema to be introspected. Use commas to define multiple schemas',
     (option: string) => option.split(','),
@@ -381,6 +385,7 @@ const overridesFromOptions = {};
 const {
   demo: isDemo = false,
   connection: pgConnectionString,
+  ownerConnection,
   subscriptions,
   watch: watchPg,
   schema: dbSchema,
@@ -452,6 +457,8 @@ const noServer = !yesServer;
 // mode, we want to use the `forum_example` schema. Otherwise the `public`
 // schema is what we want.
 const schemas: Array<string> = dbSchema || (isDemo ? ['forum_example'] : ['public']);
+
+const ownerConnectionString = ownerConnection || pgConnectionString || process.env.DATABASE_URL;
 
 // Create our Postgres config.
 const pgConfig: PoolConfig = {
@@ -580,6 +587,7 @@ const postgraphileOptions = pluginHook(
     simpleCollections,
     legacyFunctionsOnly,
     ignoreIndexes,
+    ownerConnectionString,
   },
   { config, cliOptions: program },
 );

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -606,7 +606,7 @@ if (noServer) {
     const pgPool = new Pool(pgConfig);
     pgPool.on('error', err => {
       // tslint:disable-next-line no-console
-      console.error('PostgreSQL client generated error: ', err);
+      console.error('PostgreSQL client generated error: ', err.message);
     });
     const { getGraphQLSchema } = getPostgraphileSchemaBuilder(pgPool, schemas, postgraphileOptions);
     await getGraphQLSchema();

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -236,7 +236,7 @@ program
   )
   .option(
     '--enhance-graphiql',
-    '[DEVELOPMENT] opt in to additional GraphiQL functionality (this may change over time - only intended for use in development)',
+    '[DEVELOPMENT] opt in to additional GraphiQL functionality (this may change over time - only intended for use in development; automatically enables with `subscriptions` and `live`)',
   )
   .option(
     '-b, --disable-graphiql',
@@ -563,7 +563,7 @@ const postgraphileOptions = pluginHook(
     graphqlRoute,
     graphiqlRoute,
     graphiql: !disableGraphiql,
-    enhanceGraphiql,
+    enhanceGraphiql: enhanceGraphiql ? true : undefined,
     jwtPgTypeIdentifier: jwtPgTypeIdentifier || deprecatedJwtPgTypeIdentifier,
     jwtSecret: jwtSecret || deprecatedJwtSecret,
     jwtAudiences,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -113,6 +113,10 @@ program
     '[EXPERIMENTAL] Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)',
   )
   .option(
+    '-L, --live',
+    '[EXPERIMENTAL] Enables live-query support via GraphQL subscriptions (sends updated payload any time nested collections/records change). Implies --subscriptions',
+  )
+  .option(
     '-w, --watch',
     'automatically updates your GraphQL schema when your database schema changes (NOTE: requires DB superuser to install `postgraphile_watch` schema)',
   )
@@ -387,6 +391,7 @@ const {
   connection: pgConnectionString,
   ownerConnection,
   subscriptions,
+  live,
   watch: watchPg,
   schema: dbSchema,
   host: hostname = 'localhost',
@@ -565,7 +570,8 @@ const postgraphileOptions = pluginHook(
     jwtRole,
     jwtVerifyOptions,
     pgDefaultRole,
-    subscriptions,
+    subscriptions: subscriptions || live,
+    live,
     watchPg,
     showErrorStack,
     extendedErrors,
@@ -732,7 +738,10 @@ if (noServer) {
           [
             `GraphQL API:         ${chalk.underline.bold.blue(
               `http://${hostname}:${actualPort}${graphqlRoute}`,
-            )}` + (postgraphileOptions.subscriptions ? ' (subscriptions enabled)' : ''),
+            )}` +
+              (postgraphileOptions.subscriptions
+                ? ` (${postgraphileOptions.live ? 'live ' : ''}subscriptions enabled)`
+                : ''),
             !disableGraphiql &&
               `GraphiQL GUI/IDE:    ${chalk.underline.bold.blue(
                 `http://${hostname}:${actualPort}${graphiqlRoute}`,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -745,7 +745,12 @@ if (noServer) {
             !disableGraphiql &&
               `GraphiQL GUI/IDE:    ${chalk.underline.bold.blue(
                 `http://${hostname}:${actualPort}${graphiqlRoute}`,
-              )}` + (enhanceGraphiql ? '' : ` (enhance with '--enhance-graphiql')`),
+              )}` +
+                (postgraphileOptions.enhanceGraphiql ||
+                postgraphileOptions.live ||
+                postgraphileOptions.subscriptions
+                  ? ''
+                  : ` (enhance with '--enhance-graphiql')`),
             `Postgres connection: ${chalk.underline.magenta(safeConnectionString)}${
               postgraphileOptions.watchPg ? ' (watching)' : ''
             }`,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -25,6 +25,8 @@ import * as manifest from '../../package.json';
 import sponsors = require('../../sponsors.json');
 import { enhanceHttpServerWithSubscriptions } from './http/subscriptions';
 
+const isDev = process.env.POSTGRAPHILE_ENV === 'development';
+
 // tslint:disable-next-line no-any
 function isString(str: any): str is string {
   return typeof str === 'string';
@@ -704,7 +706,9 @@ if (noServer) {
       const address = server.address();
       const actualPort = typeof address === 'string' ? port : address.port;
       const self = cluster.isMaster
-        ? 'server'
+        ? isDev
+          ? `server (pid=${process.pid})`
+          : 'server'
         : `worker ${process.env.POSTGRAPHILE_WORKER_NUMBER} (pid=${process.pid})`;
       const versionString = `v${manifest.version}`;
       if (cluster.isMaster || process.env.POSTGRAPHILE_WORKER_NUMBER === '1') {

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -744,7 +744,7 @@ export default function createPostGraphileHttpRequestHandler(
             ) {
               // We must reference this before it's deleted!
               const resultStatusCode = result.statusCode;
-              setTimeout(() => {
+              setImmediate(() => {
                 const prettyQuery = printGraphql(queryDocumentAst)
                   .replace(/\s+/g, ' ')
                   .trim();
@@ -770,7 +770,7 @@ export default function createPostGraphileHttpRequestHandler(
                     pgRole != null ? `as ${chalk.magenta(pgRole)} ` : ''
                   }in ${chalk.grey(`${ms}ms`)} :: ${prettyQuery}`,
                 );
-              }, 0);
+              });
             }
             if (debugRequest.enabled) debugRequest('GraphQL query has been executed.');
           }

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -403,7 +403,10 @@ export default function createPostGraphileHttpRequestHandler(
             `  <script>window.POSTGRAPHILE_CONFIG=${safeJSONStringify({
               graphqlUrl: `${externalUrlBase}${graphqlRoute}`,
               streamUrl: options.watchPg ? `${externalUrlBase}${graphqlRoute}/stream` : null,
-              enhanceGraphiql: options.enhanceGraphiql,
+              enhanceGraphiql:
+                options.enhanceGraphiql === false
+                  ? false
+                  : !!options.enhanceGraphiql || options.subscriptions || options.live,
               subscriptions: !!options.subscriptions,
             })};</script>\n  </head>`,
           )

--- a/src/postgraphile/index.ts
+++ b/src/postgraphile/index.ts
@@ -1,5 +1,12 @@
 import postgraphile from './postgraphile';
 import { createPostGraphileSchema, watchPostGraphileSchema } from 'postgraphile-core';
 import withPostGraphileContext from './withPostGraphileContext';
+import { enhanceHttpServerWithSubscriptions } from './http/subscriptions';
 
-export { postgraphile, createPostGraphileSchema, watchPostGraphileSchema, withPostGraphileContext };
+export {
+  postgraphile,
+  createPostGraphileSchema,
+  watchPostGraphileSchema,
+  withPostGraphileContext,
+  enhanceHttpServerWithSubscriptions,
+};

--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -6,7 +6,8 @@ import { version } from '../../package.json';
 import * as graphql from 'graphql';
 import { ExecutionParams } from 'subscriptions-transport-ws';
 
-export type HookFn<T> = (arg: T, context: {}) => T;
+// tslint:disable-next-line no-any
+export type HookFn<TArg, TContext = any> = (arg: TArg, context: TContext) => TArg;
 export type PluginHookFn = <TArgument, TContext = {}>(
   hookName: string,
   argument: TArgument,
@@ -38,7 +39,8 @@ export interface PostGraphilePlugin {
   'cli:flags:add'?: HookFn<AddFlagFn>;
   'cli:flags:add:deprecated'?: HookFn<AddFlagFn>;
   'cli:flags:add:workarounds'?: HookFn<AddFlagFn>;
-  'cli:library:options'?: HookFn<{}>;
+  // tslint:disable-next-line no-any
+  'cli:library:options'?: HookFn<PostGraphileOptions, { config: any; cliOptions: any }>;
   'cli:server:middleware'?: HookFn<HttpRequestHandler>;
   'cli:server:created'?: HookFn<Server>;
   'cli:greeting'?: HookFn<Array<string | null | void>>;

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -168,6 +168,7 @@ export default function postgraphile(
     incomingOptions,
   );
   return createPostGraphileHttpRequestHandler({
+    ...(typeof poolOrConfig === 'string' ? { ownerConnectionString: poolOrConfig } : {}),
     ...options,
     getGqlSchema: getGraphQLSchema,
     pgPool,

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -25,6 +25,10 @@ export function getPostgraphileSchemaBuilder(
   schema: string | Array<string>,
   incomingOptions: PostGraphileOptions,
 ): PostgraphileSchemaBuilder {
+  if (incomingOptions.live && incomingOptions.subscriptions == null) {
+    // live implies subscriptions
+    incomingOptions.subscriptions = true;
+  }
   const pluginHook = pluginHookFromOptions(incomingOptions);
   const options = pluginHook('postgraphile:options', incomingOptions, {
     pgPool,

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -163,7 +163,7 @@ export default function postgraphile(
      * that the event listener is registered.
      */
     // tslint:disable-next-line no-console
-    console.error('PostgreSQL client generated error: ', err);
+    console.error('PostgreSQL client generated error: ', err.message);
   });
 
   const { getGraphQLSchema, options, _emitter } = getPostgraphileSchemaBuilder(

--- a/tslint.json
+++ b/tslint.json
@@ -1,8 +1,5 @@
 {
-  "extends": [
-    "tslint:latest",
-    "tslint-config-prettier"
-  ],
+  "extends": ["tslint:latest", "tslint-config-prettier"],
   "rules": {
     "curly": false,
     "no-any": true,
@@ -12,33 +9,16 @@
     "max-file-line-count": false,
     "no-default-export": false,
     "object-literal-sort-keys": false,
-    "array-type": [
-      true,
-      "generic"
-    ],
-    "interface-name": [
-      true,
-      "never-prefix"
-    ],
+    "array-type": [true, "generic"],
+    "interface-name": [true, "never-prefix"],
     "ordered-imports": false,
-    "variable-name": [
-      true,
-      "ban-keywords",
-      "check-format",
-      "allow-leading-underscore"
-    ],
-    "no-implicit-dependencies": [
-      true,
-      "dev"
-    ],
+    "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"],
+    "no-implicit-dependencies": [true, "dev", "peer"],
     "no-string-literal": false
   },
   "jsRules": {
     "no-reference": true,
-    "only-arrow-functions": [
-      true,
-      "allow-declarations"
-    ],
+    "only-arrow-functions": [true, "allow-declarations"],
     "prefer-for-of": true,
     "ban": false,
     "curly": false,
@@ -47,14 +27,7 @@
     "no-arg": true,
     "no-bitwise": true,
     "no-conditional-assignment": true,
-    "no-console": [
-      true,
-      "log",
-      "error",
-      "warn",
-      "info",
-      "trace"
-    ],
+    "no-console": [true, "log", "error", "warn", "info", "trace"],
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-variable": true,
@@ -71,10 +44,7 @@
     "radix": true,
     "restrict-plus-operands": false,
     "switch-default": true,
-    "triple-equals": [
-      true,
-      "allow-null-check"
-    ],
+    "triple-equals": [true, "allow-null-check"],
     "use-isnan": true,
     "cyclomatic-complexity": false,
     "eofline": true,
@@ -91,11 +61,6 @@
     "object-literal-shorthand": true,
     "one-variable-per-declaration": true,
     "ordered-imports": false,
-    "variable-name": [
-      true,
-      "ban-keywords",
-      "check-format",
-      "allow-leading-underscore"
-    ]
+    "variable-name": [true, "ban-keywords", "check-format", "allow-leading-underscore"]
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.2-alpha.6:
-  version "4.3.2-alpha.6"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.6.tgz#54eb4d2fa771994441e34779153af42b4bbe141d"
-  integrity sha512-jtkiAMAmgfmD6jzja9fvd0gm9gZ/4JI3JJN4MbBs6MEO6VrtQuwGF/aHyaoqGI4I9L/yYX1fN5trZ+Ay3zuhvA==
+graphile-build-pg@4.3.2-beta.0:
+  version "4.3.2-beta.0"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-beta.0.tgz#21dc0743cf28dfb4e0ff8fbd5400587d5b5dea14"
+  integrity sha512-RQE55rh/85cD7S86Jo1Ei73rcpEe+Lv7xD8Vw4Kep08zf+hiELhMUASW/kWOcYVYMxGX7CZCfElOzRPuKV3GMw==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.2-alpha.6"
+    graphile-build "4.3.2-beta.0"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,10 +3337,10 @@ graphile-build-pg@4.3.2-alpha.6:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.2-alpha.6:
-  version "4.3.2-alpha.6"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.6.tgz#c08257357ed21326311ce2858af1abcbe623416b"
-  integrity sha512-aQ32gGi6RslRDFpy6VOmePY5APJ2n9Lf97JSeI9LJ1SeR6VP+M03qthIsRYFXOmucvT3pNNhzuPszWkBQh648w==
+graphile-build@4.3.2-beta.0:
+  version "4.3.2-beta.0"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-beta.0.tgz#d54c586f398a3f72d2f5619f5e2bdb16ab5add17"
+  integrity sha512-1GqvNbyti5Eic3ng43RHyNYGAtoFc+GCy3RfyxHWakmkBi8OQ6XjlcfPu3pp8MBrCkj4jOlBNS48/H9IpgVGhA==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
@@ -5771,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.2-alpha.6:
-  version "4.3.2-alpha.6"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.6.tgz#dadaece159a88724e9958a517a994960cbed15fb"
-  integrity sha512-pJkg60kRIIcSlVsbWvGKg/RyjE+E9QbWKehrgSMFMm+KsRZTveHL+pzzTtP+B2ZO73KCRXlCiBdkNY19VlpHVA==
+postgraphile-core@4.3.2-beta.0:
+  version "4.3.2-beta.0"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-beta.0.tgz#44712df50c20d3c97f841ebc7ecccff470f1b478"
+  integrity sha512-PcdwqJs2KU/nzyXBrv008XxaLE2QGgN4wwzEg+8labETa3bMDB5RFT5UE9aOps/AmC3y++oQlx18d1+XLGcQ+Q==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.2-alpha.6"
-    graphile-build-pg "4.3.2-alpha.6"
+    graphile-build "4.3.2-beta.0"
+    graphile-build-pg "4.3.2-beta.0"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.2-alpha.3:
-  version "4.3.2-alpha.3"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.3.tgz#71ef4211c7a6c60b16a18588682826a546a19549"
-  integrity sha512-hhl0l+AsqnWOSnpSK38BRpRgz0wIeXtUhk6olZrmwRQFu0vta61DRlyQrOkEpVqijI0ODQjlx/CYUOjGqJUrKg==
+graphile-build-pg@4.3.2-alpha.4:
+  version "4.3.2-alpha.4"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.4.tgz#6e0f44f56119088534426cd2384d807a5cb897fe"
+  integrity sha512-Echs5hcHJsYlph0dtyzkk0bvlMbWXHNl0I65EOsba4iKSXweAZaNm0OpzhU76kopDeUT5vYtAGvtRwpcsdb5Nw==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.2-alpha.3"
+    graphile-build "4.3.2-alpha.4"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,10 +3337,10 @@ graphile-build-pg@4.3.2-alpha.3:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.2-alpha.3:
-  version "4.3.2-alpha.3"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.3.tgz#dcae22579b36545bfa19210c16cb1826ef696882"
-  integrity sha512-HXL17XSPFYB4fuhRqhPVEBcjB9dIQTDycmvP0Cv7jK3k9njTwhHcKb0lRxkHQPPOxvplPmYngPnRYxr+MoXk2g==
+graphile-build@4.3.2-alpha.4:
+  version "4.3.2-alpha.4"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.4.tgz#df2a812160c3b1b64e1edd384a6e07385521ce12"
+  integrity sha512-8+2Tav5AjnMeCy7eHguoNq3aq3c3JwM2nLqSLeFPLkfkSUXUw2R+0QH0hifsawdwZFFZQRR/yF9pE1/VMAF/3w==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
@@ -5771,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.2-alpha.3:
-  version "4.3.2-alpha.3"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.3.tgz#634b271c15a87942b152d5403fcc8f29af2e9d6b"
-  integrity sha512-8A4ToNOD5d3MF1YlGxJQfyBOWaen7JRUz1uGmI6lfZK5NzPKfdtuK0ykmBl0rJhW5wrL0cDoi3Mrx00CwZGJPw==
+postgraphile-core@4.3.2-alpha.4:
+  version "4.3.2-alpha.4"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.4.tgz#51c6973c95b64b4e2f1734ad88e9bdef454ccb7b"
+  integrity sha512-v+2VQRNo3gWNhvgpw5zv8rrkXT/xCaztEERvD8bwsOLbFjk2vL3MwsX+eJZKu+/MSgWoPCefdIZ1WAQkWKdEGw==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.2-alpha.3"
-    graphile-build-pg "4.3.2-alpha.3"
+    graphile-build "4.3.2-alpha.4"
+    graphile-build-pg "4.3.2-alpha.4"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.2-alpha.5:
-  version "4.3.2-alpha.5"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.5.tgz#b76adc00739f0882001bfceefd0541f006369bbe"
-  integrity sha512-FeIg6wfVveNhcFnEeWKm+hGod9Pi5P50E38iktDOF3joY38RvSWX/b0F5yzy8krehnUhSlf98mCY4hGThgJewg==
+graphile-build-pg@4.3.2-alpha.6:
+  version "4.3.2-alpha.6"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.6.tgz#54eb4d2fa771994441e34779153af42b4bbe141d"
+  integrity sha512-jtkiAMAmgfmD6jzja9fvd0gm9gZ/4JI3JJN4MbBs6MEO6VrtQuwGF/aHyaoqGI4I9L/yYX1fN5trZ+Ay3zuhvA==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.2-alpha.5"
+    graphile-build "4.3.2-alpha.6"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,10 +3337,10 @@ graphile-build-pg@4.3.2-alpha.5:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.2-alpha.5:
-  version "4.3.2-alpha.5"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.5.tgz#25a22edc68e0d20e22f13acc1f8dc4443134dfbb"
-  integrity sha512-EOzELkxDBC5t/ehaKH1WUzim5fAdEzQWejhYIrNIS/lLGU0s375H/4ukkIUFr7JzM9uFYOJZYFoO1/9u6OMIwg==
+graphile-build@4.3.2-alpha.6:
+  version "4.3.2-alpha.6"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.6.tgz#c08257357ed21326311ce2858af1abcbe623416b"
+  integrity sha512-aQ32gGi6RslRDFpy6VOmePY5APJ2n9Lf97JSeI9LJ1SeR6VP+M03qthIsRYFXOmucvT3pNNhzuPszWkBQh648w==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
@@ -5771,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.2-alpha.5:
-  version "4.3.2-alpha.5"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.5.tgz#613662e02f4b46e17cf17c43f980b859f93e7cb2"
-  integrity sha512-aulaXQq/4IQ0JelABtX3RHZCi5dVhEGf6s7ZS8vmRCDMRQQRbBZ1Qo8YMmPFqBo2wDTJRYSpaFiWD3lGXGgj8Q==
+postgraphile-core@4.3.2-alpha.6:
+  version "4.3.2-alpha.6"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.6.tgz#dadaece159a88724e9958a517a994960cbed15fb"
+  integrity sha512-pJkg60kRIIcSlVsbWvGKg/RyjE+E9QbWKehrgSMFMm+KsRZTveHL+pzzTtP+B2ZO73KCRXlCiBdkNY19VlpHVA==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.2-alpha.5"
-    graphile-build-pg "4.3.2-alpha.5"
+    graphile-build "4.3.2-alpha.6"
+    graphile-build-pg "4.3.2-alpha.6"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.2-alpha.0:
-  version "4.3.2-alpha.0"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.0.tgz#26daa040444f2b9cc0b4574df8bb0f0f1448143e"
-  integrity sha512-0f4pGURGxJaz7yZBCOToAVPAX+EczzfoZ4PvkaBYLZb9TD/fLxT9ZyvGd1YTIBv87Vz7Mj8LPKxMwygYog3E7g==
+graphile-build-pg@4.3.2-alpha.3:
+  version "4.3.2-alpha.3"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.3.tgz#71ef4211c7a6c60b16a18588682826a546a19549"
+  integrity sha512-hhl0l+AsqnWOSnpSK38BRpRgz0wIeXtUhk6olZrmwRQFu0vta61DRlyQrOkEpVqijI0ODQjlx/CYUOjGqJUrKg==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.2-alpha.0"
+    graphile-build "4.3.2-alpha.3"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,10 +3337,10 @@ graphile-build-pg@4.3.2-alpha.0:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.2-alpha.0:
-  version "4.3.2-alpha.0"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.0.tgz#f08e2ce68a16601b973a260556bf233d0b862d33"
-  integrity sha512-NTqYqWk0APP35D5OtZxxdvMtGHSGDl2gLwjEng3xgNE4HmmBwEvR4+C9EqaE7Sn3oB3MZvAf3I9PZ+Dy5kyhlw==
+graphile-build@4.3.2-alpha.3:
+  version "4.3.2-alpha.3"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.3.tgz#dcae22579b36545bfa19210c16cb1826ef696882"
+  integrity sha512-HXL17XSPFYB4fuhRqhPVEBcjB9dIQTDycmvP0Cv7jK3k9njTwhHcKb0lRxkHQPPOxvplPmYngPnRYxr+MoXk2g==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
@@ -5771,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.2-alpha.0:
-  version "4.3.2-alpha.0"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.0.tgz#a26fa4f77eefcb8ada00a71a95a88d56e40e0873"
-  integrity sha512-bG2SUPG6XaQNRYifz4sU8jSpuPydWN9/XHFaJAnGQIQDV9/IovvHuhDK2kwn94zT9JY7dGZQ0R3VAU8MfQ6wiw==
+postgraphile-core@4.3.2-alpha.3:
+  version "4.3.2-alpha.3"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.3.tgz#634b271c15a87942b152d5403fcc8f29af2e9d6b"
+  integrity sha512-8A4ToNOD5d3MF1YlGxJQfyBOWaen7JRUz1uGmI6lfZK5NzPKfdtuK0ykmBl0rJhW5wrL0cDoi3Mrx00CwZGJPw==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.2-alpha.0"
-    graphile-build-pg "4.3.2-alpha.0"
+    graphile-build "4.3.2-alpha.3"
+    graphile-build-pg "4.3.2-alpha.3"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.2-alpha.4:
-  version "4.3.2-alpha.4"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.4.tgz#6e0f44f56119088534426cd2384d807a5cb897fe"
-  integrity sha512-Echs5hcHJsYlph0dtyzkk0bvlMbWXHNl0I65EOsba4iKSXweAZaNm0OpzhU76kopDeUT5vYtAGvtRwpcsdb5Nw==
+graphile-build-pg@4.3.2-alpha.5:
+  version "4.3.2-alpha.5"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.5.tgz#b76adc00739f0882001bfceefd0541f006369bbe"
+  integrity sha512-FeIg6wfVveNhcFnEeWKm+hGod9Pi5P50E38iktDOF3joY38RvSWX/b0F5yzy8krehnUhSlf98mCY4hGThgJewg==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.2-alpha.4"
+    graphile-build "4.3.2-alpha.5"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,10 +3337,10 @@ graphile-build-pg@4.3.2-alpha.4:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.2-alpha.4:
-  version "4.3.2-alpha.4"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.4.tgz#df2a812160c3b1b64e1edd384a6e07385521ce12"
-  integrity sha512-8+2Tav5AjnMeCy7eHguoNq3aq3c3JwM2nLqSLeFPLkfkSUXUw2R+0QH0hifsawdwZFFZQRR/yF9pE1/VMAF/3w==
+graphile-build@4.3.2-alpha.5:
+  version "4.3.2-alpha.5"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.5.tgz#25a22edc68e0d20e22f13acc1f8dc4443134dfbb"
+  integrity sha512-EOzELkxDBC5t/ehaKH1WUzim5fAdEzQWejhYIrNIS/lLGU0s375H/4ukkIUFr7JzM9uFYOJZYFoO1/9u6OMIwg==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
@@ -5771,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.2-alpha.4:
-  version "4.3.2-alpha.4"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.4.tgz#51c6973c95b64b4e2f1734ad88e9bdef454ccb7b"
-  integrity sha512-v+2VQRNo3gWNhvgpw5zv8rrkXT/xCaztEERvD8bwsOLbFjk2vL3MwsX+eJZKu+/MSgWoPCefdIZ1WAQkWKdEGw==
+postgraphile-core@4.3.2-alpha.5:
+  version "4.3.2-alpha.5"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.5.tgz#613662e02f4b46e17cf17c43f980b859f93e7cb2"
+  integrity sha512-aulaXQq/4IQ0JelABtX3RHZCi5dVhEGf6s7ZS8vmRCDMRQQRbBZ1Qo8YMmPFqBo2wDTJRYSpaFiWD3lGXGgj8Q==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.2-alpha.4"
-    graphile-build-pg "4.3.2-alpha.4"
+    graphile-build "4.3.2-alpha.5"
+    graphile-build-pg "4.3.2-alpha.5"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.2-beta.0:
-  version "4.3.2-beta.0"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-beta.0.tgz#21dc0743cf28dfb4e0ff8fbd5400587d5b5dea14"
-  integrity sha512-RQE55rh/85cD7S86Jo1Ei73rcpEe+Lv7xD8Vw4Kep08zf+hiELhMUASW/kWOcYVYMxGX7CZCfElOzRPuKV3GMw==
+graphile-build-pg@4.4.0-alpha.0:
+  version "4.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.4.0-alpha.0.tgz#8079803138899610ae7a0e6327b86e96743580ad"
+  integrity sha512-LkcyLhYyxgQTd2PYmu0rZ/ZMSEnr/KkuaZLzU0C5i9On+c8wyvSF0cljkwIZ5JZPRMv3miFOXB0MBqXraqM+gg==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.2-beta.0"
+    graphile-build "4.4.0-alpha.0"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,10 +3337,10 @@ graphile-build-pg@4.3.2-beta.0:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.2-beta.0:
-  version "4.3.2-beta.0"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-beta.0.tgz#d54c586f398a3f72d2f5619f5e2bdb16ab5add17"
-  integrity sha512-1GqvNbyti5Eic3ng43RHyNYGAtoFc+GCy3RfyxHWakmkBi8OQ6XjlcfPu3pp8MBrCkj4jOlBNS48/H9IpgVGhA==
+graphile-build@4.4.0-alpha.0:
+  version "4.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.4.0-alpha.0.tgz#ce6fcf8ab234e3738b60cfc02d7f2fab87bad49f"
+  integrity sha512-LBHEoqe0lGWEkWYWcZMdLXnicU/eRsbfHX7XdDgaH56l9qCk77BQ4N0I3eMDJmhjrIy8BVFYjgZ3AGE3a7C0kg==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
@@ -5771,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.2-beta.0:
-  version "4.3.2-beta.0"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-beta.0.tgz#44712df50c20d3c97f841ebc7ecccff470f1b478"
-  integrity sha512-PcdwqJs2KU/nzyXBrv008XxaLE2QGgN4wwzEg+8labETa3bMDB5RFT5UE9aOps/AmC3y++oQlx18d1+XLGcQ+Q==
+postgraphile-core@4.4.0-alpha.0:
+  version "4.4.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.4.0-alpha.0.tgz#e1a67a8a934b672c234c5d911000e615e2868a40"
+  integrity sha512-QdClccwDFGZhJAiH4U7OhStmCX6NRR1JareHsjQyx4BgW4xbY7cWq5PNLmRkzDRgDuVj9uomuGYO7PCySb/qlg==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.2-beta.0"
-    graphile-build-pg "4.3.2-beta.0"
+    graphile-build "4.4.0-alpha.0"
+    graphile-build-pg "4.4.0-alpha.0"
 
 postgres-array@~1.0.0:
   version "1.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3322,14 +3322,14 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
   integrity sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=
 
-graphile-build-pg@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.1.tgz#ef9e8f3d7f1ae81dd96b318c267096498cde9729"
-  integrity sha512-2Sr34q0Q2h3E0JzQjLI3lYVWfDxoGsZzfw6zpwTkkTovm/5trNPhVOjut/d/ath7eIYWcDHQ70OO97TifLjyDA==
+graphile-build-pg@4.3.2-alpha.0:
+  version "4.3.2-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.3.2-alpha.0.tgz#26daa040444f2b9cc0b4574df8bb0f0f1448143e"
+  integrity sha512-0f4pGURGxJaz7yZBCOToAVPAX+EczzfoZ4PvkaBYLZb9TD/fLxT9ZyvGd1YTIBv87Vz7Mj8LPKxMwygYog3E7g==
   dependencies:
     chalk "^2.1.0"
     debug ">=2 <3"
-    graphile-build "4.3.1"
+    graphile-build "4.3.2-alpha.0"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.1.1"
     lodash ">=4 <5"
@@ -3337,17 +3337,17 @@ graphile-build-pg@4.3.1:
     pg-sql2 "2.2.1"
     postgres-interval "^1.1.1"
 
-graphile-build@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.1.tgz#baa0b83c1d508e2314be9586574cbdb245b84415"
-  integrity sha512-o++JK8CSlLwt1eVDqPpv/hTDiql1kx5HheMfskmLr7MfRt3yObp4b09ceHDOFx/Aj9o+NvbPKbWnvHE8zhE+Eg==
+graphile-build@4.3.2-alpha.0:
+  version "4.3.2-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.3.2-alpha.0.tgz#f08e2ce68a16601b973a260556bf233d0b862d33"
+  integrity sha512-NTqYqWk0APP35D5OtZxxdvMtGHSGDl2gLwjEng3xgNE4HmmBwEvR4+C9EqaE7Sn3oB3MZvAf3I9PZ+Dy5kyhlw==
   dependencies:
     "@types/graphql" "^14.0.3"
     chalk "^2.1.0"
     debug ">=2 <3"
     graphql-parse-resolve-info "4.1.0"
     lodash ">=4 <5"
-    lru-cache ">=4 <5"
+    lru-cache "^5.0.0"
     pluralize "^7.0.0"
     semver "^5.6.0"
 
@@ -4789,6 +4789,13 @@ lowercase-keys@^1.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
+lru-cache@^5.0.0:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
+  integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
+  dependencies:
+    yallist "^3.0.2"
+
 make-dir@^1.0.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-1.3.0.tgz#79c1033b80515bd6d24ec9933e860ca75ee27f0c"
@@ -5764,14 +5771,14 @@ postcss@^6.0.1, postcss@^6.0.23:
     source-map "^0.6.1"
     supports-color "^5.4.0"
 
-postgraphile-core@4.3.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.1.tgz#38e66310fd00fa26b8a01120e53dd41e943f2cde"
-  integrity sha512-Alp0Zt6bBQSIgvHtKzKnTWA+EOM4DwVVniRCbGJYE5AQqP1AEQ0DA8zcc4yBZFAo8RCKW86BtnO2dUV2s0728g==
+postgraphile-core@4.3.2-alpha.0:
+  version "4.3.2-alpha.0"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.3.2-alpha.0.tgz#a26fa4f77eefcb8ada00a71a95a88d56e40e0873"
+  integrity sha512-bG2SUPG6XaQNRYifz4sU8jSpuPydWN9/XHFaJAnGQIQDV9/IovvHuhDK2kwn94zT9JY7dGZQ0R3VAU8MfQ6wiw==
   dependencies:
     "@types/graphql" "^14.0.3"
-    graphile-build "4.3.1"
-    graphile-build-pg "4.3.1"
+    graphile-build "4.3.2-alpha.0"
+    graphile-build-pg "4.3.2-alpha.0"
 
 postgres-array@~1.0.0:
   version "1.0.2"


### PR DESCRIPTION
- Adds websockets support to PostGraphile and PostGraphiQL
- `--subscriptions` implies `--enhance-graphiql`
- `--live` implies `--subscriptions`
- Add `ownerConnectionString` option which can be used to install the watch fixtures, among other things
- Improve error messages
- Output less debugging information in error messages when PostgreSQL server restarts
- Tweak typings of pluginHooks
- Stronger types in other places