### PR TITLE
making the jwtRole optional, fixes #1028

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -302,7 +302,7 @@ export interface WithPostGraphileContextOptions {
   jwtToken?: string;
   jwtSecret?: string;
   jwtAudiences?: Array<string>;
-  jwtRole: Array<string>;
+  jwtRole?: Array<string>;
   jwtVerifyOptions?: jwt.VerifyOptions;
   pgDefaultRole?: string;
   pgSettings?: { [key: string]: mixed };


### PR DESCRIPTION
The WithPostGraphileContextOptions interface does not require this property and sets a default if it needs one.