### PR TITLE
Remove @types/graphql dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
   },
   "dependencies": {
     "@graphile/lru": "^4.4.1-alpha.2",
-    "@types/graphql": "^14.0.3",
     "@types/jsonwebtoken": "^8.3.2",
     "@types/koa": "^2.0.44",
     "@types/pg": "^7.4.10",

--- a/rmlocal.sh
+++ b/rmlocal.sh
@@ -1,1 +1,1 @@
-rm -Rf node_modules/graphile-utils node_modules/graphile-build node_modules/graphile-build-pg node_modules/postgraphile-core/ node_modules/graphql-parse-resolve-info node_modules/graphql node_modules/pg-sql2 node_modules/@types/graphql node_modules/@types/pg node_modules/pg-sql2 node_modules/@graphile
+rm -Rf node_modules/graphile-utils node_modules/graphile-build node_modules/graphile-build-pg node_modules/postgraphile-core/ node_modules/graphql-parse-resolve-info node_modules/graphql node_modules/pg-sql2 node_modules/@types/pg node_modules/pg-sql2 node_modules/@graphile

--- a/yarn.lock
+++ b/yarn.lock
@@ -983,7 +983,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/graphql@^14.0.3", "@types/graphql@^14.2.0":
+"@types/graphql@^14.2.0":
   version "14.2.0"
   resolved "https://registry.yarnpkg.com/@types/graphql/-/graphql-14.2.0.tgz#74e1da5f2a4a744ac6eb3ed57b48242ea9367202"
   integrity sha512-lELg5m6eBOmATWyCZl8qULEOvnPIUG6B443yXKj930glXIgwQirIBPp5rthP2amJW0YSzUg2s5sfgba4mRRCNw==
@@ -3348,9 +3348,9 @@ graphql-parse-resolve-info@4.4.3:
     debug "^4.1.1"
 
 "graphql@^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2":
-  version "14.3.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.3.1.tgz#b3aa50e61a841ada3c1f9ccda101c483f8e8c807"
-  integrity sha512-FZm7kAa3FqKdXy8YSSpAoTtyDFMIYSpCDOr+3EqlI1bxmtHu+Vv/I2vrSeT1sBOEnEniX3uo4wFhFdS/8XN6gA==
+  version "14.5.3"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.5.3.tgz#e025851cc413e153220f4edbbb25d49f55104fa0"
+  integrity sha512-W8A8nt9BsMg0ZK2qA3DJIVU6muWhxZRYLTmc+5XGwzWzVdUdPVlAAg5hTBjiTISEnzsKL/onasu6vl3kgGTbYg==
   dependencies:
     iterall "^1.2.2"
 


### PR DESCRIPTION
When installing postgraphile, I get warnings:
```
warning postgraphile > @types/graphql@14.5.0: This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.
warning postgraphile > postgraphile-core > @types/graphql@14.5.0: This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.
warning postgraphile > postgraphile-core > graphile-build > @types/graphql@14.5.0: This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.
warning postgraphile > postgraphile-core > graphile-build > graphql-parse-resolve-info > @types/graphql@14.5.0: This is a stub types definition. graphql provides its own type definitions, so you do not need this installed.

```
This PR, together with https://github.com/graphile/graphile-engine/pull/511 should fix them