### PR TITLE
fix(types): replace explicit framework types with stubs

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,6 @@
     "@graphile/lru": "4.9.0",
     "@types/json5": "^0.0.30",
     "@types/jsonwebtoken": "^8.3.2",
-    "@types/koa": "^2.0.44",
     "@types/pg": "^7.4.10",
     "@types/ws": "^6.0.1",
     "body-parser": "^1.15.2",

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -75,7 +75,7 @@ export interface PostGraphileOptions<
   // may want to authenticate your users using sessions or similar. You can
   // pass some simple middlewares here that will be executed against the
   // websocket connection in order to perform authentication. We current only
-  // support express (not Koa) middlewares here.
+  // support Express (not Koa, Fastify, Restify, etc) middlewares here.
   /* @middlewareOnly */
   websocketMiddlewares?: Array<Middleware<Request, Response>>;
   // The default Postgres role to use. If no role was provided in a provided

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -17,7 +17,6 @@ import { pluginHookFromOptions } from '../pluginHook';
 import { HttpRequestHandler, mixed, CreateRequestHandlerOptions } from '../../interfaces';
 import setupServerSentEvents from './setupServerSentEvents';
 import withPostGraphileContext from '../withPostGraphileContext';
-import { Context as KoaContext } from 'koa';
 import LRU from '@graphile/lru';
 
 import chalk from 'chalk';
