### PR TITLE
feat(http2): basic HTTP2 support for event-stream

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,6 @@
     "@types/lru-cache": "^4.1.1",
     "@types/node": "^10.9.4",
     "@types/parseurl": "^1.3.1",
-    "@types/superagent": "^3.8.6",
     "babel-loader": "8.0.2",
     "connect": "^3.5.0",
     "css-loader": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "@types/lru-cache": "^4.1.1",
     "@types/node": "^10.9.4",
     "@types/parseurl": "^1.3.1",
+    "@types/superagent": "^3.8.6",
     "babel-loader": "8.0.2",
     "connect": "^3.5.0",
     "css-loader": "1.0.0",
@@ -99,7 +100,7 @@
     "prettier": "^1.15.2",
     "source-map-support": "^0.4.6",
     "style-loader": "^0.23.0",
-    "supertest": "^2.0.1",
+    "superagent": "^4.1.0",
     "ts-node": "^2.0.0",
     "tslint": "^5.10.0",
     "tslint-config-prettier": "^1.14.0",
@@ -112,7 +113,8 @@
     },
     "moduleFileExtensions": [
       "ts",
-      "js"
+      "js",
+      "json"
     ],
     "setupFiles": [
       "<rootDir>/resources/jest-setup.js"

--- a/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
+++ b/src/postgraphile/http/__tests__/__snapshots__/createPostGraphileHttpRequestHandler-test.js.snap
@@ -238,6 +238,54 @@ Array [
 ]
 `;
 
+exports[`fastify-http2 will report an extended error when extendedErrors is enabled 1`] = `
+Array [
+  Object {
+    "detail": "test detail",
+    "errcode": "12345",
+    "extensions": Object {
+      "exception": Object {
+        "detail": "test detail",
+        "errcode": "12345",
+        "hint": "test hint",
+      },
+      "testingExtensions": true,
+    },
+    "hint": "test hint",
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
+exports[`fastify-http2 will report standard error when extendedErrors is not enabled 1`] = `
+Array [
+  Object {
+    "extensions": Object {
+      "testingExtensions": true,
+    },
+    "locations": Array [
+      Object {
+        "column": 2,
+        "line": 1,
+      },
+    ],
+    "message": "test message",
+    "path": Array [
+      "testError",
+    ],
+  },
+]
+`;
+
 exports[`http will report an extended error when extendedErrors is enabled 1`] = `
 Array [
   Object {

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -1,9 +1,9 @@
 import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
 import { $$pgClient } from '../../../postgres/inventory/pgClientFromContext';
 import createPostGraphileHttpRequestHandler from '../createPostGraphileHttpRequestHandler';
+import request from './supertest';
 
 const http = require('http');
-const request = require('supertest');
 const connect = require('connect');
 const express = require('express');
 const compress = require('koa-compress');

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -13,6 +13,7 @@ const compress = require('koa-compress');
 const koa = require('koa');
 const koaMount = require('koa-mount');
 const fastify = require('fastify');
+// tslint:disable-next-line variable-name
 const EventEmitter = require('events');
 
 const shortString = 'User_Running_These_Tests';

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -1,7 +1,15 @@
 import { GraphQLSchema, GraphQLObjectType, GraphQLString } from 'graphql';
 import { $$pgClient } from '../../../postgres/inventory/pgClientFromContext';
 import createPostGraphileHttpRequestHandler from '../createPostGraphileHttpRequestHandler';
-import request from './supertest';
+import baseRequest from './supertest';
+
+const request = app => {
+  const ret = baseRequest(app);
+  if (app._http2) {
+    return ret.http2(true);
+  }
+  return ret;
+};
 
 const http = require('http');
 const connect = require('connect');

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -150,7 +150,7 @@ const serverCreators = new Map([
       let server;
       function serverFactory(fastlyHandler, opts) {
         if (server) throw new Error('Factory called twice');
-        server = http2.createServer((req, res) => {
+        server = http2.createServer({}, (req, res) => {
           fastlyHandler(req, res);
         });
         return server;

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -130,18 +130,20 @@ const serverCreators = new Map([
       return server;
     },
   ],
+  [
+    'koa',
+    (handler, options = {}, subpath) => {
+      const app = new koa();
+      if (options.onPreCreate) options.onPreCreate(app);
+      if (subpath) {
+        app.use(koaMount(subpath, handler));
+      } else {
+        app.use(handler);
+      }
+      return http.createServer(app.callback());
+    },
+  ],
 ]);
-
-serverCreators.set('koa', (handler, options = {}, subpath) => {
-  const app = new koa();
-  if (options.onPreCreate) options.onPreCreate(app);
-  if (subpath) {
-    app.use(koaMount(subpath, handler));
-  } else {
-    app.use(handler);
-  }
-  return http.createServer(app.callback());
-});
 
 const toTest = [];
 for (const [name, createServerFromHandler] of Array.from(serverCreators)) {

--- a/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
+++ b/src/postgraphile/http/__tests__/createPostGraphileHttpRequestHandler-test.js
@@ -258,6 +258,7 @@ for (const { name, createServerFromHandler, subpath = '' } of toTest) {
       const server = await createServer({ enableCors: true });
       await request(server)
         .post(`${subpath}/graphql`)
+        .expect(400)
         .expect('Access-Control-Allow-Origin', '*')
         .expect('Access-Control-Allow-Methods', 'HEAD, GET, POST')
         .expect('Access-Control-Allow-Headers', /Accept, Authorization, X-Apollo-Tracing/)

--- a/src/postgraphile/http/__tests__/supertest/index.ts
+++ b/src/postgraphile/http/__tests__/supertest/index.ts
@@ -1,0 +1,35 @@
+// tslint:disable no-any
+import * as http from 'http';
+import Test from './lib/test';
+import agent from './lib/agent';
+
+const methods = http.METHODS.map(m => m.toLowerCase());
+
+/**
+ * Test against the given `app`,
+ * returning a new `Test`.
+ *
+ * @param {Function|Server} app
+ * @return {Test}
+ * @api public
+ */
+export default (app: any) => {
+  const obj: any = {};
+
+  if (typeof app === 'function') {
+    app = http.createServer(app); // eslint-disable-line no-param-reassign
+  }
+
+  methods.forEach(method => {
+    obj[method] = (url: string) => {
+      return new Test(app, method, url);
+    };
+  });
+
+  // Support previous use of del
+  obj.del = obj.delete;
+
+  return obj;
+};
+
+export { Test, agent };

--- a/src/postgraphile/http/__tests__/supertest/lib/agent.ts
+++ b/src/postgraphile/http/__tests__/supertest/lib/agent.ts
@@ -1,0 +1,65 @@
+// tslint:disable
+/**
+ * Module dependencies.
+ */
+
+import { agent as Agent } from 'superagent';
+import * as http from 'http';
+import Test from './test';
+
+const methods = http.METHODS.map(m => m.toLowerCase());
+
+/**
+ * Initialize a new `TestAgent`.
+ *
+ * @param {Function|Server} app
+ * @param {Object} options
+ * @api public
+ */
+
+function TestAgent(app: any, options: any) {
+  // @ts-ignore
+  if (!(this instanceof TestAgent)) return new TestAgent(app, options);
+  if (typeof app === 'function') app = http.createServer(app); // eslint-disable-line no-param-reassign
+  if (options) {
+    this._ca = options.ca;
+    this._key = options.key;
+    this._cert = options.cert;
+  }
+  Agent.call(this);
+  this.app = app;
+}
+
+/**
+ * Inherits from `Agent.prototype`.
+ */
+
+Object.setPrototypeOf(TestAgent.prototype, Agent.prototype);
+
+// set a host name
+TestAgent.prototype.host = function(host: any) {
+  this._host = host;
+  return this;
+};
+
+// override HTTP verb methods
+methods.forEach(method => {
+  TestAgent.prototype[method] = function(url: any, _fn: any) {
+    // eslint-disable-line no-unused-vars
+    var req = new Test(this.app, method.toUpperCase(), url, this._host);
+    req.ca(this._ca);
+    req.cert(this._cert);
+    req.key(this._key);
+
+    req.on('response', this._saveCookies.bind(this));
+    req.on('redirect', this._saveCookies.bind(this));
+    req.on('redirect', this._attachCookies.bind(this, req));
+    this._attachCookies(req);
+
+    return req;
+  };
+});
+
+TestAgent.prototype.del = TestAgent.prototype.delete;
+
+export default TestAgent;

--- a/src/postgraphile/http/__tests__/supertest/lib/test.ts
+++ b/src/postgraphile/http/__tests__/supertest/lib/test.ts
@@ -52,6 +52,12 @@ class Test extends Request {
         );
       return promise.then(cb, ecb);
     };
+    ['get', 'post', 'put', 'delete', 'options'].forEach(method => {
+      const old = this[method];
+      this[method] = function(...args) {
+        return old.apply(this, args).http2(app._http2);
+      };
+    });
   }
   /**
    * Returns a URL, extracted from a server.

--- a/src/postgraphile/http/__tests__/supertest/lib/test.ts
+++ b/src/postgraphile/http/__tests__/supertest/lib/test.ts
@@ -1,0 +1,316 @@
+// tslint:disable
+/**
+ * Module dependencies.
+ */
+
+import * as request from 'superagent';
+import * as util from 'util';
+import * as http from 'http';
+import * as https from 'https';
+import * as assert from 'assert';
+
+// @ts-ignore
+const Request: any = request.Request;
+
+/**
+ * Initialize a new `Test` with the given `app`,
+ * request `method` and `path`.
+ *
+ * @param {Server} app
+ * @param {String} method
+ * @param {String} path
+ * @api public
+ */
+
+class Test extends Request {
+  constructor(app: any, method: any, path: any, host?: any) {
+    super(method.toUpperCase(), path);
+    this.redirects(0);
+    this.buffer();
+    this.app = app;
+    this._asserts = [];
+    this.url = typeof app === 'string' ? app + path : this.serverAddress(app, path, host);
+
+    // Make awaiting work
+    const oldThen = this.then;
+    const donePromise = new Promise(resolve => {
+      this.completeCallback = resolve;
+    });
+    let promise;
+    this.then = cb => {
+      if (!promise) promise = oldThen.call(this, () => donePromise, () => donePromise);
+      return promise.then(cb);
+    };
+  }
+  /**
+   * Returns a URL, extracted from a server.
+   *
+   * @param {Server} app
+   * @param {String} path
+   * @returns {String} URL address
+   * @api private
+   */
+
+  serverAddress(app: any, path: any, host: any) {
+    var addr = app.address();
+    var port;
+    var protocol;
+
+    if (!addr) this._server = app.listen(0);
+    port = app.address().port;
+    protocol = app instanceof https.Server ? 'https' : 'http';
+    return protocol + '://' + (host || '127.0.0.1') + ':' + port + path;
+  }
+
+  /**
+   * Expectations:
+   *
+   *   .expect(200)
+   *   .expect(200, fn)
+   *   .expect(200, body)
+   *   .expect('Some body')
+   *   .expect('Some body', fn)
+   *   .expect('Content-Type', 'application/json')
+   *   .expect('Content-Type', 'application/json', fn)
+   *   .expect(fn)
+   *
+   * @return {Test}
+   * @api public
+   */
+
+  expect(a: any, b: any, c: any) {
+    // callback
+    if (typeof a === 'function') {
+      this._asserts.push(a);
+      return this;
+    }
+    if (typeof b === 'function') this.end(b);
+    if (typeof c === 'function') this.end(c);
+
+    // status
+    if (typeof a === 'number') {
+      this._asserts.push(this._assertStatus.bind(this, a));
+      // body
+      if (typeof b !== 'function' && arguments.length > 1) {
+        this._asserts.push(this._assertBody.bind(this, b));
+      }
+      return this;
+    }
+
+    // header field
+    if (typeof b === 'string' || typeof b === 'number' || b instanceof RegExp) {
+      this._asserts.push(this._assertHeader.bind(this, { name: '' + a, value: b }));
+      return this;
+    }
+
+    // body
+    this._asserts.push(this._assertBody.bind(this, a));
+
+    return this;
+  }
+
+  /**
+   * Defer invoking superagent's `.end()` until
+   * the server is listening.
+   *
+   * @param {Function} fn
+   * @api public
+   */
+
+  end(fn: any) {
+    var self = this;
+    var server = this._server;
+    var end = Request.prototype.end;
+
+    end.call(this, (err: any, res: any) => {
+      if (server && server._handle) return server.close(localAssert);
+
+      localAssert();
+
+      function localAssert() {
+        self.assert(err, res, fn);
+      }
+    });
+
+    return this;
+  }
+
+  /**
+   * Perform assertions and invoke `fn(err, res)`.
+   *
+   * @param {?Error} resError
+   * @param {Response} res
+   * @param {Function} fn
+   * @api private
+   */
+
+  assert(resError: any, res: any, fn: any) {
+    this.completeCallback(res);
+    var error;
+    var i;
+
+    // check for unexpected network errors or server not running/reachable errors
+    // when there is no response and superagent sends back a System Error
+    // do not check further for other asserts, if any, in such case
+    // https://nodejs.org/api/errors.html#errors_common_system_errors
+    var sysErrors = {
+      ECONNREFUSED: 'Connection refused',
+      ECONNRESET: 'Connection reset by peer',
+      EPIPE: 'Broken pipe',
+      ETIMEDOUT: 'Operation timed out',
+    };
+
+    if (!res && resError) {
+      if (
+        resError instanceof Error &&
+        resError['syscall'] === 'connect' &&
+        Object.getOwnPropertyNames(sysErrors).indexOf(resError['code']) >= 0
+      ) {
+        error = new Error(resError['code'] + ': ' + sysErrors[resError['code']]);
+      } else {
+        error = resError;
+      }
+    }
+
+    // asserts
+    for (i = 0; i < this._asserts.length && !error; i += 1) {
+      error = this._assertFunction(this._asserts[i], res);
+    }
+
+    // set unexpected superagent error if no other error has occurred.
+    if (!error && resError instanceof Error && (!res || resError['status'] !== res.status)) {
+      error = resError;
+    }
+
+    fn.call(this, error || null, res);
+  }
+
+  /**
+   * Perform assertions on a response body and return an Error upon failure.
+   *
+   * @param {Mixed} body
+   * @param {Response} res
+   * @return {?Error}
+   * @api private
+   */
+
+  _assertBody(body: any, res: any) {
+    var isregexp = body instanceof RegExp;
+    var a;
+    var b;
+
+    // parsed
+    if (typeof body === 'object' && !isregexp) {
+      try {
+        assert.deepStrictEqual(body, res.body);
+      } catch (err) {
+        a = util.inspect(body);
+        b = util.inspect(res.body);
+        return error('expected ' + a + ' response body, got ' + b, body, res.body);
+      }
+    } else if (body !== res.text) {
+      // string
+      a = util.inspect(body);
+      b = util.inspect(res.text);
+
+      // regexp
+      if (isregexp) {
+        if (!body.test(res.text)) {
+          return error('expected body ' + b + ' to match ' + body, body, res.body);
+        }
+      } else {
+        return error('expected ' + a + ' response body, got ' + b, body, res.body);
+      }
+    }
+  }
+
+  /**
+   * Perform assertions on a response header and return an Error upon failure.
+   *
+   * @param {Object} header
+   * @param {Response} res
+   * @return {?Error}
+   * @api private
+   */
+
+  _assertHeader(header: any, res: any) {
+    var field = header.name;
+    var actual = res.header[field.toLowerCase()];
+    var fieldExpected = header.value;
+
+    if (typeof actual === 'undefined') return new Error('expected "' + field + '" header field');
+    // This check handles header values that may be a String or single element Array
+    if (
+      (Array.isArray(actual) && actual.toString() === fieldExpected) ||
+      fieldExpected === actual
+    ) {
+      return;
+    }
+    if (fieldExpected instanceof RegExp) {
+      if (!fieldExpected.test(actual)) {
+        return new Error(
+          'expected "' + field + '" matching ' + fieldExpected + ', got "' + actual + '"',
+        );
+      }
+    } else {
+      return new Error('expected "' + field + '" of "' + fieldExpected + '", got "' + actual + '"');
+    }
+  }
+
+  /**
+   * Perform assertions on the response status and return an Error upon failure.
+   *
+   * @param {Number} status
+   * @param {Response} res
+   * @return {?Error}
+   * @api private
+   */
+
+  _assertStatus(status: any, res: any) {
+    var a;
+    var b;
+    if (res.status !== status) {
+      a = http.STATUS_CODES[status];
+      b = http.STATUS_CODES[res.status];
+      return new Error('expected ' + status + ' "' + a + '", got ' + res.status + ' "' + b + '"');
+    }
+  }
+
+  /**
+   * Performs an assertion by calling a function and return an Error upon failure.
+   *
+   * @param {Function} fn
+   * @param {Response} res
+   * @return {?Error}
+   * @api private
+   */
+  _assertFunction(fn: any, res: any) {
+    var err;
+    try {
+      err = fn(res);
+    } catch (e) {
+      err = e;
+    }
+    if (err instanceof Error) return err;
+  }
+}
+
+/**
+ * Return an `Error` with `msg` and results properties.
+ *
+ * @param {String} msg
+ * @param {Mixed} expected
+ * @param {Mixed} actual
+ * @return {Error}
+ * @api private
+ */
+
+function error(msg: any, expected: any, actual: any) {
+  var err: any = new Error(msg);
+  err.expected = expected;
+  err.actual = actual;
+  err.showDiff = true;
+  return err;
+}
+
+export default Test;

--- a/src/postgraphile/http/__tests__/supertest/lib/test.ts
+++ b/src/postgraphile/http/__tests__/supertest/lib/test.ts
@@ -25,6 +25,7 @@ const Request: any = request.Request;
 class Test extends Request {
   constructor(app: any, method: any, path: any, host?: any) {
     super(method.toUpperCase(), path);
+    this._enableHttp2 = app._http2;
     this.redirects(0);
     this.buffer();
     this.app = app;
@@ -43,21 +44,16 @@ class Test extends Request {
           this,
           () => donePromise,
           e => {
-            if (this.expectedStatus >= 400) {
+            if (this.expectedStatus >= 400 && e.status === this.expectedStatus) {
               return donePromise;
             } else {
+              console.error(e);
               return Promise.reject(e);
             }
           },
         );
       return promise.then(cb, ecb);
     };
-    ['get', 'post', 'put', 'delete', 'options'].forEach(method => {
-      const old = this[method];
-      this[method] = function(...args) {
-        return old.apply(this, args).http2(app._http2);
-      };
-    });
   }
   /**
    * Returns a URL, extracted from a server.

--- a/src/postgraphile/http/__tests__/supertest/lib/test.ts
+++ b/src/postgraphile/http/__tests__/supertest/lib/test.ts
@@ -37,9 +37,20 @@ class Test extends Request {
       this.completeCallback = resolve;
     });
     let promise;
-    this.then = cb => {
-      if (!promise) promise = oldThen.call(this, () => donePromise, () => donePromise);
-      return promise.then(cb);
+    this.then = (cb, ecb) => {
+      if (!promise)
+        promise = oldThen.call(
+          this,
+          () => donePromise,
+          e => {
+            if (this.expectedStatus >= 400) {
+              return donePromise;
+            } else {
+              return Promise.reject(e);
+            }
+          },
+        );
+      return promise.then(cb, ecb);
     };
   }
   /**
@@ -89,6 +100,7 @@ class Test extends Request {
 
     // status
     if (typeof a === 'number') {
+      this.expectedStatus = a;
       this._asserts.push(this._assertStatus.bind(this, a));
       // body
       if (typeof b !== 'function' && arguments.length > 1) {

--- a/src/postgraphile/http/setupServerSentEvents.ts
+++ b/src/postgraphile/http/setupServerSentEvents.ts
@@ -19,7 +19,11 @@ export default function setupServerSentEvents(
   res.statusCode = 200;
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
+  if (req.httpVersionMajor >= 2) {
+    // NOOP
+  } else {
+    res.setHeader('Connection', 'keep-alive');
+  }
   const koaCtx = (req as object)['_koaCtx'];
   const isKoa = !!koaCtx;
   const stream = isKoa ? new PassThrough() : null;

--- a/src/postgraphile/http/setupServerSentEvents.ts
+++ b/src/postgraphile/http/setupServerSentEvents.ts
@@ -60,4 +60,5 @@ export default function setupServerSentEvents(
   req.on('close', cleanup);
   req.on('finish', cleanup);
   req.on('error', cleanup);
+  _emitter.on('test:close', cleanup);
 }

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -50,7 +50,7 @@ export function getPostgraphileSchemaBuilder(
   // Creates the Postgres schemas array.
   const pgSchemas: Array<string> = Array.isArray(schema) ? schema : [schema];
 
-  const _emitter = new EventEmitter();
+  const _emitter = options._emitter || new EventEmitter();
 
   // Creates a promise which will resolve to a GraphQL schema. Connects a
   // client from our pool to introspect the database.

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,11 +710,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/cookiejar@*":
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
-  integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
-
 "@types/cookies@*":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.1.tgz#f9f204bd6767d389eea3b87609e30c090c77a540"
@@ -873,14 +868,6 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
-
-"@types/superagent@^3.8.6":
-  version "3.8.6"
-  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.6.tgz#3676d8920d8979ea4ca57513f27995064f92dc43"
-  integrity sha512-YQjdsk27MLb6uyXjjywGyYeuqavwV3CirHt6btBz00HkKJyowdB8gjjB1zIZxrOybDRqO8FLjTZeEtmtC2hqxA==
-  dependencies:
-    "@types/cookiejar" "*"
-    "@types/node" "*"
 
 "@types/ws@^6.0.1":
   version "6.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -710,6 +710,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cookiejar@*":
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/@types/cookiejar/-/cookiejar-2.1.1.tgz#90b68446364baf9efd8e8349bb36bd3852b75b80"
+  integrity sha512-aRnpPa7ysx3aNW60hTiCtLHlQaIFsXFCgQlpakNgDNVFzbtusSY8PwjAQgRWfSk0ekNoBjO51eQRB6upA9uuyw==
+
 "@types/cookies@*":
   version "0.7.1"
   resolved "https://registry.yarnpkg.com/@types/cookies/-/cookies-0.7.1.tgz#f9f204bd6767d389eea3b87609e30c090c77a540"
@@ -868,6 +873,14 @@
   dependencies:
     "@types/express-serve-static-core" "*"
     "@types/mime" "*"
+
+"@types/superagent@^3.8.6":
+  version "3.8.6"
+  resolved "https://registry.yarnpkg.com/@types/superagent/-/superagent-3.8.6.tgz#3676d8920d8979ea4ca57513f27995064f92dc43"
+  integrity sha512-YQjdsk27MLb6uyXjjywGyYeuqavwV3CirHt6btBz00HkKJyowdB8gjjB1zIZxrOybDRqO8FLjTZeEtmtC2hqxA==
+  dependencies:
+    "@types/cookiejar" "*"
+    "@types/node" "*"
 
 "@types/ws@^6.0.1":
   version "6.0.1"
@@ -1299,7 +1312,7 @@ async-limiter@~1.0.0:
   resolved "https://registry.yarnpkg.com/async-limiter/-/async-limiter-1.0.0.tgz#78faed8c3d074ab81f22b4e985d79e8738f720f8"
   integrity sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==
 
-async@^1.4.0, async@^1.5.2:
+async@^1.4.0:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/async/-/async-1.5.2.tgz#ec6a61ae56480c0c3cb241c95618e20892f9672a"
   integrity sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=
@@ -2030,10 +2043,17 @@ colors@1.0.3:
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
   integrity sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs=
 
-combined-stream@1.0.6, combined-stream@^1.0.5, combined-stream@~1.0.5:
+combined-stream@1.0.6, combined-stream@~1.0.5:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.6.tgz#723e7df6e801ac5613113a7e445a9b69cb632818"
   integrity sha1-cj599ugBrFYTETp+RFqbactjKBg=
+  dependencies:
+    delayed-stream "~1.0.0"
+
+combined-stream@^1.0.6:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.7.tgz#2d1d24317afb8abe95d6d2c0b07b57813539d828"
+  integrity sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==
   dependencies:
     delayed-stream "~1.0.0"
 
@@ -2165,7 +2185,7 @@ cookie@0.3.1:
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.3.1.tgz#e7e0a1f9ef43b4c8ba925c5c5a96e806d16873bb"
   integrity sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s=
 
-cookiejar@^2.0.6:
+cookiejar@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/cookiejar/-/cookiejar-2.1.2.tgz#dd8a235530752f988f9a0844f3fc589e3111125c"
   integrity sha512-Mw+adcfzPxcPeI+0WlvRrr/3lGVO0bD75SxX6811cxSh1Wbxx7xZBGK1eVtDf6si8rg2lhnUjsVLMFMfbRIuwA==
@@ -2368,6 +2388,13 @@ debug@^4.0.1:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.0.tgz#373687bffa678b38b1cd91f861b63850035ddc87"
   integrity sha512-heNPJUJIqC+xB6ayLAMHaIrmN9HKa7aQO8MGqKpvCA+uJYVcvR6l5kgdrhRuwPFHU7P5/A1w0BjByPHwpfTDKg==
+  dependencies:
+    ms "^2.1.1"
+
+debug@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
+  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
   dependencies:
     ms "^2.1.1"
 
@@ -2879,7 +2906,7 @@ extend-shallow@^3.0.0, extend-shallow@^3.0.2:
     assign-symbols "^1.0.0"
     is-extendable "^1.0.1"
 
-extend@^3.0.0, extend@~3.0.1:
+extend@~3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.1.tgz#a755ea7bc1adfcc5a31ce7e762dbaadc5e636444"
   integrity sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ=
@@ -3124,14 +3151,14 @@ forever-agent@~0.6.1:
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
 
-form-data@1.0.0-rc4:
-  version "1.0.0-rc4"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-1.0.0-rc4.tgz#05ac6bc22227b43e4461f488161554699d4f8b5e"
-  integrity sha1-BaxrwiIntD5EYfSIFhVUaZ1Pi14=
+form-data@^2.3.3:
+  version "2.3.3"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
+  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
   dependencies:
-    async "^1.5.2"
-    combined-stream "^1.0.5"
-    mime-types "^2.1.10"
+    asynckit "^0.4.0"
+    combined-stream "^1.0.6"
+    mime-types "^2.1.12"
 
 form-data@~2.3.1:
   version "2.3.2"
@@ -3142,7 +3169,7 @@ form-data@~2.3.1:
     combined-stream "1.0.6"
     mime-types "^2.1.12"
 
-formidable@^1.0.17:
+formidable@^1.2.0:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/formidable/-/formidable-1.2.1.tgz#70fb7ca0290ee6ff961090415f4b3df3d2082659"
   integrity sha512-Fs9VRguL0gqGHkXS5GQiMCr1VhZBxz0JnJs4JmMp/2jL18Fmbzvv7vOFRU+U8TBkHEE/CX1qDXzJplVULgsLeg==
@@ -4889,7 +4916,7 @@ merge@^1.2.0:
   resolved "https://registry.yarnpkg.com/merge/-/merge-1.2.0.tgz#7531e39d4949c281a66b8c5a6e0265e8b05894da"
   integrity sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=
 
-methods@1.x, methods@^1.1.1, methods@~1.1.2:
+methods@^1.1.1, methods@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/methods/-/methods-1.1.2.tgz#5529a4d67654134edcc5266656835b0f851afcee"
   integrity sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4=
@@ -4958,7 +4985,7 @@ mime-db@~1.33.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.33.0.tgz#a3492050a5cb9b63450541e39d9788d2272783db"
   integrity sha512-BHJ/EKruNIqJf/QahvxwQZXKygOQ256myeN/Ew+THcAa5q+PjyTTMMeNQC4DZw5AwfvelsUrA6B67NKMqXDbzQ==
 
-mime-types@^2.1.10, mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.17, mime-types@~2.1.18:
+mime-types@^2.1.12, mime-types@^2.1.18, mime-types@~2.1.17, mime-types@~2.1.18:
   version "2.1.18"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.18.tgz#6f323f60a83d11146f831ff11fd66e2fe5503bb8"
   integrity sha512-lc/aahn+t4/SWV/qcmumYjymLsWfN3ELhpmVuUFjgsORruuZPVSwAQryq+HHGvO/SI2KVX26bx+En+zhM8g8hQ==
@@ -4970,10 +4997,10 @@ mime@1.4.1:
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.4.1.tgz#121f9ebc49e3766f311a76e1fa1c8003c4b03aa6"
   integrity sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==
 
-mime@^1.3.4:
-  version "1.6.0"
-  resolved "https://registry.yarnpkg.com/mime/-/mime-1.6.0.tgz#32cd9e5c64553bd58d19a568af452acff04981b1"
-  integrity sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==
+mime@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/mime/-/mime-2.4.0.tgz#e051fd881358585f3279df333fe694da0bcffdd6"
+  integrity sha512-ikBcWwyqXQSHKtciCcctu9YfPbFYZ4+gbHEmE0Q8jzcTYQg5dHCr3g2wwAZjPoJfQVXZq6KXAjpXOTf5/cjT7w==
 
 minimalistic-assert@^1.0.0, minimalistic-assert@^1.0.1:
   version "1.0.1"
@@ -5958,10 +5985,15 @@ qs@6.5.1:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
   integrity sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==
 
-qs@6.5.2, qs@^6.1.0, qs@~6.5.1:
+qs@6.5.2, qs@~6.5.1:
   version "6.5.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+
+qs@^6.6.0:
+  version "6.6.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.6.0.tgz#a99c0f69a8d26bf7ef012f871cdabb0aee4424c2"
+  integrity sha512-KIJqT9jQJDQx5h5uAVPimw6yVg2SekOKu959OCtktD3FjzbpvaPr8i4zzg07DOMz+igA4W/aNM7OV8H37pFYfA==
 
 querystring-es3@^0.2.0:
   version "0.2.1"
@@ -6056,7 +6088,7 @@ read-pkg@^1.0.0:
     normalize-package-data "^2.3.2"
     path-type "^1.0.0"
 
-"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.5, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
+"readable-stream@1 || 2", readable-stream@^2.0.0, readable-stream@^2.0.1, readable-stream@^2.0.2, readable-stream@^2.0.4, readable-stream@^2.0.6, readable-stream@^2.1.5, readable-stream@^2.2.2, readable-stream@^2.3.3, readable-stream@^2.3.6, readable-stream@~2.3.6:
   version "2.3.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-2.3.6.tgz#b11c27d88b8ff1fbe070643cf94b0c79ae1b0aaf"
   integrity sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==
@@ -6083,6 +6115,15 @@ readable-stream@^3.0.0:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.0.6.tgz#351302e4c68b5abd6a2ed55376a7f9a25be3057a"
   integrity sha512-9E1oLoOWfhSXHGv6QlwXJim7uNzd9EVlWK+21tCU9Ju/kR0/p2AZYPz4qSchgO8PlLIH4FpZYfzwS+rEksZjIg==
+  dependencies:
+    inherits "^2.0.3"
+    string_decoder "^1.1.1"
+    util-deprecate "^1.0.1"
+
+readable-stream@^3.0.6:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/readable-stream/-/readable-stream-3.1.1.tgz#ed6bbc6c5ba58b090039ff18ce670515795aeb06"
+  integrity sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==
   dependencies:
     inherits "^2.0.3"
     string_decoder "^1.1.1"
@@ -6830,29 +6871,20 @@ subscriptions-transport-ws@^0.9.15:
     symbol-observable "^1.0.4"
     ws "^5.2.0"
 
-superagent@^2.0.0:
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/superagent/-/superagent-2.3.0.tgz#703529a0714e57e123959ddefbce193b2e50d115"
-  integrity sha1-cDUpoHFOV+EjlZ3e+84ZOy5Q0RU=
+superagent@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/superagent/-/superagent-4.1.0.tgz#c465c2de41df2b8d05c165cbe403e280790cdfd5"
+  integrity sha512-FT3QLMasz0YyCd4uIi5HNe+3t/onxMyEho7C3PSqmti3Twgy2rXT4fmkTz6wRL6bTF4uzPcfkUCa8u4JWHw8Ag==
   dependencies:
     component-emitter "^1.2.0"
-    cookiejar "^2.0.6"
-    debug "^2.2.0"
-    extend "^3.0.0"
-    form-data "1.0.0-rc4"
-    formidable "^1.0.17"
+    cookiejar "^2.1.2"
+    debug "^4.1.0"
+    form-data "^2.3.3"
+    formidable "^1.2.0"
     methods "^1.1.1"
-    mime "^1.3.4"
-    qs "^6.1.0"
-    readable-stream "^2.0.5"
-
-supertest@^2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/supertest/-/supertest-2.0.1.tgz#a058081d788f1515d4700d7502881e6b759e44cd"
-  integrity sha1-oFgIHXiPFRXUcA11Aogea3WeRM0=
-  dependencies:
-    methods "1.x"
-    superagent "^2.0.0"
+    mime "^2.4.0"
+    qs "^6.6.0"
+    readable-stream "^3.0.6"
 
 supports-color@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
Fixes #994 


This PR that took me many hours:

- disables one line of code when in HTTP2 mode (namely: `res.setHeader('Connection', 'keep-alive');`)
- includes a fork of supertest that sort-of supports superagent v4 which supports http2
- hopefully doesn't introduce any bugs into the tests
- was a pain in the butt.