### PR TITLE
chore(examples): export GraphQL schema

### DIFF
--- a/examples/servers/common.ts
+++ b/examples/servers/common.ts
@@ -64,6 +64,8 @@ export const options: PostGraphileOptions = {
   extendedErrors: ['hint', 'detail', 'errcode'],
   allowExplain: true,
   legacyRelations: 'omit',
+  exportGqlSchemaPath: `${__dirname}/schema.graphql`,
+  sortExport: true,
 };
 
 export const port: number = process.env.PORT ? parseInt(process.env.PORT, 10) : 3000;

--- a/examples/servers/schema.graphql
+++ b/examples/servers/schema.graphql
@@ -1,0 +1,692 @@
+"""All input for the create `Foo` mutation."""
+input CreateFooInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `Foo` to be created by this mutation."""
+  foo: FooInput!
+}
+
+"""The output of our create `Foo` mutation."""
+type CreateFooPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Foo` that was created by this mutation."""
+  foo: Foo
+
+  """An edge for our `Foo`. May be used by Relay 1."""
+  fooEdge(
+    """The method to use when ordering `Foo`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FoosEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""All input for the create `ReallyLong` mutation."""
+input CreateReallyLongInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """The `ReallyLong` to be created by this mutation."""
+  reallyLong: ReallyLongInput!
+}
+
+"""The output of our create `ReallyLong` mutation."""
+type CreateReallyLongPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The `ReallyLong` that was created by this mutation."""
+  reallyLong: ReallyLong
+
+  """An edge for our `ReallyLong`. May be used by Relay 1."""
+  reallyLongEdge(
+    """The method to use when ordering `ReallyLong`."""
+    orderBy: [ReallyLongsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReallyLongsEdge
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""All input for the `deleteFooById` mutation."""
+input DeleteFooByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  id: Int!
+}
+
+"""All input for the `deleteFoo` mutation."""
+input DeleteFooInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `Foo` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `Foo` mutation."""
+type DeleteFooPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedFooId: ID
+
+  """The `Foo` that was deleted by this mutation."""
+  foo: Foo
+
+  """An edge for our `Foo`. May be used by Relay 1."""
+  fooEdge(
+    """The method to use when ordering `Foo`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FoosEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""
+All input for the `deleteReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCcc` mutation.
+"""
+input DeleteReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCccInput {
+  aaa: Int!
+  bar: Int!
+  baz: Int!
+  bbb: Int!
+  ccc: Int!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  foo: Int!
+  qux: Int!
+}
+
+"""All input for the `deleteReallyLong` mutation."""
+input DeleteReallyLongInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ReallyLong` to be deleted.
+  """
+  nodeId: ID!
+}
+
+"""The output of our delete `ReallyLong` mutation."""
+type DeleteReallyLongPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+  deletedReallyLongId: ID
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The `ReallyLong` that was deleted by this mutation."""
+  reallyLong: ReallyLong
+
+  """An edge for our `ReallyLong`. May be used by Relay 1."""
+  reallyLongEdge(
+    """The method to use when ordering `ReallyLong`."""
+    orderBy: [ReallyLongsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReallyLongsEdge
+}
+
+type Foo implements Node {
+  id: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""
+A condition to be used against `Foo` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input FooCondition {
+  """Checks for equality with the object’s `id` field."""
+  id: Int
+}
+
+"""An input for mutations affecting `Foo`"""
+input FooInput {
+  id: Int
+}
+
+"""Represents an update to a `Foo`. Fields that are set will be updated."""
+input FooPatch {
+  id: Int
+}
+
+"""A connection to a list of `Foo` values."""
+type FoosConnection {
+  """
+  A list of edges which contains the `Foo` and cursor to aid in pagination.
+  """
+  edges: [FoosEdge!]!
+
+  """A list of `Foo` objects."""
+  nodes: [Foo!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Foo` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Foo` edge in the connection."""
+type FoosEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Foo` at the end of the edge."""
+  node: Foo!
+}
+
+"""Methods to use when ordering `Foo`."""
+enum FoosOrderBy {
+  ID_ASC
+  ID_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+}
+
+"""
+The root mutation type which contains root level fields which mutate data.
+"""
+type Mutation {
+  """Creates a single `Foo`."""
+  createFoo(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateFooInput!
+  ): CreateFooPayload
+
+  """Creates a single `ReallyLong`."""
+  createReallyLong(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: CreateReallyLongInput!
+  ): CreateReallyLongPayload
+
+  """Deletes a single `Foo` using its globally unique id."""
+  deleteFoo(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteFooInput!
+  ): DeleteFooPayload
+
+  """Deletes a single `Foo` using a unique key."""
+  deleteFooById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteFooByIdInput!
+  ): DeleteFooPayload
+
+  """Deletes a single `ReallyLong` using its globally unique id."""
+  deleteReallyLong(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteReallyLongInput!
+  ): DeleteReallyLongPayload
+
+  """Deletes a single `ReallyLong` using a unique key."""
+  deleteReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCcc(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: DeleteReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCccInput!
+  ): DeleteReallyLongPayload
+
+  """Updates a single `Foo` using its globally unique id and a patch."""
+  updateFoo(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateFooInput!
+  ): UpdateFooPayload
+
+  """Updates a single `Foo` using a unique key and a patch."""
+  updateFooById(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateFooByIdInput!
+  ): UpdateFooPayload
+
+  """
+  Updates a single `ReallyLong` using its globally unique id and a patch.
+  """
+  updateReallyLong(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateReallyLongInput!
+  ): UpdateReallyLongPayload
+
+  """Updates a single `ReallyLong` using a unique key and a patch."""
+  updateReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCcc(
+    """
+    The exclusive input argument for this mutation. An object type, make sure to see documentation for this object’s fields.
+    """
+    input: UpdateReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCccInput!
+  ): UpdateReallyLongPayload
+}
+
+"""An object with a globally unique `ID`."""
+interface Node {
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+}
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""The root query type which gives access points into the data universe."""
+type Query implements Node {
+  """Reads and enables pagination through a set of `Foo`."""
+  allFoos(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: FooCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `Foo`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FoosConnection
+
+  """Reads and enables pagination through a set of `ReallyLong`."""
+  allReallyLongs(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: ReallyLongCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """The method to use when ordering `ReallyLong`."""
+    orderBy: [ReallyLongsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReallyLongsConnection
+  currentUserId: String
+
+  """Reads a single `Foo` using its globally unique `ID`."""
+  foo(
+    """The globally unique `ID` to be used in selecting a single `Foo`."""
+    nodeId: ID!
+  ): Foo
+  fooById(id: Int!): Foo
+
+  """Fetches an object given its globally unique `ID`."""
+  node(
+    """The globally unique `ID`."""
+    nodeId: ID!
+  ): Node
+
+  """
+  The root query type must be a `Node` to work well with Relay 1 mutations. This just resolves to `query`.
+  """
+  nodeId: ID!
+
+  """
+  Exposes the root query type nested one level down. This is helpful for Relay 1
+  which can only query top level fields if they are in a particular form.
+  """
+  query: Query!
+
+  """Reads a single `ReallyLong` using its globally unique `ID`."""
+  reallyLong(
+    """
+    The globally unique `ID` to be used in selecting a single `ReallyLong`.
+    """
+    nodeId: ID!
+  ): ReallyLong
+  reallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCcc(aaa: Int!, bar: Int!, baz: Int!, bbb: Int!, ccc: Int!, foo: Int!, qux: Int!): ReallyLong
+}
+
+type ReallyLong implements Node {
+  aaa: Int!
+  bar: Int!
+  baz: Int!
+  bbb: Int!
+  ccc: Int!
+  foo: Int!
+
+  """
+  A globally unique identifier. Can be used in various places throughout the system to identify this single value.
+  """
+  nodeId: ID!
+  qux: Int!
+}
+
+"""
+A condition to be used against `ReallyLong` object types. All fields are tested
+for equality and combined with a logical ‘and.’
+"""
+input ReallyLongCondition {
+  """Checks for equality with the object’s `aaa` field."""
+  aaa: Int
+
+  """Checks for equality with the object’s `bar` field."""
+  bar: Int
+
+  """Checks for equality with the object’s `baz` field."""
+  baz: Int
+
+  """Checks for equality with the object’s `bbb` field."""
+  bbb: Int
+
+  """Checks for equality with the object’s `ccc` field."""
+  ccc: Int
+
+  """Checks for equality with the object’s `foo` field."""
+  foo: Int
+
+  """Checks for equality with the object’s `qux` field."""
+  qux: Int
+}
+
+"""An input for mutations affecting `ReallyLong`"""
+input ReallyLongInput {
+  aaa: Int!
+  bar: Int!
+  baz: Int!
+  bbb: Int!
+  ccc: Int!
+  foo: Int!
+  qux: Int!
+}
+
+"""
+Represents an update to a `ReallyLong`. Fields that are set will be updated.
+"""
+input ReallyLongPatch {
+  aaa: Int
+  bar: Int
+  baz: Int
+  bbb: Int
+  ccc: Int
+  foo: Int
+  qux: Int
+}
+
+"""A connection to a list of `ReallyLong` values."""
+type ReallyLongsConnection {
+  """
+  A list of edges which contains the `ReallyLong` and cursor to aid in pagination.
+  """
+  edges: [ReallyLongsEdge!]!
+
+  """A list of `ReallyLong` objects."""
+  nodes: [ReallyLong!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `ReallyLong` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `ReallyLong` edge in the connection."""
+type ReallyLongsEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `ReallyLong` at the end of the edge."""
+  node: ReallyLong!
+}
+
+"""Methods to use when ordering `ReallyLong`."""
+enum ReallyLongsOrderBy {
+  AAA_ASC
+  AAA_DESC
+  BAR_ASC
+  BAR_DESC
+  BAZ_ASC
+  BAZ_DESC
+  BBB_ASC
+  BBB_DESC
+  CCC_ASC
+  CCC_DESC
+  FOO_ASC
+  FOO_DESC
+  NATURAL
+  PRIMARY_KEY_ASC
+  PRIMARY_KEY_DESC
+  QUX_ASC
+  QUX_DESC
+}
+
+"""
+The root subscription type: contains realtime events you can subscribe to with the `subscription` operation.
+"""
+type Subscription {
+  time: TimePayload
+}
+
+type TimePayload {
+  currentTimestamp: String
+  query: Query
+}
+
+"""All input for the `updateFooById` mutation."""
+input UpdateFooByIdInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Foo` being updated.
+  """
+  fooPatch: FooPatch!
+  id: Int!
+}
+
+"""All input for the `updateFoo` mutation."""
+input UpdateFooInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  An object where the defined keys will be set on the `Foo` being updated.
+  """
+  fooPatch: FooPatch!
+
+  """
+  The globally unique `ID` which will identify a single `Foo` to be updated.
+  """
+  nodeId: ID!
+}
+
+"""The output of our update `Foo` mutation."""
+type UpdateFooPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """The `Foo` that was updated by this mutation."""
+  foo: Foo
+
+  """An edge for our `Foo`. May be used by Relay 1."""
+  fooEdge(
+    """The method to use when ordering `Foo`."""
+    orderBy: [FoosOrderBy!] = [PRIMARY_KEY_ASC]
+  ): FoosEdge
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+}
+
+"""
+All input for the `updateReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCcc` mutation.
+"""
+input UpdateReallyLongByFooAndBarAndBazAndQuxAndAaaAndBbbAndCccInput {
+  aaa: Int!
+  bar: Int!
+  baz: Int!
+  bbb: Int!
+  ccc: Int!
+
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+  foo: Int!
+  qux: Int!
+
+  """
+  An object where the defined keys will be set on the `ReallyLong` being updated.
+  """
+  reallyLongPatch: ReallyLongPatch!
+}
+
+"""All input for the `updateReallyLong` mutation."""
+input UpdateReallyLongInput {
+  """
+  An arbitrary string value with no semantic meaning. Will be included in the
+  payload verbatim. May be used to track mutations by the client.
+  """
+  clientMutationId: String
+
+  """
+  The globally unique `ID` which will identify a single `ReallyLong` to be updated.
+  """
+  nodeId: ID!
+
+  """
+  An object where the defined keys will be set on the `ReallyLong` being updated.
+  """
+  reallyLongPatch: ReallyLongPatch!
+}
+
+"""The output of our update `ReallyLong` mutation."""
+type UpdateReallyLongPayload {
+  """
+  The exact same `clientMutationId` that was provided in the mutation input,
+  unchanged and unused. May be used by a client to track mutations.
+  """
+  clientMutationId: String
+
+  """
+  Our root query field type. Allows us to run any query from our mutation payload.
+  """
+  query: Query
+
+  """The `ReallyLong` that was updated by this mutation."""
+  reallyLong: ReallyLong
+
+  """An edge for our `ReallyLong`. May be used by Relay 1."""
+  reallyLongEdge(
+    """The method to use when ordering `ReallyLong`."""
+    orderBy: [ReallyLongsOrderBy!] = [PRIMARY_KEY_ASC]
+  ): ReallyLongsEdge
+}


### PR DESCRIPTION
Added an export of the GraphQL schema from the examples to make it easier to spot if anything goes wrong (currently all schema export identical schemas, which is desired).