### PR TITLE
feat: add option for throwOnInitFail to handle fails on schema build

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -10,6 +10,16 @@ import { EventEmitter } from 'events';
 type PromiseOrDirect<T> = T | Promise<T>;
 type DirectOrCallback<Request, T> = T | ((req: Request) => PromiseOrDirect<T>);
 
+// type ValueOf<T> = T[keyof T];
+
+// export enum OnInitFail {
+//   ThrowError = 'throw-error',
+//   ExitProcess = 'exit-process',
+//   Retry = 'retry',
+// }
+
+// export type OnInitFailOption = ValueOf<OnInitFail>;
+
 /**
  * A narrower type than `any` that won’t swallow errors from assumptions about
  * code.
@@ -54,7 +64,7 @@ export interface PostGraphileOptions<
   //   `DROP SCHEMA postgraphile_watch CASCADE;`
   /* @middlewareOnly */
   watchPg?: boolean;
-  // When false (default), PostGraphile will exit if it fails to build the
+  // When false (default), PostGraphile will _exit the process_ if it fails to build the
   // initial schema (for example if it cannot connect to the database, or if
   // there are fatal naming conflicts in the schema). When true, PostGraphile
   // will keep trying to rebuild the schema indefinitely, using an exponential
@@ -62,6 +72,14 @@ export interface PostGraphileOptions<
   // between retries.
   /* @middlewareOnly */
   retryOnInitFail?: boolean;
+  // When true, PostGraphile will _throw an error_ if it fails to build the
+  // initial schema (for example if it cannot connect to the database, or if
+  // there are fatal naming conflicts in the schema). When false (default),
+  // PostGraphile will fallback to another strategy to handle the error
+  // (see `retryOnInitFail`)
+  /* @middlewareOnly */
+  throwOnInitFail?: boolean;
+  // onInitFail?: OnInitFailOption;
   // Connection string to use to connect to the database as a privileged user (e.g. for setting up watch fixtures, logical decoding, etc).
   ownerConnectionString?: string;
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -720,7 +720,13 @@ if (noServer) {
       console.error('PostgreSQL client generated error: ', err.message);
     });
     const { getGraphQLSchema } = getPostgraphileSchemaBuilder(pgPool, schemas, postgraphileOptions);
-    await getGraphQLSchema();
+    try {
+      await getGraphQLSchema();
+    } catch (e) {
+      console.error('Getting PostGraphile schema generated an error: ', e.message);
+      await pgPool.end();
+      throw e;
+    }
     if (!watchPg) {
       await pgPool.end();
     }


### PR DESCRIPTION
Adds option named `throwOnInitFail` for #1042 to offer an alternative to exiting the process during library usage.

My usecase: I want to wrap `postgraphile` around a `try {} catch (e) {}`:

 `try { postgraphile() } catch(e) {app.get('/', (req, res) => res.send('There was an error starting Postgraphile'))}`

Note on why this is "Draft": I started this before I noticed that #1302 was open. This PR probably has the same issue of uncaught error handling (I think @benjie's last comment might be referring to this). I figured I'd open this nonetheless to offer a potential different option.

--

I didn't implement this yet, but this commented out TS snippet kind of hints at a third way, a more explicit way, to handle this option:

```ts
type ValueOf<T> = T[keyof T];

export enum OnInitFail {
   ThrowError = 'throw-error',
   ExitProcess = 'exit-process',
   Retry = 'retry',
}

export type OnInitFailOption = ValueOf<OnInitFail>; // === 'throw-error' | 'exit-process' | 'retry'
```