### PR TITLE
feat(types): much stronger TypeScript types

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "version": "yarn run changelog && git add CHANGELOG.md"
   },
   "dependencies": {
-    "@graphile/lru": "4.5.0",
+    "@graphile/lru": "4.6.0-alpha.0",
     "@types/json5": "^0.0.30",
     "@types/jsonwebtoken": "^8.3.2",
     "@types/koa": "^2.0.44",
@@ -58,7 +58,7 @@
     "commander": "^2.19.0",
     "debug": "^4.1.1",
     "finalhandler": "^1.0.6",
-    "graphile-utils": "^4.5.2",
+    "graphile-utils": "^4.6.0-alpha.0",
     "graphql": "^0.6.0 || ^0.7.0 || ^0.8.0-b || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.2",
     "http-errors": "^1.5.1",
     "iterall": "^1.0.2",
@@ -67,8 +67,8 @@
     "parseurl": "^1.3.2",
     "pg": ">=6.1.0 <8",
     "pg-connection-string": "^2.0.0",
-    "pg-sql2": "4.5.0",
-    "postgraphile-core": "4.5.0",
+    "pg-sql2": "4.6.0-alpha.0",
+    "postgraphile-core": "4.6.0-alpha.0",
     "subscriptions-transport-ws": "^0.9.15",
     "tslib": "^1.5.0",
     "ws": "^6.1.3"

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,7 @@ export {
   postGraphileClassicIdsOverrides,
   PostGraphileInflectionPlugin,
   PostGraphileClassicIdsInflectionPlugin,
+  GraphileResolverContext,
 } from 'postgraphile-core';
 
 export {
@@ -31,7 +32,7 @@ export {
   watchPostGraphileSchema,
   withPostGraphileContext,
   enhanceHttpServerWithSubscriptions,
-  // Backwards compatability
+  // Backwards compatibility
   postgraphile as postgraphql,
   createPostGraphileSchema as createPostGraphQLSchema,
   watchPostGraphileSchema as watchPostGraphQLSchema,

--- a/src/postgraphile/http/liveSubscribe.ts
+++ b/src/postgraphile/http/liveSubscribe.ts
@@ -20,6 +20,7 @@ import {
 } from 'graphql';
 import mapAsyncIterator from './mapAsyncIterator';
 import { isAsyncIterable } from 'iterall';
+import { GraphileResolverContext } from 'postgraphile-core';
 
 type mixed = any;
 
@@ -27,7 +28,7 @@ export default function liveSubscribe(
   argsOrSchema: any | GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
-  contextValue?: any,
+  contextValue?: GraphileResolverContext,
   variableValues?: { [key: string]: any },
   operationName?: string,
   fieldResolver?: GraphQLFieldResolver<any, any>,
@@ -62,7 +63,7 @@ function liveSubscribeImpl(
   schema: GraphQLSchema,
   document: DocumentNode,
   rootValue?: any,
-  contextValue?: any,
+  contextValue?: GraphileResolverContext,
   variableValues?: { [key: string]: any },
   operationName?: string,
   fieldResolver?: GraphQLFieldResolver<any, any>,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -1,5 +1,5 @@
 import { Server, IncomingMessage, ServerResponse, OutgoingHttpHeaders } from 'http';
-import { HttpRequestHandler, mixed, Middleware } from '../../interfaces';
+import { HttpRequestHandler, Middleware } from '../../interfaces';
 import {
   subscribe as graphqlSubscribe,
   ExecutionResult,
@@ -15,6 +15,7 @@ import parseUrl = require('parseurl');
 import { pluginHookFromOptions } from '../pluginHook';
 import { isEmpty } from './createPostGraphileHttpRequestHandler';
 import liveSubscribe from './liveSubscribe';
+import { GraphileResolverContext } from 'postgraphile-core';
 
 interface Deferred<T> extends Promise<T> {
   resolve: (input?: T | PromiseLike<T> | undefined) => void;
@@ -83,7 +84,7 @@ export async function enhanceHttpServerWithSubscriptions<
   };
 
   const addContextForSocketAndOpId = (
-    context: mixed,
+    context: GraphileResolverContext,
     ws: WebSocket,
     opId: string,
   ): Deferred<void> => {
@@ -153,7 +154,7 @@ export async function enhanceHttpServerWithSubscriptions<
     return { req, res: dummyRes };
   };
 
-  const getContext = (socket: WebSocket, opId: string): Promise<mixed> => {
+  const getContext = (socket: WebSocket, opId: string): Promise<GraphileResolverContext> => {
     return new Promise((resolve, reject): void => {
       reqResFromSocket(socket)
         .then(({ req, res }) =>

--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -56,7 +56,7 @@ export interface PostGraphilePlugin {
   'postgraphile:middleware'?: HookFn<HttpRequestHandler>;
   'postgraphile:ws:onOperation'?: HookFn<ExecutionParams>;
 
-  withPostGraphileContext?: HookFn<WithPostGraphileContextFn>;
+  withPostGraphileContext?: HookFn<WithPostGraphileContextFn<any>>;
 }
 type HookName = keyof PostGraphilePlugin;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -744,10 +744,10 @@
     exec-sh "^0.3.2"
     minimist "^1.2.0"
 
-"@graphile/lru@4.5.0":
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/@graphile/lru/-/lru-4.5.0.tgz#e8fe036d322dfe1715675aab171979981e28ac9e"
-  integrity sha512-OoIgewLowjegJzz3tpcRE5LpQKqsap1ETFaZtC1r9p36h5ieUJnWTxCTpB7XIsU9muMTt7MMt8x0E5apS47QIQ==
+"@graphile/lru@4.6.0-alpha.0":
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/@graphile/lru/-/lru-4.6.0-alpha.0.tgz#ed9c3b32936520781db88d2436625ba40f9d0753"
+  integrity sha512-0TXcROcXyrYx1VSlzxLwIgA7dEqAzm51qqf94aIfa0gfDFg3ClH4dgMT8VkwBGm7Jef9xEDYwqIyL1145g/dMQ==
 
 "@jest/console@^24.7.1", "@jest/console@^24.9.0":
   version "24.9.0"
@@ -1093,6 +1093,11 @@
     "@types/koa-compose" "*"
     "@types/node" "*"
 
+"@types/lodash@^4.14.149":
+  version "4.14.149"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.149.tgz#1342d63d948c6062838fbf961012f74d4e638440"
+  integrity sha512-ijGqzZt/b7BfzcK9vTrS6MFljQRPn5BFWOx8oE0GYxribu6uV+aA9zZuXI1zc/etK9E8nrgdoF2+LgUw7+9tJQ==
+
 "@types/lru-cache@>=4 <5":
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/@types/lru-cache/-/lru-cache-4.1.2.tgz#528ba392658055dba78fc3be906ca338a1a2d1c5"
@@ -1127,18 +1132,28 @@
   dependencies:
     moment ">=2.14.0"
 
-"@types/pg@>=6 <8", "@types/pg@^7.4.10":
-  version "7.11.1"
-  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.11.1.tgz#3b0b53e8be0fd44579f1cdbd27b64a67a7434e03"
-  integrity sha512-ayO8XV0xuJV3cEY4wySyD/7MA1HL75UpvJ5JAme00kNWA5pddlGtN4BRG97xgGe2NHgwxN8AkdjTQUEDypM8Uw==
+"@types/pg@>=6 <8", "@types/pg@^7.11.2", "@types/pg@^7.4.10":
+  version "7.11.2"
+  resolved "https://registry.yarnpkg.com/@types/pg/-/pg-7.11.2.tgz#199dec09426c9359574dedede37313805ba3fca2"
+  integrity sha512-4+rj7fnidA77jFURNanuPPc1HrQv+RkhI6s+K18G9zOKbOUUpChA/rbNMqFukNuZ89LoIt/I9dAlxf329TjCNw==
   dependencies:
     "@types/node" "*"
     "@types/pg-types" "*"
+
+"@types/pluralize@^0.0.29":
+  version "0.0.29"
+  resolved "https://registry.yarnpkg.com/@types/pluralize/-/pluralize-0.0.29.tgz#6ffa33ed1fc8813c469b859681d09707eb40d03c"
+  integrity sha512-BYOID+l2Aco2nBik+iYS4SZX0Lf20KPILP5RGmM1IgzdwNdTs0eebiFriOPcej1sX9mLnSoiNte5zcFxssgpGA==
 
 "@types/range-parser@*":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.3.tgz#7ee330ba7caafb98090bece86a5ee44115904c2c"
   integrity sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==
+
+"@types/semver@^6.2.0":
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/@types/semver/-/semver-6.2.0.tgz#d688d574400d96c5b0114968705366f431831e1a"
+  integrity sha512-1OzrNb4RuAzIT7wHSsgZRlMBlNsJl+do6UblR7JMW4oB7bbR+uBEYtUh7gEc/jM84GGilh68lSOokyM/zNUlBA==
 
 "@types/serve-static@*":
   version "1.13.3"
@@ -3877,41 +3892,43 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.2.tgz#6f0952605d0140c1cfdb138ed005775b92d67b02"
   integrity sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q==
 
-graphile-build-pg@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.5.0.tgz#de3cbc7fff3ed692ffae1f8b531d11a9999ef09c"
-  integrity sha512-zXLLk2PIKi2ehtyGzuGQTMMHk+WDOXw5Bo6Bi3BHbK+t2VAsIauliJA7nNgZ/5Ms2P0aE/FixxIBHxYAC5PS4Q==
+graphile-build-pg@4.6.0-alpha.0:
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-build-pg/-/graphile-build-pg-4.6.0-alpha.0.tgz#1ac3d40d2600d364bc9ad4a9544d66abdad806f8"
+  integrity sha512-mIgEqhcCSuNo6Q+NDZH9P6ArVM4eDS520lBDvJf0XpKEBiow/JH0zZX451xUEDxuSEEq9G95TIWeE3Q2nuLl8g==
   dependencies:
-    "@graphile/lru" "4.5.0"
+    "@graphile/lru" "4.6.0-alpha.0"
+    "@types/lodash" "^4.14.149"
+    "@types/pg" "^7.11.2"
     chalk "^2.4.2"
     debug "^4.1.1"
-    graphile-build "4.5.0"
+    graphile-build "4.6.0-alpha.0"
     graphql-iso-date "^3.6.0"
     jsonwebtoken "^8.5.1"
     lodash ">=4 <5"
-    lru-cache ">=4 <5"
-    pg-sql2 "4.5.0"
+    pg-sql2 "4.6.0-alpha.0"
     postgres-interval "^1.2.0"
 
-graphile-build@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.5.0.tgz#f7c627c146e051f454c4f19116231e9d8b653e04"
-  integrity sha512-U/1K4nHWp3MGJ7kwTwIYBZnO3ZDlufmHHpdd1t4uFA46OtxdP7RG7KnXyol/XB8hfTfqSVGabaZP8lr+NVyQPA==
+graphile-build@4.6.0-alpha.0:
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-build/-/graphile-build-4.6.0-alpha.0.tgz#2e41cf502a47ffa31fdef7d33b365635789d9828"
+  integrity sha512-MnJPvsRjFzizKG/2bO3gRJVbw81sLgmMhjRXUzSkGc73kjhwyjoh1ECZVIwnH1ys8Fv8PbckEg6mrarjvgtP9g==
   dependencies:
-    "@graphile/lru" "4.5.0"
+    "@graphile/lru" "4.6.0-alpha.0"
+    "@types/pluralize" "^0.0.29"
+    "@types/semver" "^6.2.0"
     chalk "^2.4.2"
     debug "^4.1.1"
-    graphql-parse-resolve-info "4.5.0"
+    graphql-parse-resolve-info "4.6.0-alpha.0"
     iterall "^1.2.2"
     lodash ">=4 <5"
-    lru-cache "^5.0.0"
     pluralize "^7.0.0"
     semver "^6.0.0"
 
-graphile-utils@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/graphile-utils/-/graphile-utils-4.5.2.tgz#c4938910c9df9acdff30388d2ab1b43236ed6335"
-  integrity sha512-UZrelrqxrEszClVE0MP1cc9+1vcpriK0BywIPneD1/4wu87kWmTbAGPO9orp4ePv9S+MHnqQuGwnDuKTYoLwVA==
+graphile-utils@^4.6.0-alpha.0:
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphile-utils/-/graphile-utils-4.6.0-alpha.0.tgz#908aee7f322e8674001089d7c0fbc41662b68e14"
+  integrity sha512-7G2AlzK7NffRVbFKS59R6j9ygtgfxjYCpxqljXHkf1/r+JtO3aHMX54W8lMHS+qBrsr7We920hClkt5GaQXetQ==
   dependencies:
     debug "^4.1.1"
     graphql ">=0.9 <0.14 || ^14.0.2"
@@ -3921,10 +3938,10 @@ graphql-iso-date@^3.6.0:
   resolved "https://registry.yarnpkg.com/graphql-iso-date/-/graphql-iso-date-3.6.1.tgz#bd2d0dc886e0f954cbbbc496bbf1d480b57ffa96"
   integrity sha512-AwFGIuYMJQXOEAgRlJlFL4H1ncFM8n8XmoVDTNypNOZyQ8LFDG2ppMFlsS862BSTCDcSUfHp8PD3/uJhv7t59Q==
 
-graphql-parse-resolve-info@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.5.0.tgz#cb9bf800c9ce81eebecd86ec62182a7b645d1fad"
-  integrity sha512-51eKipZcj9AQWKLtstAmqys3GmOHUoUwFN/ALe1s4k2his0sP4ASri/ZdqcweLRnno4cDPqp2dcWnJ/Pe2a2rQ==
+graphql-parse-resolve-info@4.6.0-alpha.0:
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/graphql-parse-resolve-info/-/graphql-parse-resolve-info-4.6.0-alpha.0.tgz#a1e3927b1fcca7ae50393c5c50957e778d429a1e"
+  integrity sha512-II5daQl2DQrrK9zUHGl/fu13STo0k7A6Nu1RA886pMEUUVdMncdQHJwEROWIZzCwhbkvfJFyTIaPEqxTgXnQfw==
   dependencies:
     debug "^4.1.1"
 
@@ -5444,7 +5461,7 @@ lowercase-keys@^1.0.0:
   resolved "https://registry.yarnpkg.com/lowercase-keys/-/lowercase-keys-1.0.1.tgz#6f9e30b47084d971a7c820ff15a6c5167b74c26f"
   integrity sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
 
-"lru-cache@>=4 <5", lru-cache@^4.0.1:
+lru-cache@^4.0.1:
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.5.tgz#8bbe50ea85bed59bc9e33dcab8235ee9bcf443cd"
   integrity sha512-sWZlbEP2OsHNkXrMl5GYk/jKk70MBng6UU4YI/qGDYbgf6YbP4EvmqISbXCoJiRKs+1bSpFHVgQxvJ17F2li5g==
@@ -5452,7 +5469,7 @@ lowercase-keys@^1.0.0:
     pseudomap "^1.0.2"
     yallist "^2.1.2"
 
-lru-cache@^5.0.0, lru-cache@^5.1.1:
+lru-cache@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-5.1.1.tgz#1da27e6710271947695daf6848e847f01d84b920"
   integrity sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==
@@ -6391,12 +6408,12 @@ pg-pool@^2.0.4:
   resolved "https://registry.yarnpkg.com/pg-pool/-/pg-pool-2.0.7.tgz#f14ecab83507941062c313df23f6adcd9fd0ce54"
   integrity sha512-UiJyO5B9zZpu32GSlP0tXy8J2NsJ9EFGFfz5v6PSbdz/1hBLX1rNiiy5+mAm5iJJYwfCv4A0EBcQLGWwjbpzZw==
 
-pg-sql2@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-4.5.0.tgz#d1f5f039c5717f8266e340508b1e29e760f5e2ce"
-  integrity sha512-kmqhJgKbOWsVzKjhzsfglZagyrV5fXkrHeY33WdeSsxhegZI1Evpa/lQzG1uQj2ZfLPIePV7RyoaZH8eVHRd3A==
+pg-sql2@4.6.0-alpha.0:
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/pg-sql2/-/pg-sql2-4.6.0-alpha.0.tgz#2d85222dcabc19dbef3428d7ca823b7c1c97c8fb"
+  integrity sha512-oZ3SqsKSEXHBaJTaQomFiIZ3FTqv1UHhWResOLTYiRWr9/n4mE+oHQx9Tx7bPn+k9LQmXV/HzlhN05jb1vSjMw==
   dependencies:
-    "@graphile/lru" "4.5.0"
+    "@graphile/lru" "4.6.0-alpha.0"
     "@types/pg" ">=6 <8"
     debug ">=3 <5"
 
@@ -6559,13 +6576,13 @@ postcss@^7.0.14, postcss@^7.0.5, postcss@^7.0.6:
     source-map "^0.6.1"
     supports-color "^6.1.0"
 
-postgraphile-core@4.5.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.5.0.tgz#b25fa6d9f523669018ad81ab52f0005fdd72556d"
-  integrity sha512-1UE8XmYi2DO1yon1/3x/CJqZdQuFwvPDJ6t81pf2o/DPJJMRJpoNOhtG/KLxNA2NqYbXBEK+H0HGxJiAiFUkQg==
+postgraphile-core@4.6.0-alpha.0:
+  version "4.6.0-alpha.0"
+  resolved "https://registry.yarnpkg.com/postgraphile-core/-/postgraphile-core-4.6.0-alpha.0.tgz#71aebb4a60f96f1c60601a506a7afe2db912fd88"
+  integrity sha512-EDQFd+Tkcc5WwQzwvBSh6Zwe6aVbIj4sRidGFiD+zBew+CLIZ4regfRxvGGClteON60anjt3JBYhK1uBe7aZXw==
   dependencies:
-    graphile-build "4.5.0"
-    graphile-build-pg "4.5.0"
+    graphile-build "4.6.0-alpha.0"
+    graphile-build-pg "4.6.0-alpha.0"
 
 postgres-array@~2.0.0:
   version "2.0.0"


### PR DESCRIPTION
The long planned migration to TypeScript is now complete! Code churn has been absolutely massive, but all the tests still pass and none of the APIs have changed in any significant way.

- https://github.com/graphile/graphile-engine/pull/573
- https://github.com/graphile/graphile-engine/pull/578
- https://github.com/graphile/graphile-engine/pull/579
- https://github.com/graphile/graphile-engine/pull/581

TypeScript users may have to update types in places, particularly if they have their own custom Graphile Engine plugins written in TypeScript.

Anyone using `additionalGraphQLContextFromRequest` may need to use "declaration merging" to allow them to add additional fields to the context that they can then use later:

```ts
declare module 'postgraphile' {
  interface GraphileResolverContext {
    myCustomInt?: number;
  }
}
```

`pgSettings` type definition has been tightened a little to reflect the runtime restrictions that API has.