### PR TITLE
fix(graphiql): fix operation detection on multi-op documents

### DIFF
--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -41,11 +41,21 @@ const defaultQuery = `\
 #
 `;
 
-const isSubscription = ({ query }) =>
-  parse(query).definitions.some(
+const isSubscription = ({ query, operationName }) => {
+  const { definitions } = parse(query);
+
+  if (operationName) {
+    const definition = definitions.find(def => def.name && def.name.value === operationName);
+    if (definition) {
+      return definition.operation === 'subscription';
+    }
+  }
+
+  return definitions.some(
     definition =>
       definition.kind === 'OperationDefinition' && definition.operation === 'subscription',
   );
+};
 
 const {
   POSTGRAPHILE_CONFIG = {

--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import GraphiQL from 'graphiql';
-import { parse } from 'graphql';
+import { getOperationAST, parse } from 'graphql';
 import GraphiQLExplorer from 'graphiql-explorer';
 import StorageAPI from 'graphiql/dist/utility/StorageAPI';
 import './postgraphiql.css';
@@ -42,19 +42,11 @@ const defaultQuery = `\
 `;
 
 const isSubscription = ({ query, operationName }) => {
-  const { definitions } = parse(query);
+  const node = parse(query);
 
-  if (operationName) {
-    const definition = definitions.find(def => def.name && def.name.value === operationName);
-    if (definition) {
-      return definition.operation === 'subscription';
-    }
-  }
+  const operation = getOperationAST(node, operationName);
 
-  return definitions.some(
-    definition =>
-      definition.kind === 'OperationDefinition' && definition.operation === 'subscription',
-  );
+  return operation && operation.operation === 'subscription';
 };
 
 const {


### PR DESCRIPTION
in isSubscription not all operations always run, so
if there is provided name of operation, check only that operation type.