### PR TITLE
fix(docker): remove GRAPHILE_TURBO

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ FROM node:12-alpine
 LABEL description="Instant extensible high-performance GraphQL API for your PostgreSQL database https://graphile.org/postgraphile"
 
 EXPOSE 5000
-ENV GRAPHILE_TURBO=1
 WORKDIR /postgraphile/
 ENTRYPOINT ["./cli.js"]
 


### PR DESCRIPTION
## Description

Dockerfile references Node 12; GRAPHILE_TURBO now requires Node 14

## Performance impact

The Docker Hub image will run slower; npm build is unaffected.

## Security impact

None.
