### PR TITLE
Added Access-Control-Expose-Headers for X-GraphQL-Event-Stream header

### DIFF
--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -240,6 +240,7 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
         .expect('Access-Control-Allow-Origin', '*')
         .expect('Access-Control-Allow-Methods', 'HEAD, GET, POST')
         .expect('Access-Control-Allow-Headers', /Accept, Authorization, X-Apollo-Tracing/)
+        .expect('Access-Control-Expose-Headers', 'X-GraphQL-Event-Stream')
         .expect('');
     });
 
@@ -249,7 +250,8 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
         .post(`${subpath}/graphql`)
         .expect('Access-Control-Allow-Origin', '*')
         .expect('Access-Control-Allow-Methods', 'HEAD, GET, POST')
-        .expect('Access-Control-Allow-Headers', /Accept, Authorization, X-Apollo-Tracing/);
+        .expect('Access-Control-Allow-Headers', /Accept, Authorization, X-Apollo-Tracing/)
+        .expect('Access-Control-Expose-Headers', 'X-GraphQL-Event-Stream');
     });
 
     test('will not allow requests other than POST', async () => {

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -919,6 +919,12 @@ function addCORSHeaders(res: ServerResponse): void {
       'Content-Length',
     ].join(', '),
   );
+  res.setHeader(
+    'Access-Control-Expose-Headers',
+    [
+      'X-GraphQL-Event-Stream'
+    ]
+  );
 }
 
 function createBadAuthorizationHeaderError(): httpError.HttpError {

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -919,12 +919,7 @@ function addCORSHeaders(res: ServerResponse): void {
       'Content-Length',
     ].join(', '),
   );
-  res.setHeader(
-    'Access-Control-Expose-Headers',
-    [
-      'X-GraphQL-Event-Stream'
-    ].join(', ')
-  );
+  res.setHeader('Access-Control-Expose-Headers', ['X-GraphQL-Event-Stream'].join(', '));
 }
 
 function createBadAuthorizationHeaderError(): httpError.HttpError {

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -923,7 +923,7 @@ function addCORSHeaders(res: ServerResponse): void {
     'Access-Control-Expose-Headers',
     [
       'X-GraphQL-Event-Stream'
-    ]
+    ].join(', ')
   );
 }
 


### PR DESCRIPTION
Added `Access-Control-Expose-Headers` header to allow user agents access to the `X-GraphQL-Event-Stream` header.