### PR TITLE
Add a close function to the middleware

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -320,6 +320,7 @@ export interface CreateRequestHandlerOptions extends PostGraphileOptions {
   // A Postgres client pool we use to connect Postgres clients.
   pgPool: Pool;
   _emitter: EventEmitter;
+  close: () => Promise<void>;
 }
 
 export interface GraphQLFormattedErrorExtended {
@@ -372,6 +373,7 @@ export interface HttpRequestHandler<
   faviconRouteHandler: ((res: PostGraphileResponse) => Promise<void>) | null;
   eventStreamRoute: string;
   eventStreamRouteHandler: ((res: PostGraphileResponse) => Promise<void>) | null;
+  close: Promise<void>;
 }
 
 /**

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -177,6 +177,7 @@ export default function createPostGraphileHttpRequestHandler(
     pgPool,
     pgSettings,
     pgDefaultRole,
+    close,
     queryCacheMaxSize = 50 * MEGABYTE,
     extendedErrors,
     showErrorStack,
@@ -1102,6 +1103,7 @@ export default function createPostGraphileHttpRequestHandler(
   middleware.faviconRouteHandler = graphiql ? faviconRouteHandler : null;
   middleware.eventStreamRoute = eventStreamRoute;
   middleware.eventStreamRouteHandler = watchPg ? eventStreamRouteHandler : null;
+  middleware.close = close;
 
   const hookedMiddleware = pluginHook('postgraphile:middleware', middleware, {
     options,


### PR DESCRIPTION
## Description

This adds a `close()` function to the Postgraphile middleware. As discussed in https://github.com/graphile/postgraphile/issues/461#issuecomment-531247990 this allows for a clean shutdown of the PgPool and the watchers. It's particularly useful for unit tests.

I've marked it a work in progress. I'm curious to start getting comments and to think about how to incorporate [the idea of  shutdownActions from Graphile Starter](https://github.com/graphile/starter/blob/58699dd1b759a3dd8e6f50cdc0622979f037e897/%40app/server/README.md#shutdownactions).

I've tested this locally with my unit tests, and it does clean everything up locally when `watchPg` is on and when it's off.

Really eager for your feedback!

## Performance impact

None

## Security impact

None

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.