### PR TITLE
feat: add Node version info and clarify enhance-graphiql

### DIFF
--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -10,6 +10,7 @@
  */
 import config from './postgraphilerc';
 
+import * as os from 'os';
 import { createServer } from 'http';
 import chalk from 'chalk';
 import program = require('commander');
@@ -854,7 +855,7 @@ if (noServer) {
                 postgraphileOptions.live ||
                 postgraphileOptions.subscriptions
                   ? ''
-                  : ` (enhance with '--enhance-graphiql')`),
+                  : ` (${chalk.bold('RECOMMENDATION')}: add '--enhance-graphiql')`),
             `Postgres connection: ${chalk.underline.magenta(safeConnectionString)}${
               postgraphileOptions.watchPg ? ' (watching)' : ''
             }`,
@@ -862,6 +863,7 @@ if (noServer) {
             `Documentation:       ${chalk.underline(
               `https://graphile.org/postgraphile/introduction/`,
             )}`,
+            `Node.js version:     ${process.version} on ${os.platform()} ${os.arch()}`,
             extractedPlugins.length === 0
               ? `Join ${chalk.bold(
                   sponsor,


### PR DESCRIPTION
## Description

Adds "Node.js version" section to PostGraphile CLI output (includes platform). Also hopefully draws more attention to the `--enhance-graphiql` recommendation as I've seen a lot of people wanting this option but not noticing the previous message.

Fixes #1400.

![Screenshot_20201125_115813](https://user-images.githubusercontent.com/129910/100225016-83622c80-2f15-11eb-8ca0-ae155f4a480a.png)

## Performance impact

Negligible.

## Security impact

None known.
