### PR TITLE
New feature graphiql-authorization-event-origin

### DIFF
--- a/postgraphiql/public/example_authorization_wrapper/index.html
+++ b/postgraphiql/public/example_authorization_wrapper/index.html
@@ -1,0 +1,57 @@
+<!doctype html>
+<!-- As a very rough example, this page can be hosted with http-server.
+	Longer term, better to have it be a page that could be served by the postgraphile cli or something maybe?
+	
+	1. npm install http-server -g
+	2. cd .../public/example_authorization_wrapper
+	3. http-server
+	4. postgraphile -c ... --jwt-secret magic --graphiql-authorization-event-origin http://localhost:8080
+	5. Visit http://localhost:8080/
+	6. Open Developer Tools console
+	7. Should see message: "Setting up listener for messages from  http://localhost:8080"
+	8. Make a JWT token using the secret above (i.e. jwt.io)
+	9. Paste it into the input field at the top of the page
+	10. Should see the messages: "Sending changed authorization value to graphiql iframe" and "Authorization header updated by  http://localhost:8080"
+-->
+<html lang="en">
+  <head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <title>PostGraphile GraphiQL with Authorization Passthrough</title>
+    <meta name="robots" content="noindex"/>
+    <style>
+      body, html {width: 100%; height: 100%; margin: 0; padding: 0}
+      .row-container {display: flex; width: 100%; height: 100%; flex-direction: column; overflow: hidden;}
+      .first-row {}
+      .second-row { flex-grow: 1; border: none; margin: 0; padding: 0; }
+    </style>
+    <script>
+      document.addEventListener('DOMContentLoaded', function() {
+        document.querySelector("#authorization").addEventListener("change",function (evt) {
+          console.log('Sending changed authorization value to graphiql iframe');
+          document.querySelector("#graphiql").contentWindow.postMessage(
+            // The data to pass
+            { Authorization: evt.target.value },
+            // The expected origin of the target
+            "http://localhost:5000/"
+          );
+        });
+      }, false);
+    </script>
+  </head>
+  <body>
+    <div class="row-container">
+      <div class="first-row">
+        <p>This example shows how to embed the GraphiQL app inside another site and use window.postMessage to update the Authorization header used for queries.</p>
+
+        <label for="authorization">Enter an Authorization header value (i.e. a Bearer JWT token):</label>
+
+        <input type="text" id="authorization" name="authorization" required size="50" placeholder="Bearer ..."/>
+      </div>
+      <iframe id="graphiql"
+              title="Embedded GraphiQL" 
+              class="second-row"
+              src="http://localhost:5000/graphiql"/>
+    </div>
+  </body>
+</html>

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -163,9 +163,11 @@ class PostGraphiQL extends React.PureComponent {
      * a message event listener to allow windows with that origin to update our Authorization header.
      */
     if (POSTGRAPHILE_CONFIG.graphiqlAuthorizationEventOrigin) {
-      console.log('Setting up listener for messages from ', POSTGRAPHILE_CONFIG.graphiqlAuthorizationEventOrigin);
+      // We want to support a space separated list of origins but avoid a false positive if someone is tricky.
+      const paddedOriginsList = ` ${POSTGRAPHILE_CONFIG.graphiqlAuthorizationEventOrigin} `;
+      console.log('Setting up listener for messages from', paddedOriginsList);
       window.addEventListener("message", (event) => {
-          if (event.origin !== POSTGRAPHILE_CONFIG.graphiqlAuthorizationEventOrigin) {
+          if (!paddedOriginsList.includes(event.origin)) {
             console.error('window.postMessage received from an unauthorized origin: ', event.origin);
             return;
           }
@@ -174,7 +176,7 @@ class PostGraphiQL extends React.PureComponent {
             const val = JSON.stringify({ Authorization: event.data.Authorization });
             // destructuring to be paranoid and grab only the Authorization header value
             this.updateHeadersState(val);
-            console.log('Authorization header updated by ', POSTGRAPHILE_CONFIG.graphiqlAuthorizationEventOrigin);
+            console.log('Authorization header updated by ', event.origin);
           }
         }, false);
     } else {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -184,6 +184,10 @@ export interface PostGraphileOptions<
   // Set this to `true` to enable the GraphiQL interface.
   /* @middlewareOnly */
   graphiql?: boolean;
+  // Set this to a URI to allow windows from that origin to call window.postMessage on the graphiql window
+  // with data object containing an Authorization header value.  Defaults to `null` which disables this functionality.
+  /* @middlewareOnly */
+  graphiqlAuthorizationEventOrigin?: string;
   // Set this to `true` to add some enhancements to GraphiQL; intended for development usage only (automatically enables with `subscriptions` and `live`).
   /* @middlewareOnly */
   enhanceGraphiql?: boolean;

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -249,6 +249,10 @@ program
     '[DEVELOPMENT] opt in to additional GraphiQL functionality (this may change over time - only intended for use in development; automatically enables with `subscriptions` and `live`)',
   )
   .option(
+    '--graphiql-authorization-event-origin <string>',
+    'specifies the URI of a window that is allowed to use window.postMessage to update the Authorization header value GraphiQL uses to make GraphQL requests.',
+  )
+  .option(
     '-b, --disable-graphiql',
     'disables the GraphiQL interface. overrides the GraphiQL route option',
   )
@@ -413,6 +417,7 @@ const {
   graphql: graphqlRoute = '/graphql',
   graphiql: graphiqlRoute = '/graphiql',
   enhanceGraphiql = false,
+  graphiqlAuthorizationEventOrigin = null,
   disableGraphiql = false,
   secret: deprecatedJwtSecret,
   jwtSecret,
@@ -590,6 +595,7 @@ const postgraphileOptions = pluginHook(
     graphiqlRoute,
     graphiql: !disableGraphiql,
     enhanceGraphiql: enhanceGraphiql ? true : undefined,
+    graphiqlAuthorizationEventOrigin,
     jwtPgTypeIdentifier: jwtPgTypeIdentifier || deprecatedJwtPgTypeIdentifier,
     jwtSecret: jwtSecret || deprecatedJwtSecret,
     jwtAudiences,


### PR DESCRIPTION
allows a window to update graphiql with an authorization header value to be used on every request

See postgraphiql/public/example_authorization_wrapper/index.html for a quick demo

Happy to turn it into a proper PR if there is interest.