### PR TITLE
fix(turbo): warn users that Node v14 is required

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,4 +1,5 @@
 module.exports = {
+  root: true,
   parser: '@typescript-eslint/parser',
   parserOptions: {
     sourceType: 'module',

--- a/isTurbo.js
+++ b/isTurbo.js
@@ -1,7 +1,9 @@
 if (process.env.GRAPHILE_TURBO === '1') {
   const major = parseInt(process.version.replace(/\..*$/, ''), 10);
   if (major < 14) {
-    throw new Error('Turbo mode currently requires Node v14 or higher, please upgrade Node.js or remove the GRAPHILE_TURBO environmental variable.');
+    throw new Error(
+      'Turbo mode currently requires Node v14 or higher, please upgrade Node.js or remove the GRAPHILE_TURBO environmental variable.'
+    );
   }
   module.exports = true;
 } else {

--- a/isTurbo.js
+++ b/isTurbo.js
@@ -2,7 +2,7 @@ if (process.env.GRAPHILE_TURBO === '1') {
   const major = parseInt(process.version.replace(/\..*$/, ''), 10);
   if (major < 14) {
     throw new Error(
-      'Turbo mode currently requires Node v14 or higher, please upgrade Node.js or remove the GRAPHILE_TURBO environmental variable.'
+      'Turbo mode currently requires Node v14 or higher, please upgrade Node.js or remove the GRAPHILE_TURBO environmental variable.',
     );
   }
   module.exports = true;

--- a/isTurbo.js
+++ b/isTurbo.js
@@ -1,7 +1,7 @@
 if (process.env.GRAPHILE_TURBO === '1') {
   const major = parseInt(process.version.replace(/\..*$/, ''), 10);
-  if (major < 12) {
-    throw new Error('Turbo mode requires Node v12 or higher');
+  if (major < 14) {
+    throw new Error('Turbo mode currently requires Node v14 or higher, please upgrade Node.js or remove the GRAPHILE_TURBO environmental variable.');
   }
   module.exports = true;
 } else {


### PR DESCRIPTION
## Description

`GRAPHILE_TURBO` is an opt-in to performance optimisations from reduced transpilation; it always targets the latest Node release. Currently we need support for optional chaining `?.` syntax which requires Node 14.

## Performance impact

None.

## Security impact

If you upgrade PostGraphile whilst running Node 12 AND with the opt-in `GRAPHILE_TURBO` flag enabled then your server may refuse to start. It's advised that you only use `GRAPHILE_TURBO` when you are targetting the very latest Node.js release and you want the absolute best performance we can squeeze out; for stable usage, do not use this flag.