### PR TITLE
fix(cli): abort if given unused arguments

### DIFF
--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -381,7 +381,7 @@ function exitWithErrorMessage(message: string): never {
   console.error(message);
   console.error();
   console.error('For help, run `postgraphile --help`');
-  return process.exit(1);
+  process.exit(1);
 }
 
 if (program.args.length) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7453,9 +7453,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^3.4.3:
-  version "3.6.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.6.3.tgz#fea942fabb20f7e1ca7164ff626f1a9f3f70b4da"
-  integrity sha512-N7bceJL1CtRQ2RiG0AQME13ksR7DiuQh/QehubYcghzv20tnh+MQnQIuJddTmsbqYj+dztchykemz0zFzlvdQw==
+  version "3.7.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.2.tgz#27e489b95fa5909445e9fef5ee48d81697ad18fb"
+  integrity sha512-ml7V7JfiN2Xwvcer+XAf2csGO1bPBdRbFCkYBczNZggrBZ9c7G3riSUeJmqEU5uOtXNPMhE3n+R4FA/3YOAWOQ==
 
 uglify-js@3.4.x:
   version "3.4.10"


### PR DESCRIPTION
Fixes #1092  
Fixes #881

If this breaks your application then it's because some of your CLI arguments were being ignored. This could potentially be very dangerous; as such I'm calling this a bugfix rather than a breaking change. I don't believe there's any projects legitimately relying on this broken behaviour. If you need to add CLI arguments for a plugin or similar the way to achieve this is with a [server plugin](https://www.graphile.org/postgraphile/plugins/).

If you're affected by this (CLI only) you'll notice because the server will immediately exit with a failing status code (currently `1` but don't rely on that).