### PR TITLE
Improvements to Forum Example Authentication and Windows Support for Build Schema Script

### DIFF
--- a/examples/forum/scripts/build-schema
+++ b/examples/forum/scripts/build-schema
@@ -32,7 +32,7 @@ ${schemaMarkdownFile
     if (isInsideMarkdownSQLCode) {
       // If this line closes our SQL, do not include this line, but do
       // change our state.
-      if (line === '```') {
+      if (line.trim() === '```') {
         isInsideMarkdownSQLCode = false
         return `${sql}\n`
       }
@@ -42,7 +42,7 @@ ${schemaMarkdownFile
     // code so far.
     else {
       // If this line opens a block of SQL, change our state.
-      if (line === '```sql')
+      if (line.trim() === '```sql')
         isInsideMarkdownSQLCode = true
 
       return sql


### PR DESCRIPTION
This is a pretty small set of changes.

1. Simplified the `authenticate` function in the schema so that it is simple sql code that requires less explanation.
1. Added a `change_password` functionality.
1. Added Windows support to the build_schema (just needed to add `trim` thanks to windows newline nonsense)