### PR TITLE
chore: rename responseStream to endWithStream

### DIFF
--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -30,9 +30,9 @@ export abstract class PostGraphileResponse {
   }
 
   /**
-   * Use `responseStream` or `end`; not both.
+   * Use `endWithStream` or `end`; not both.
    */
-  public responseStream(): PassThrough {
+  public endWithStream(): PassThrough {
     if (this._body != null) {
       throw new Error("Cannot return a stream when there's already a response body");
     }
@@ -43,7 +43,7 @@ export abstract class PostGraphileResponse {
   }
 
   /**
-   * Use `responseStream` or `end`; not both
+   * Use `endWithStream` or `end`; not both
    */
   public end(moreBody?: Buffer | string | null) {
     if (moreBody) {
@@ -220,12 +220,12 @@ export class PostGraphileResponseKoa extends PostGraphileResponse {
     // middleware.
   }
 
-  responseStream() {
+  endWithStream() {
     // We're going to assume this is the EventStream which we want to
     // be realtime for watch mode, and there's no value in compressing it.
     this._ctx.compress = false;
     // TODO: find a better way of flushing the event stream on write.
-    return super.responseStream();
+    return super.endWithStream();
   }
 
   setBody(body: Stream | Buffer | string | undefined) {
@@ -268,7 +268,7 @@ export class PostGraphileResponseFastify3 extends PostGraphileResponse {
     this._reply.headers(headers);
   }
 
-  responseStream() {
+  endWithStream() {
     // We're going to assume this is the EventStream which we want to
     // be realtime for watch mode, and there's no value in compressing it.
     this.setHeader('x-no-compression', '1');
@@ -276,7 +276,7 @@ export class PostGraphileResponseFastify3 extends PostGraphileResponse {
     // solve it in userland by adding `{ config: { compress: false } }` to the
     // route options.
     // TODO: find a better way of flushing the event stream on write.
-    return super.responseStream();
+    return super.endWithStream();
   }
 
   setBody(body: Stream | Buffer | string | undefined) {

--- a/src/postgraphile/http/setupServerSentEvents.ts
+++ b/src/postgraphile/http/setupServerSentEvents.ts
@@ -33,7 +33,7 @@ export default function setupServerSentEvents(
   }
 
   // Creates a stream for the response
-  const stream = res.responseStream();
+  const stream = res.endWithStream();
 
   // Notify client that connection is open.
   stream.write('event: open\n\n');


### PR DESCRIPTION
## Description

Makes it more obvious what it does, and that `end` and `endWithStream` are mutually exclusive.

This is a public interface, but it's not been officially released yet, so this is not a breaking change.

## Performance impact

None

## Security impact

None