### PR TITLE
fix: don't compress event stream in Fastify

### DIFF
--- a/examples/servers/fastify3/rum-and-raisin.ts
+++ b/examples/servers/fastify3/rum-and-raisin.ts
@@ -60,12 +60,7 @@ if (middleware.options.watchPg) {
       middleware.eventStreamRoute,
       convertHandler(middleware.eventStreamRouteHandler),
     );
-    fastify.get(
-      middleware.eventStreamRoute,
-      // Must disable compression on event stream otherwise the request just hangs indefinitely
-      { config: { compress: false } },
-      convertHandler(middleware.eventStreamRouteHandler),
-    );
+    fastify.get(middleware.eventStreamRoute, convertHandler(middleware.eventStreamRouteHandler));
   }
 }
 

--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -224,6 +224,7 @@ export class PostGraphileResponseKoa extends PostGraphileResponse {
     // We're going to assume this is the EventStream which we want to
     // be realtime for watch mode, and there's no value in compressing it.
     this._ctx.compress = false;
+
     // TODO: find a better way of flushing the event stream on write.
     return super.responseStream();
   }
@@ -271,10 +272,12 @@ export class PostGraphileResponseFastify3 extends PostGraphileResponse {
   responseStream() {
     // We're going to assume this is the EventStream which we want to
     // be realtime for watch mode, and there's no value in compressing it.
-    this.setHeader('x-no-compression', '1');
-    // TODO: this setHeader doesn't seem to actually fix the issue; had to
-    // solve it in userland by adding `{ config: { compress: false } }` to the
-    // route options.
+
+    // Fastify will disable compression if we set the relevant request header
+    // (see:
+    // https://github.com/fastify/fastify-compress/blob/068c673fc0bd50da1f4d9f3fd2423b482c364a89/index.js#L217-L218)
+    this._request.headers['x-no-compression'] = '1';
+
     // TODO: find a better way of flushing the event stream on write.
     return super.responseStream();
   }


### PR DESCRIPTION
## Description

This prevents compression on the event stream route when using Fastify v3 server with the `fastify-compress` plugin. User code no longer needs to worry about this. It's a bit of a hack to mutate the client headers, but it seems to be the only way we can handle it internally; however I've sent an upstream fix that will hopefully prevent Fastify attempting to compress event streams: https://github.com/fastify/fastify-compress/pull/133

## Performance impact

Negligible.

## Security impact

Overwrites client header; but otherwise negligible.
