### PR TITLE
fix(postgraphile): add buffer support as jwt secret

### DIFF
--- a/prettier.config.js
+++ b/prettier.config.js
@@ -2,5 +2,5 @@ module.exports = {
   printWidth: 100,
   semi: true,
   singleQuote: true,
-  trailingComma: "all",
-}
+  trailingComma: 'all',
+};

--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -283,9 +283,15 @@ async function getSettingsForPgClientTransaction({
     // Try to run `jwt.verify`. If it fails, capture the error and re-throw it
     // as a 403 error because the token is not trustworthy.
     try {
-      // If a JWT token was defined, but a secret was not provided to the server
-      // throw a 403 error.
-      if (typeof jwtSecret !== 'string') throw new Error('Not allowed to provide a JWT token.');
+      // If a JWT token was defined, but a secret was not provided to the server or
+      // secret had unsupported type, throw a 403 error.
+      if (!Buffer.isBuffer(jwtSecret) && typeof jwtSecret !== 'string') {
+        // tslint:disable-next-line no-console
+        console.error(
+          'ERROR: `jwtToken` was provided, but `jwtSecret` was not set to a string or buffer - rejecting request.',
+        );
+        throw new Error('Not allowed to provide a JWT token.');
+      }
 
       if (jwtAudiences != null && jwtVerifyOptions && 'audience' in jwtVerifyOptions)
         throw new Error(


### PR DESCRIPTION
Currently it is only accepted to provide type `string` for JWT secret when JWT can accept both `buffer` and `string`. With this PR, we allow type buffer to be passed as jwtSecret.