### PR TITLE
Add configurable credentials behavior to GraphiQL

### DIFF
--- a/postgraphiql/src/components/PostGraphiQL.js
+++ b/postgraphiql/src/components/PostGraphiQL.js
@@ -56,6 +56,7 @@ const {
     enhanceGraphiql: true,
     subscriptions: true,
     allowExplain: true,
+    credentials: 'same-origin',
   },
 } = window;
 
@@ -311,7 +312,7 @@ class PostGraphiQL extends React.PureComponent {
         },
         extraHeaders,
       ),
-      credentials: 'same-origin',
+      credentials: POSTGRAPHILE_CONFIG.credentials,
       body: JSON.stringify(graphQLParams),
     });
 

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -210,6 +210,7 @@ export interface PostGraphileOptions<
   // Set this to `true` to enable the GraphiQL interface.
   /* @middlewareOnly */
   graphiql?: boolean;
+  graphiqlCredentials?: 'include' | 'omit' | 'same-origin';
   // Set this to `true` to add some enhancements to GraphiQL; intended for development usage only (automatically enables with `subscriptions` and `live`).
   /* @middlewareOnly */
   enhanceGraphiql?: boolean;

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -210,6 +210,8 @@ export interface PostGraphileOptions<
   // Set this to `true` to enable the GraphiQL interface.
   /* @middlewareOnly */
   graphiql?: boolean;
+  // Set this to change the way GraphiQL handles credentials. By default this is set to `same-origin`.
+  /* @middlewareOnly */
   graphiqlCredentials?: 'include' | 'omit' | 'same-origin';
   // Set this to `true` to add some enhancements to GraphiQL; intended for development usage only (automatically enables with `subscriptions` and `live`).
   /* @middlewareOnly */

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -230,6 +230,9 @@ export default function createPostGraphileHttpRequestHandler(
   // Gets the route names for our GraphQL endpoint, and our GraphiQL endpoint.
   const graphqlRoute = options.graphqlRoute || '/graphql';
   const graphiqlRoute = options.graphiqlRoute || '/graphiql';
+  // Set the request credential behavior in graphiql.
+  const graphiqlCredentials = options.graphiqlCredentials || 'same-origin';
+
   const eventStreamRoute = options.eventStreamRoute || `${graphqlRoute.replace(/\/+$/, '')}/stream`;
   const externalGraphqlRoute = options.externalGraphqlRoute;
   const externalEventStreamRoute =
@@ -427,6 +430,7 @@ export default function createPostGraphileHttpRequestHandler(
               typeof options.allowExplain === 'function'
                 ? ALLOW_EXPLAIN_PLACEHOLDER
                 : !!options.allowExplain,
+            credentials: graphiqlCredentials,
           })};</script>\n  </head>`,
         )
       : null;


### PR DESCRIPTION
## Description
This PR adds the ability to set the Request credential behavior on the GraphiQL instance built into Postgraphile. This allows users that rely on cookies to have a seamless experience querying in GraphiQL.

## Performance impact
- Negligible, adds an extra option in the config.

## Security impact
- Should only be enabled in dev-mode / unknown

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
