### PR TITLE
feat: allow overriding init fail handling

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -59,9 +59,11 @@ export interface PostGraphileOptions<
   // there are fatal naming conflicts in the schema). When true, PostGraphile
   // will keep trying to rebuild the schema indefinitely, using an exponential
   // backoff between attempts, starting at 100ms and increasing up to 30s delay
-  // between retries.
+  // between retries. When a function, the function will be called passing the
+  // error and the number of attempts, and it should return true to retry,
+  // false to permanently abort trying.
   /* @middlewareOnly */
-  retryOnInitFail?: boolean;
+  retryOnInitFail?: boolean | ((error: Error, attempts: number) => boolean | Promise<boolean>);
   // Connection string to use to connect to the database as a privileged user (e.g. for setting up watch fixtures, logical decoding, etc).
   ownerConnectionString?: string;
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -866,7 +866,7 @@ export default function createPostGraphileHttpRequestHandler(
 
       // Overwrite entire response
       returnArray = false;
-      results = [{ errors: [error] }];
+      results = [{ errors: (handleErrors as any)([error], req, res) }];
 
       // If the status code is 500, let’s log our error.
       if (res.statusCode === 500)


### PR DESCRIPTION
Previously, if a fatal error occurred that prevented building the GraphQL schema:

- if `retryOnInitFail` was not set/falsy, the process would exit with code 34
- if `retryOnInitFail` was truthy, PostGraphile would keep retrying forever, with exponential backoff

Fatal errors can include things like not being able to connect to the database, and not being able to build the schema due to a naming conflict. These issues could be solved (e.g. when the database comes online, or if someone adds a smart comment to the database) so for some users this made sense. For others, particularly those running multiple versions of PostGraphile through the same node process, it made less sense.

This PR gives users a third option; they may specify `retryOnInitFail` as a callback function. The function is called with the error that occurred, and the number of attempts that have so far been made. The function is expected to return a promise which:

- should return `true` to retry
- should return `false` or reject to abort

When returning true, the function is expected to perform exponential backoff to prevent overwhelming the database. An example function to perform exponential back-off and retry forever could be:

```js
async retryOnInitFail(error, attempts) {
  const delay = Math.min(100 * Math.pow(attempts, 2), 30000);
  await sleep(delay);
  return true;
}
```

If the function returns false or rejects, PostGraphile will release any Postgres pool it has created (if it was passed an already created pool, it will not release that since that is not its responsibility) and any requests that come through in the interrim will be met with 503 status code and the resulting JSON `{"errors":[{"message":"Failed to initialize GraphQL schema."}]}`.

The callback could be used for other purposes too, such as to unmount the middleware or shut down the server. The following example server, for example, cleanly shuts down after 10 retries if an error occurs during startup.

```js
const http = require('http');
const { postgraphile } = require('./build/postgraphile');

const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));

const server = http.createServer(
  postgraphile('postgres://foo:bar@baz/qux', ['a', 'b', 'c', 'd'], {
    graphiql: true,
    enhanceGraphiql: true,
    async retryOnInitFail(error, attempts) {
      if (attempts >= 10) {
        server.close();
        return false;
      }
      const delay = Math.min(100 * Math.pow(attempts, 2), 30000);
      console.log(`ERROR OCCURRED: ${error} (attempts = ${attempts}, delay = ${delay})`);
      await sleep(delay);
      return true;
    },
  }),
);

server.listen(5001, () => {
  console.log('Server listening: http://localhost:5001/graphiql');
});
```

Fixes #1315
Fixes #1302
Fixes #1073