### PR TITLE
feat(jwt): add support for JWT_SECRET envvar

### DIFF
--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -664,7 +664,7 @@ const postgraphileOptions = pluginHook(
     graphiql: !disableGraphiql,
     enhanceGraphiql: enhanceGraphiql ? true : undefined,
     jwtPgTypeIdentifier: jwtPgTypeIdentifier || deprecatedJwtPgTypeIdentifier,
-    jwtSecret: jwtSecret || deprecatedJwtSecret,
+    jwtSecret: jwtSecret || deprecatedJwtSecret || process.env.JWT_SECRET,
     jwtPublicKey,
     jwtAudiences,
     jwtSignOptions,


### PR DESCRIPTION
I'm working on using Postgraphile on a cloud hosting service in a customized Docker image.  Being able to pass the `jwtSecret` via environment variables would make configuring different environments a lot easier.

Passing the info via command line arguments makes it harder to reuse one docker image with different settings.

I haven't studied the codebase in depth, I hope that the place I chose is a reasonable place to look for the environment variable.

