### PR TITLE
feat: hooks for route handlers

### DIFF
--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -580,7 +580,20 @@ export default function createPostGraphileHttpRequestHandler(
     'eventStreamRouteHandler',
     async function eventStreamRouteHandler(res: PostGraphileResponse) {
       try {
-        const req = res.getNodeServerRequest();
+        // You can use this hook either to modify the incoming request or to tell
+        // PostGraphile not to handle the request further (return null). NOTE: if
+        // you return `null` from this hook then you are also responsible for
+        // terminating the request however your framework handles that (e.g.
+        // `res.send(...)` or `next()`).
+        const req = pluginHook(
+          'postgraphile:http:eventStreamRouteHandler',
+          res.getNodeServerRequest(),
+          { options, response: res },
+        );
+        if (req == null) {
+          return;
+        }
+
         // Add our CORS headers to be good web citizens (there are perf
         // implications though so be careful!)
         //
@@ -606,7 +619,19 @@ export default function createPostGraphileHttpRequestHandler(
   const faviconRouteHandler = neverReject('faviconRouteHandler', async function faviconRouteHandler(
     res: PostGraphileResponse,
   ) {
-    const req = res.getNodeServerRequest();
+    // You can use this hook either to modify the incoming request or to tell
+    // PostGraphile not to handle the request further (return null). NOTE: if
+    // you return `null` from this hook then you are also responsible for
+    // terminating the request however your framework handles that (e.g.
+    // `res.send(...)` or `next()`).
+    const req = pluginHook('postgraphile:http:faviconRouteHandler', res.getNodeServerRequest(), {
+      options,
+      response: res,
+    });
+    if (req == null) {
+      return;
+    }
+
     // If this is the wrong method, we should let the client know.
     if (!(req.method === 'GET' || req.method === 'HEAD')) {
       res.statusCode = req.method === 'OPTIONS' ? 200 : 405;
@@ -632,7 +657,19 @@ export default function createPostGraphileHttpRequestHandler(
   const graphiqlRouteHandler = neverReject(
     'graphiqlRouteHandler',
     async function graphiqlRouteHandler(res: PostGraphileResponse) {
-      const req = res.getNodeServerRequest();
+      // You can use this hook either to modify the incoming request or to tell
+      // PostGraphile not to handle the request further (return null). NOTE: if
+      // you return `null` from this hook then you are also responsible for
+      // terminating the request however your framework handles that (e.g.
+      // `res.send(...)` or `next()`).
+      const req = pluginHook('postgraphile:http:graphiqlRouteHandler', res.getNodeServerRequest(), {
+        options,
+        response: res,
+      });
+      if (req == null) {
+        return;
+      }
+
       if (firstRequestHandler) firstRequestHandler(req);
 
       // If using the incorrect method, let the user know.
@@ -671,7 +708,19 @@ export default function createPostGraphileHttpRequestHandler(
   const graphqlRouteHandler = neverReject('graphqlRouteHandler', async function graphqlRouteHandler(
     res: PostGraphileResponse,
   ) {
-    const req = res.getNodeServerRequest();
+    // You can use this hook either to modify the incoming request or to tell
+    // PostGraphile not to handle the request further (return null). NOTE: if
+    // you return `null` from this hook then you are also responsible for
+    // terminating the request however your framework handles that (e.g.
+    // `res.send(...)` or `next()`).
+    const req = pluginHook('postgraphile:http:graphqlRouteHandler', res.getNodeServerRequest(), {
+      options,
+      response: res,
+    });
+    if (req == null) {
+      return;
+    }
+
     if (firstRequestHandler) firstRequestHandler(req);
 
     // Add our CORS headers to be good web citizens (there are perf

--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -120,6 +120,10 @@ export class PostGraphileResponseNode extends PostGraphileResponse {
     return this._res;
   }
 
+  getNextCallback() {
+    return this._next;
+  }
+
   setHeaders(statusCode: number, headers: Headers) {
     for (const key in headers) {
       if (Object.hasOwnProperty.call(headers, key)) {
@@ -222,6 +226,10 @@ export class PostGraphileResponseKoa extends PostGraphileResponse {
 
   getNodeServerResponse() {
     return this._ctx.res;
+  }
+
+  getNextCallback() {
+    return this._next;
   }
 
   setHeaders(statusCode: number, headers: Headers) {

--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -30,7 +30,7 @@ export interface PostGraphileHTTPEnd {
   result: Record<string, any> | Array<Record<string, any>>;
 }
 export interface PostGraphilePlugin {
-  init?: HookFn<null>;
+  init?: HookFn<null, { version: string; graphql: typeof import('graphql') }>;
 
   pluginHook?: HookFn<PluginHookFn>;
 

--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -1,10 +1,15 @@
 import { AddFlagFn } from './cli';
 import { Server, IncomingMessage } from 'http';
-import { HttpRequestHandler, PostGraphileOptions } from '../interfaces';
+import {
+  CreateRequestHandlerOptions,
+  HttpRequestHandler,
+  PostGraphileOptions,
+} from '../interfaces';
 import { WithPostGraphileContextFn } from './withPostGraphileContext';
 import { version } from '../../package.json';
 import * as graphql from 'graphql';
 import { ExecutionParams } from 'subscriptions-transport-ws';
+import { PostGraphileResponse } from './http/frameworks';
 
 // tslint:disable-next-line no-any
 export type HookFn<TArg, TContext = any> = (arg: TArg, context: TContext) => TArg;
@@ -48,12 +53,38 @@ export interface PostGraphilePlugin {
   'postgraphile:options'?: HookFn<PostGraphileOptions>;
   'postgraphile:validationRules:static'?: HookFn<typeof graphql.specifiedRules>;
   'postgraphile:graphiql:html'?: HookFn<string>;
+
+  // Wrap the middleware:
+  'postgraphile:middleware'?: HookFn<HttpRequestHandler>;
+
+  // Inside the middleware:
   'postgraphile:http:handler'?: HookFn<IncomingMessage>;
+
+  // Inside the route handlers (including via middleware):
+  'postgraphile:http:eventStreamRouteHandler'?: HookFn<
+    IncomingMessage,
+    { options: CreateRequestHandlerOptions; response: PostGraphileResponse }
+  >;
+  'postgraphile:http:faviconRouteHandler'?: HookFn<
+    IncomingMessage,
+    { options: CreateRequestHandlerOptions; response: PostGraphileResponse }
+  >;
+  'postgraphile:http:graphiqlRouteHandler'?: HookFn<
+    IncomingMessage,
+    { options: CreateRequestHandlerOptions; response: PostGraphileResponse }
+  >;
+  'postgraphile:http:graphqlRouteHandler'?: HookFn<
+    IncomingMessage,
+    { options: CreateRequestHandlerOptions; response: PostGraphileResponse }
+  >;
+
+  // Deep inside the graphqlRouteHandler (including via middleware)
   'postgraphile:http:result'?: HookFn<PostGraphileHTTPResult>;
   'postgraphile:http:end'?: HookFn<PostGraphileHTTPEnd>;
   'postgraphile:httpParamsList'?: HookFn<Array<Record<string, any>>>;
+
   'postgraphile:validationRules'?: HookFn<typeof graphql.specifiedRules>; // AVOID THIS where possible; use 'postgraphile:validationRules:static' instead.
-  'postgraphile:middleware'?: HookFn<HttpRequestHandler>;
+
   'postgraphile:ws:onOperation'?: HookFn<ExecutionParams>;
 
   withPostGraphileContext?: HookFn<WithPostGraphileContextFn>;


### PR DESCRIPTION
## Description

With the middleware we have `postgraphile:http:handler` hook that allows exiting the middleware early, or manipulating the request in some way. This PR adds as similar hook to each of the route handlers (event stream, favicon, graphiql, graphql) so you can do the same within the specific route handler - note that these also work from the middleware too, so may be the preferred way of accomplishing some tasks.

Fixes #1383 

## Performance impact

Minimal.

## Security impact

None known.

