### PR TITLE
docs: `readCache` takes an object too

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -145,9 +145,9 @@ export interface PostGraphileOptions<
   replaceAllPlugins?: Array<Plugin>;
   // An array of [Graphile Engine](/graphile-build/plugins/) schema plugins to skip.
   skipPlugins?: Array<Plugin>;
-  // A file path string. Reads cached values from local cache file to improve
-  // startup time (you may want to do this in production).
-  readCache?: string;
+  // A file path string or an object. Reads cached values to improve startup time
+  // (you may want to do this in production).
+  readCache?: string | object;
   // A file path string. Writes computed values to local cache file so startup
   // can be faster (do this during the build phase).
   writeCache?: string;


### PR DESCRIPTION
As per: [graphile/graphile-engine#479](https://github.com/graphile/graphile-engine/pull/479)

Clarifies: [graphile/postgraphile-lambda-example#16](https://github.com/graphile/postgraphile-lambda-example/issues/16)