### PR TITLE
feat(server): option to not exit when initial schema build fails

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -52,6 +52,12 @@ export interface PostGraphileOptions<
   //   `DROP SCHEMA postgraphile_watch CASCADE;`
   /* @middlewareOnly */
   watchPg?: boolean;
+  // When true (default), PostGraphile will exit if it fails to build the
+  // initial schema (for example if it cannot connect to the database, or if
+  // there are fatal naming conflicts in the schema). When false, PostGraphile
+  // will keep trying to rebuilding the schema with exponential backoff,
+  // starting at 100ms and increasing up to 30s.
+  exitOnFail?: boolean;
   // Connection string to use to connect to the database as a privileged user (e.g. for setting up watch fixtures, logical decoding, etc).
   ownerConnectionString?: string;
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -52,12 +52,14 @@ export interface PostGraphileOptions<
   //   `DROP SCHEMA postgraphile_watch CASCADE;`
   /* @middlewareOnly */
   watchPg?: boolean;
-  // When true (default), PostGraphile will exit if it fails to build the
+  // When false (default), PostGraphile will exit if it fails to build the
   // initial schema (for example if it cannot connect to the database, or if
-  // there are fatal naming conflicts in the schema). When false, PostGraphile
-  // will keep trying to rebuilding the schema with exponential backoff,
-  // starting at 100ms and increasing up to 30s.
-  exitOnFail?: boolean;
+  // there are fatal naming conflicts in the schema). When true, PostGraphile
+  // will keep trying to rebuild the schema indefinitely, using an exponential
+  // backoff between attempts, starting at 100ms and increasing up to 30s delay
+  // between retries.
+  /* @middlewareOnly */
+  retryOnInitFail?: boolean;
   // Connection string to use to connect to the database as a privileged user (e.g. for setting up watch fixtures, logical decoding, etc).
   ownerConnectionString?: string;
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -132,6 +132,10 @@ program
   .option(
     '-r, --default-role <string>',
     'the default Postgres role to use when a request is made. supercedes the role used to connect to the database',
+  )
+  .option(
+    '--no-exit-on-fail',
+    'if an error occurs building the initial schema, this flag will cause PostGraphile to keep trying to build the schema with exponential backoff rather than exiting',
   );
 
 pluginHook('cli:flags:add:standard', addFlag);
@@ -384,7 +388,7 @@ process.on('SIGINT', () => {
 // re-overwrites the values if necessary.
 const configOptions = config['options'] || {};
 const overridesFromOptions = {};
-['ignoreIndexes', 'ignoreRbac', 'setofFunctionsContainNulls'].forEach(option => {
+['ignoreIndexes', 'ignoreRbac', 'setofFunctionsContainNulls', 'exitOnFail'].forEach(option => {
   if (option in configOptions) {
     overridesFromOptions[option] = configOptions[option];
   }
@@ -405,6 +409,7 @@ const {
   timeout: serverTimeout,
   maxPoolSize,
   defaultRole: pgDefaultRole,
+  exitOnFail = true,
   graphql: graphqlRoute = '/graphql',
   graphiql: graphiqlRoute = '/graphiql',
   enhanceGraphiql = false,
@@ -590,6 +595,7 @@ const postgraphileOptions = pluginHook(
     jwtAudiences,
     jwtRole,
     jwtVerifyOptions,
+    exitOnFail,
     pgDefaultRole,
     subscriptions: subscriptions || live,
     live,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -134,7 +134,7 @@ program
     'the default Postgres role to use when a request is made. supercedes the role used to connect to the database',
   )
   .option(
-    '--no-exit-on-fail',
+    '--retry-on-init-fail',
     'if an error occurs building the initial schema, this flag will cause PostGraphile to keep trying to build the schema with exponential backoff rather than exiting',
   );
 
@@ -388,7 +388,7 @@ process.on('SIGINT', () => {
 // re-overwrites the values if necessary.
 const configOptions = config['options'] || {};
 const overridesFromOptions = {};
-['ignoreIndexes', 'ignoreRbac', 'setofFunctionsContainNulls', 'exitOnFail'].forEach(option => {
+['ignoreIndexes', 'ignoreRbac', 'setofFunctionsContainNulls'].forEach(option => {
   if (option in configOptions) {
     overridesFromOptions[option] = configOptions[option];
   }
@@ -409,7 +409,7 @@ const {
   timeout: serverTimeout,
   maxPoolSize,
   defaultRole: pgDefaultRole,
-  exitOnFail = true,
+  retryOnInitFail,
   graphql: graphqlRoute = '/graphql',
   graphiql: graphiqlRoute = '/graphiql',
   enhanceGraphiql = false,
@@ -595,7 +595,7 @@ const postgraphileOptions = pluginHook(
     jwtAudiences,
     jwtRole,
     jwtVerifyOptions,
-    exitOnFail,
+    retryOnInitFail,
     pgDefaultRole,
     subscriptions: subscriptions || live,
     live,

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -115,12 +115,18 @@ export function getPostgraphileSchemaBuilder<
       } catch (error) {
         attempts++;
         const delay = Math.min(100 * Math.pow(attempts, 2), 30000);
-        // If we fail to build our schema, log the error and retry shortly
+        // exitOnFail defaults to true
+        const { exitOnFail = true } = options;
+        // If we fail to build our schema, log the error and either exit or retry shortly
         logSeriousError(
           error,
           'building the initial schema' + (attempts > 1 ? ` (attempt ${attempts})` : ''),
-          `We'll try again in ${delay}ms.`,
+          exitOnFail ? 'Exiting because `exitOnFail` is true.' : `We'll try again in ${delay}ms.`,
         );
+        if (exitOnFail) {
+          process.exit(34);
+        }
+        // Retry shortly
         await sleep(delay);
       }
     }

--- a/src/postgraphile/postgraphile.ts
+++ b/src/postgraphile/postgraphile.ts
@@ -115,13 +115,14 @@ export function getPostgraphileSchemaBuilder<
       } catch (error) {
         attempts++;
         const delay = Math.min(100 * Math.pow(attempts, 2), 30000);
-        // exitOnFail defaults to true
-        const { exitOnFail = true } = options;
+        const exitOnFail = !options.retryOnInitFail;
         // If we fail to build our schema, log the error and either exit or retry shortly
         logSeriousError(
           error,
           'building the initial schema' + (attempts > 1 ? ` (attempt ${attempts})` : ''),
-          exitOnFail ? 'Exiting because `exitOnFail` is true.' : `We'll try again in ${delay}ms.`,
+          exitOnFail
+            ? 'Exiting because `retryOnInitFail` is not set.'
+            : `We'll try again in ${delay}ms.`,
         );
         if (exitOnFail) {
           process.exit(34);


### PR DESCRIPTION
Relates to #1044

Prevents this new feature being a breaking change.

To _not_ exit on fail you need to set either `--retry-on-init-fail` on the CLI or `retryOnInitFail: true` in the library.