### PR TITLE
Added websocket transport support for query & mutation.

### DIFF
--- a/SPONSORS.md
+++ b/SPONSORS.md
@@ -8,7 +8,6 @@ sponsor](https://graphile.org/sponsor/).
 
 - Chad Furman
 - Storyscript
-- Point 72 Ventures
 
 ## Leaders
 
@@ -16,16 +15,18 @@ sponsor](https://graphile.org/sponsor/).
 - DOMONDA
 - Stagency
 - James Allain
+- Robert Claypool
 - 8th Light
 - Jack Dinker
 - Nigel Taylor
 - OpenLaw NZ
+- DocIQ
+- Principia Mentis
 - Partners in School Innovation
 - Sterblue
 - HR-ON
-- DocIQ
 - Ian Stewart
-- Principia Mentis
+- Janakan Arulkumarasan
 
 ## Supporters
 
@@ -36,15 +37,14 @@ sponsor](https://graphile.org/sponsor/).
 - Michel Pelletier
 - Chris Watland
 - James Rascoe
-- Dan Lynch
 - Mark Lipscombe
 - purge
-- Robert Claypool
 - Frank
 - Mark Rapoza
 - innovation.rocks
 - cybere
-- dwwoelfel
+- Daniel Woelfel
 - Bjørn Michelsen
 - CJ
 - Ben Botwin
+- Cameron Ellis

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -67,7 +67,7 @@ export interface PostGraphileOptions<
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)
   subscriptions?: boolean;
   // ENable GrqphQL websocket transport support for query & Mutation
-  websocketTransport?: boolean;
+  websocketOperations?: 'all' | 'subscriptions' | 'none';
   // [EXPERIMENTAL] Enables live-query support via GraphQL subscriptions (sends updated payload any time nested collections/records change)
   live?: boolean;
   // [EXPERIMENTAL] If you're using websockets (subscriptions || live) then you

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -66,6 +66,8 @@ export interface PostGraphileOptions<
   ownerConnectionString?: string;
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)
   subscriptions?: boolean;
+  // ENable GrqphQL websocket transport support for query & Mutation
+  websocketTransport?: boolean;
   // [EXPERIMENTAL] Enables live-query support via GraphQL subscriptions (sends updated payload any time nested collections/records change)
   live?: boolean;
   // [EXPERIMENTAL] If you're using websockets (subscriptions || live) then you

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -413,7 +413,8 @@ export default function createPostGraphileHttpRequestHandler(
         )
       : null;
 
