### PR TITLE
fix(ts): add jwtSignOptions to PostGraphileOptions type

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -217,6 +217,9 @@ export interface PostGraphileOptions<
   // null.
   /* @middlewareOnly */
   jwtVerifyOptions?: jwt.VerifyOptions;
+  // Options with which to perform JWT signing - see
+  // https://github.com/auth0/node-jsonwebtoken#jwtsignpayload-secretorprivatekey-options-callback
+  jwtSignOptions?: jwt.SignOptions;
   // An array of (strings) path components that make up the path in the jwt from which to extract the postgres role.
   // By default, the role is extracted from `token.role`, so the default value is `['role']`.
   // e.g. `{ iat: 123456789, creds: { local: { role: "my_role" } } }`


### PR DESCRIPTION
Looks like this has been supported for a while but went undocumented.