### PR TITLE
feat: allow access to Fastify request from Node request

### DIFF
--- a/examples/servers/fastify3/rum-and-raisin.ts
+++ b/examples/servers/fastify3/rum-and-raisin.ts
@@ -7,15 +7,34 @@ import {
 } from /*'postgraphile'*/ '../../../';
 import { database, schemas, options, port } from '../common';
 
-const middleware = postgraphile(database, schemas, options);
+const middleware = postgraphile(database, schemas, {
+  ...options,
+  pgSettings(req) {
+    // Adding this to ensure that all servers pass through the request in a
+    // good enough way that we can extract headers.
+    // CREATE FUNCTION current_user_id() RETURNS text AS $$ SELECT current_setting('graphile.test.x-user-id', TRUE); $$ LANGUAGE sql STABLE;
+    return {
+      'graphile.test.x-user-id':
+        // In GraphiQL, open console and enter `document.cookie = "userId=3"` to become user 3.
+        req._fastifyRequest?.cookies.userId ||
+        // `normalizedConnectionParams` comes from websocket connections, where
+        // the headers often cannot be customized by the client.
+        (req as any).normalizedConnectionParams?.['x-user-id'],
+    };
+  },
+});
 
 /******************************************************************************/
 // These middlewares aren't needed; we just add them to make sure that
 // PostGraphile still works correctly with them in place.
 
-import fastifyCompression from 'fastify-compress';
 const fastify = Fastify({ logger: true });
+
+import fastifyCompression from 'fastify-compress';
 fastify.register(fastifyCompression, { threshold: 0, inflateIfDeflated: false });
+
+import fastifyCookie from 'fastify-cookie';
+fastify.register(fastifyCookie, { secret: 'USE_A_SECURE_SECRET!' });
 
 /******************************************************************************/
 

--- a/package.json
+++ b/package.json
@@ -111,6 +111,7 @@
     "express": "^4.14.0",
     "fastify": "^3.7.0",
     "fastify-compress": "^3.3.1",
+    "fastify-cookie": "^4.1.0",
     "fastify-formbody": "^5.0.0",
     "fastify-v2": "npm:fastify@^2.2.0",
     "helmet": "^4.1.1",

--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -6,7 +6,6 @@ import type { FastifyReply, FastifyRequest } from 'fastify';
 declare module 'http' {
   interface IncomingMessage {
     _koaCtx?: KoaContext;
-    _fastifyReply?: FastifyReply;
     _fastifyRequest?: FastifyRequest;
     _body?: boolean;
     body?: any;
@@ -261,10 +260,9 @@ export class PostGraphileResponseFastify3 extends PostGraphileResponse {
     this._reply = reply;
 
     // For backwards compatibility, and to allow getting "back" to the Fastify
-    // request/reply from pgSettings, etc
+    // request from pgSettings, etc
     const req = this.getNodeServerRequest();
     req._fastifyRequest = this._request;
-    req._fastifyReply = this._reply;
 
     // Make Fastify's body parsing trigger skipping of our `body-parser`
     if (this._request.body) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3091,6 +3091,11 @@ cookie-signature@1.0.6:
   resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.0.6.tgz#e303a882b342cc3ee8ca513a79999734dab3ae2c"
   integrity sha1-4wOogrNCzD7oylE6eZmXNNqzriw=
 
+cookie-signature@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/cookie-signature/-/cookie-signature-1.1.0.tgz#cc94974f91fb9a9c1bb485e95fc2b7f4b120aff2"
+  integrity sha512-Alvs19Vgq07eunykd3Xy2jF0/qSNv2u7KDbAek9H5liV1UMijbqFs5cycZvv5dVsvseT/U4H8/7/w8Koh35C4A==
+
 cookie@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/cookie/-/cookie-0.4.0.tgz#beb437e7022b3b6d49019d088665303ebe9c14ba"
@@ -4200,6 +4205,15 @@ fastify-compress@^3.3.1:
     string-to-stream "^3.0.0"
     unzipper "^0.10.8"
 
+fastify-cookie@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/fastify-cookie/-/fastify-cookie-4.1.0.tgz#b063f2b97cf9de7a33eb799a951b604ede48a915"
+  integrity sha512-+se+kNPFDE49JCiBYQrfPfchcW9s8BXjCqP5ijuYpbydTcMlo9pnyd8tyxLi43SIXBmeTBkB1CjklmD7nlHsXg==
+  dependencies:
+    cookie "^0.4.0"
+    cookie-signature "^1.1.0"
+    fastify-plugin "^2.0.0"
+
 fastify-error@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/fastify-error/-/fastify-error-0.2.0.tgz#9a1c28d4f42b6259e7a549671c8e5e2d85660634"
@@ -4212,7 +4226,7 @@ fastify-formbody@^5.0.0:
   dependencies:
     fastify-plugin "^2.3.2"
 
-fastify-plugin@^2.2.0, fastify-plugin@^2.3.2:
+fastify-plugin@^2.0.0, fastify-plugin@^2.2.0, fastify-plugin@^2.3.2:
   version "2.3.4"
   resolved "https://registry.yarnpkg.com/fastify-plugin/-/fastify-plugin-2.3.4.tgz#b17abdc36a97877d88101fb86ad8a07f2c07de87"
   integrity sha512-I+Oaj6p9oiRozbam30sh39BiuiqBda7yK2nmSPVwDCfIBlKnT8YB3MY+pRQc2Fcd07bf6KPGklHJaQ2Qu81TYQ==


### PR DESCRIPTION
## Description

For `pgSettings` and `additionalGraphQLContextFromRequest` users may need a way to get "back" from the Node request to the Fastify request so that they can use the features of Fastify middleware. We already enable this via `req._koaCtx` for Koa, this PR adds `req._fastifyRequest` for Fastify (v3).

Fixes #1382

## Performance impact

Negligible

## Security impact

None known.