-    if (subscriptions) {
+    if (subscriptions || options.websocketOperations == 'all'
+                      || options.websocketOperations == 'subscriptions') {
       const server = req && req.connection && req.connection['server'];
       if (!server) {
         // tslint:disable-next-line no-console

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -413,8 +413,11 @@ export default function createPostGraphileHttpRequestHandler(
         )
       : null;
 
-    if (subscriptions || options.websocketOperations == 'all'
-                      || options.websocketOperations == 'subscriptions') {
+    if (
+      subscriptions ||
+      options.websocketOperations == 'all' ||
+      options.websocketOperations == 'subscriptions'
+    ) {
       const server = req && req.connection && req.connection['server'];
       if (!server) {
         // tslint:disable-next-line no-console

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -415,7 +415,7 @@ export default function createPostGraphileHttpRequestHandler(
 
     if (
       subscriptions &&
-      (options.websocketOperations === 'all' || options.websocketOperations === 'subscriptions')
+      options.websocketOperations !== 'none'
     ) {
       const server = req && req.connection && req.connection['server'];
       if (!server) {

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -414,9 +414,10 @@ export default function createPostGraphileHttpRequestHandler(
       : null;
 
     if (
-      subscriptions ||
-      options.websocketOperations == 'all' ||
-      options.websocketOperations == 'subscriptions'
+      subscriptions && (
+        options.websocketOperations === 'all' ||
+        options.websocketOperations === 'subscriptions'
+      )
     ) {
       const server = req && req.connection && req.connection['server'];
       if (!server) {

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -414,10 +414,8 @@ export default function createPostGraphileHttpRequestHandler(
       : null;
 
     if (
-      subscriptions && (
-        options.websocketOperations === 'all' ||
-        options.websocketOperations === 'subscriptions'
-      )
+      subscriptions &&
+      (options.websocketOperations === 'all' || options.websocketOperations === 'subscriptions')
     ) {
       const server = req && req.connection && req.connection['server'];
       if (!server) {

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -189,7 +189,7 @@ export async function enhanceHttpServerWithSubscriptions<
     {
       schema,
       validationRules: staticValidationRules,
-      execute: options.websocketTransport
+      execute: options.websocketOperations == 'all'
         ? execute
         : () => {
             throw new Error('Only subscriptions are allowed over websocket transport');

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -189,7 +189,8 @@ export async function enhanceHttpServerWithSubscriptions<
     {
       schema,
       validationRules: staticValidationRules,
-      execute: options.websocketTransport ?  execute :  () => {     throw new Error('Only subscriptions are allowed over websocket transport'); },
+      execute: options.websocketTransport ?  execute :
+                () => {  throw new Error('Only subscriptions are allowed over websocket transport'); },
       subscribe: options.live ? liveSubscribe : graphqlSubscribe,
       onConnect(
         connectionParams: object,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -189,7 +189,7 @@ export async function enhanceHttpServerWithSubscriptions<
     {
       schema,
       validationRules: staticValidationRules,
-      execute,
+      execute: options.websocketTransport ?  execute :  () => {     throw new Error('Only subscriptions are allowed over websocket transport'); },
       subscribe: options.live ? liveSubscribe : graphqlSubscribe,
       onConnect(
         connectionParams: object,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -189,11 +189,12 @@ export async function enhanceHttpServerWithSubscriptions<
     {
       schema,
       validationRules: staticValidationRules,
-      execute: options.websocketOperations == 'all'
-        ? execute
-        : () => {
-            throw new Error('Only subscriptions are allowed over websocket transport');
-          },
+      execute:
+        options.websocketOperations == 'all'
+          ? execute
+          : () => {
+              throw new Error('Only subscriptions are allowed over websocket transport');
+            },
       subscribe: options.live ? liveSubscribe : graphqlSubscribe,
       onConnect(
         connectionParams: object,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -189,8 +189,11 @@ export async function enhanceHttpServerWithSubscriptions<
     {
       schema,
       validationRules: staticValidationRules,
-      execute: options.websocketTransport ?  execute :
-                () => {  throw new Error('Only subscriptions are allowed over websocket transport'); },
+      execute: options.websocketTransport
+        ? execute
+        : () => {
+            throw new Error('Only subscriptions are allowed over websocket transport');
+          },
       subscribe: options.live ? liveSubscribe : graphqlSubscribe,
       onConnect(
         connectionParams: object,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -5,6 +5,7 @@ import {
   ExecutionResult,
   specifiedRules,
   validate,
+  execute,
   GraphQLError,
   parse,
   DocumentNode,
@@ -188,9 +189,7 @@ export async function enhanceHttpServerWithSubscriptions<
     {
       schema,
       validationRules: staticValidationRules,
-      execute: () => {
-        throw new Error('Only subscriptions are allowed over websocket transport');
-      },
+      execute,
       subscribe: options.live ? liveSubscribe : graphqlSubscribe,
       onConnect(
         connectionParams: object,

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -190,7 +190,7 @@ export async function enhanceHttpServerWithSubscriptions<
       schema,
       validationRules: staticValidationRules,
       execute:
-        options.websocketOperations == 'all'
+        options.websocketOperations === 'all'
           ? execute
           : () => {
               throw new Error('Only subscriptions are allowed over websocket transport');


### PR DESCRIPTION
`subscriptions-transport-ws` supports websocket transport. I just modified the `execute` function which did the trick for me and seems to work with all the auth etc., too.