@@ -54,7 +53,8 @@ import favicon from '../../assets/favicon.ico';
 import baseGraphiqlHtml from '../../assets/graphiql.html';
 import { enhanceHttpServerWithSubscriptions } from './subscriptions';
 import {
-  KoaNext,
+  CompatKoaContext,
+  CompatKoaNext,
   PostGraphileResponse,
   PostGraphileResponseKoa,
   PostGraphileResponseNode,
@@ -1066,8 +1066,8 @@ export default function createPostGraphileHttpRequestHandler(
     // `koa` middleware.
     if (isKoaApp(a, b)) {
       // Set the correct `koa` variable names…
-      const ctx = a as KoaContext;
-      const next = b as KoaNext;
+      const ctx = a as CompatKoaContext;
+      const next = b as CompatKoaNext;
       const responseHandler = new PostGraphileResponseKoa(ctx, next);
 
       // Execute our request handler. If an error is thrown, we don’t call

--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -1,12 +1,56 @@
-import { IncomingMessage, ServerResponse } from 'http';
 import { PassThrough, Stream } from 'stream';
-import type { Context as KoaContext } from 'koa';
-import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { IncomingMessage, ServerResponse } from 'http';
+import type { Http2ServerRequest, Http2ServerResponse } from 'http2';
+
+/******************************************************************************/
+// Really we want:
+//
+//    import type { FastifyReply, FastifyRequest } from 'fastify';
+//
+// however, we don't want people to have to install fastify to get these types,
+// so we're going to do rough approximations of them. Care should be taken to
+// keep these compatible with the official fastify types.
+export type CompatFastifyReply = {
+  raw: ServerResponse | Http2ServerResponse;
+  status(statusCode: number): CompatFastifyReply;
+  headers(values: { [key: string]: any }): CompatFastifyReply;
+  send(payload?: any): CompatFastifyReply;
+};
+export type CompatFastifyRequest = {
+  raw: IncomingMessage | Http2ServerRequest;
+  body: unknown;
+  readonly headers: { [key: string]: unknown };
+};
+/******************************************************************************/
+
+/******************************************************************************/
+// Really we want:
+//
+//     import type { Context as KoaContext } from 'koa';
+//
+// however, we don't want people to have to install koa to get these types,
+// so we're going to do rough approximations of them. Care should be taken to
+// keep these compatible with the official koa types.
+export type CompatKoaContext = {
+  [key: string]: any;
+  req: IncomingMessage;
+  res: ServerResponse;
+};
+/******************************************************************************/
 
 declare module 'http' {
   interface IncomingMessage {
-    _koaCtx?: KoaContext;
-    _fastifyRequest?: FastifyRequest;
+    _koaCtx?: CompatKoaContext;
+    _fastifyRequest?: CompatFastifyRequest;
+    _body?: boolean;
+    body?: any;
+    originalUrl?: string;
+  }
+}
+declare module 'http2' {
+  interface Http2ServerRequest {
+    _koaCtx?: CompatKoaContext;
+    _fastifyRequest?: CompatFastifyRequest;
     _body?: boolean;
     body?: any;
     originalUrl?: string;
@@ -91,8 +135,8 @@ export abstract class PostGraphileResponse {
   /**
    * Returns the `res` object that the underlying HTTP server would have.
    */
-  public abstract getNodeServerRequest(): IncomingMessage;
-  public abstract getNodeServerResponse(): ServerResponse;
+  public abstract getNodeServerRequest(): IncomingMessage | Http2ServerRequest;
+  public abstract getNodeServerResponse(): ServerResponse | Http2ServerResponse;
   public abstract setHeaders(statusCode: number, headers: Headers): void;
   public abstract setBody(body: Stream | Buffer | string | undefined): void;
 }
@@ -191,16 +235,16 @@ export class PostGraphileResponseNode extends PostGraphileResponse {
   }
 }
 
-export type KoaNext = (error?: Error) => Promise<any>;
+export type CompatKoaNext = (error?: Error) => Promise<any>;
 
 /**
  * Suitable for Koa.
  */
 export class PostGraphileResponseKoa extends PostGraphileResponse {
-  private _ctx: KoaContext;
-  private _next: KoaNext;
+  private _ctx: CompatKoaContext;
+  private _next: CompatKoaNext;
 
-  constructor(ctx: KoaContext, next: KoaNext) {
+  constructor(ctx: CompatKoaContext, next: CompatKoaNext) {
     super();
     this._ctx = ctx;
     this._next = next;
@@ -259,10 +303,10 @@ export class PostGraphileResponseKoa extends PostGraphileResponse {
  * approach for Fastify v2)
  */
 export class PostGraphileResponseFastify3 extends PostGraphileResponse {
-  private _request: FastifyRequest;
-  private _reply: FastifyReply;
+  private _request: CompatFastifyRequest;
+  private _reply: CompatFastifyReply;
 
-  constructor(request: FastifyRequest, reply: FastifyReply) {
+  constructor(request: CompatFastifyRequest, reply: CompatFastifyReply) {
     super();
     this._request = request;
     this._reply = reply;

--- a/src/postgraphile/http/frameworks.ts
+++ b/src/postgraphile/http/frameworks.ts
@@ -1,6 +1,5 @@
 import { PassThrough, Stream } from 'stream';
 import type { IncomingMessage, ServerResponse } from 'http';
-import type { Http2ServerRequest, Http2ServerResponse } from 'http2';
 
 /******************************************************************************/
 // Really we want:
@@ -11,13 +10,13 @@ import type { Http2ServerRequest, Http2ServerResponse } from 'http2';
 // so we're going to do rough approximations of them. Care should be taken to
 // keep these compatible with the official fastify types.
 export type CompatFastifyReply = {
-  raw: ServerResponse | Http2ServerResponse;
+  raw: ServerResponse; // TODO:v5: | Http2ServerResponse;
   status(statusCode: number): CompatFastifyReply;
   headers(values: { [key: string]: any }): CompatFastifyReply;
   send(payload?: any): CompatFastifyReply;
 };
 export type CompatFastifyRequest = {
-  raw: IncomingMessage | Http2ServerRequest;
+  raw: IncomingMessage; // TODO:v5: | Http2ServerRequest;
   body: unknown;
   readonly headers: { [key: string]: unknown };
 };
@@ -47,6 +46,7 @@ declare module 'http' {
     originalUrl?: string;
   }
 }
+/* TODO:v5:
 declare module 'http2' {
   interface Http2ServerRequest {
     _koaCtx?: CompatKoaContext;
@@ -56,6 +56,7 @@ declare module 'http2' {
     originalUrl?: string;
   }
 }
+*/
 
 type Headers = { [header: string]: string };
 
@@ -135,8 +136,8 @@ export abstract class PostGraphileResponse {
   /**
    * Returns the `res` object that the underlying HTTP server would have.
    */
-  public abstract getNodeServerRequest(): IncomingMessage | Http2ServerRequest;
-  public abstract getNodeServerResponse(): ServerResponse | Http2ServerResponse;
+  public abstract getNodeServerRequest(): IncomingMessage; // TODO:v5: | Http2ServerRequest;
+  public abstract getNodeServerResponse(): ServerResponse; // TODO:v5: | Http2ServerResponse;
   public abstract setHeaders(statusCode: number, headers: Headers): void;
   public abstract setBody(body: Stream | Buffer | string | undefined): void;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1384,7 +1384,7 @@
     "@types/koa" "*"
     "@types/node" "*"
 
-"@types/koa@*", "@types/koa@^2.0.44":
+"@types/koa@*":
   version "2.11.4"
   resolved "https://registry.yarnpkg.com/@types/koa/-/koa-2.11.4.tgz#8af02a069a9f8e08fa47b8da28d982e652f69cfb"
   integrity sha512-Etqs0kdqbuAsNr5k6mlZQelpZKVwMu9WPRHVVTLnceZlhr0pYmblRNJbCgoCMzKWWePldydU0AYEOX4Q9fnGUQ==


### PR DESCRIPTION
## Description

TypeScript baulks when it sees us importing types from `koa` and `fastify` without adding these things to dependencies; however we don't depend on these things and don't want our users to have to install them if they're not using them (if they use express, no need; if they use koa there's no need for the fastify types and vice versa). It seems that the best way to deal with this (according to Daniel Rosenwasser, the TypeScript Program Manager at Microsoft) currently is to use stub types that are structurally compatible with the underlying types: https://twitter.com/drosenwasser/status/1326294777969532928. This PR does that.

## Performance impact

None - types only.

## Security impact

None - types only.
