### PR TITLE
fix(postgraphile): use externalUrlBase for websockets

### DIFF
--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -62,6 +62,7 @@ export async function enhanceHttpServerWithSubscriptions(
     handleErrors,
   } = postgraphileMiddleware;
   const pluginHook = pluginHookFromOptions(options);
+  const externalUrlBase = options.externalUrlBase || '';
   const graphqlRoute = options.graphqlRoute || '/graphql';
 
   const schema = await getGraphQLSchema();
@@ -152,9 +153,8 @@ export async function enhanceHttpServerWithSubscriptions(
   let socketId = 0;
 
   websocketServer.on('upgrade', (req, socket, head) => {
-    // TODO: this will not support mounting postgraphile at a subpath right now...
     const { pathname = '' } = parseUrl(req) || {};
-    const isGraphqlRoute = pathname === graphqlRoute;
+    const isGraphqlRoute = pathname === externalUrlBase + graphqlRoute;
     if (isGraphqlRoute) {
       wss.handleUpgrade(req, socket, head, ws => {
         wss.emit('connection', ws, req);


### PR DESCRIPTION
https://github.com/graphile/postgraphile/blob/44c44e2196883b7d659ff796e1eac8c4557e0884/src/postgraphile/http/subscriptions.ts#L155

Subscriptions do not work correctly when mounted on a subpath. This pull request resolves this for most use cases by using the value of the existing `externalUrlBase` option to determine whether we should account for a specific subpath in the web socket handler.

The documentation already tells users to fill out when mounting Postgraphile at a subpath, so no additional changes are required by users wanting to take advantage of this fix.

When this option is not specified we default to a empty string which results in the same behaviour as before.