### PR TITLE
fix(ws): fix missing websockets config on CLI

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -69,12 +69,12 @@ export interface PostGraphileOptions<
   ownerConnectionString?: string;
   // Enable GraphQL websocket transport support for subscriptions (you still need a subscriptions plugin currently)
   subscriptions?: boolean;
-  // Choose which websocket transport libraries to use. Use commas to define multiple. Defaults to '[v0, v1]' if `--subscriptions` was passed, '[]' otherwise
+  // [EXPERIMENTAL] Enables live-query support via GraphQL subscriptions (sends updated payload any time nested collections/records change)
+  live?: boolean;
+  // Choose which websocket transport libraries to use. Use commas to define multiple. Defaults to `['v0', 'v1']` if `subscriptions` or `live` are true, `[]` otherwise
   websockets?: ('v0' | 'v1')[];
   // Toggle which GraphQL websocket transport operations are supported: 'subscriptions' or 'all'. Defaults to `subscriptions`
   websocketOperations?: 'all' | 'subscriptions';
-  // [EXPERIMENTAL] Enables live-query support via GraphQL subscriptions (sends updated payload any time nested collections/records change)
-  live?: boolean;
   // [EXPERIMENTAL] If you're using websockets (subscriptions || live) then you
   // may want to authenticate your users using sessions or similar. You can
   // pass some simple middlewares here that will be executed against the

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -695,6 +695,7 @@ const postgraphileOptions = pluginHook(
     retryOnInitFail,
     pgDefaultRole,
     subscriptions: subscriptions || live,
+    websockets,
     live,
     watchPg,
     showErrorStack,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -122,7 +122,7 @@ program
   )
   .option(
     '--websockets <string>',
-    "Choose which websocket transport libraries to use. Use commas to define multiple. Defaults to '[v0, v1]' if `--subscriptions` was passed, '[]' otherwise",
+    "Choose which websocket transport libraries to use. Use commas to define multiple. Defaults to 'v0,v1' if `--subscriptions` or `--live` were passed, '[]' otherwise",
     (option: string) => option.split(','),
   )
   .option(
@@ -435,8 +435,8 @@ const {
   connection: pgConnectionString,
   ownerConnection,
   subscriptions,
-  websockets = subscriptions ? ['v0', 'v1'] : [],
   live,
+  websockets = subscriptions || live ? ['v0', 'v1'] : [],
   watch: watchPg,
   schema: dbSchema,
   host: hostname = 'localhost',

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -184,7 +184,7 @@ export default function createPostGraphileHttpRequestHandler(
     watchPg,
     disableQueryLog,
     enableQueryBatching,
-    websockets = subscriptions ? ['v0', 'v1'] : [],
+    websockets = options.subscriptions || options.live ? ['v0', 'v1'] : [],
   } = options;
   const live = !!options.live;
   const enhanceGraphiql =

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -73,10 +73,11 @@ export async function enhanceHttpServerWithWebSockets<
   const graphqlRoute =
     (subscriptionServerOptions && subscriptionServerOptions.graphqlRoute) ||
     (options.externalUrlBase || '') + (options.graphqlRoute || '/graphql');
+  const { subscriptions, websockets = subscriptions ? ['v0', 'v1'] : [] } = options;
 
   // enhance with WebSockets shouldnt be called if there are no websocket versions
-  if (!options.websockets?.length) {
-    throw new Error(`Invalid value for \`websockets\` option: '${options.websockets}'`);
+  if (!websockets?.length) {
+    throw new Error(`Invalid value for \`websockets\` option: '${JSON.stringify(websockets)}'`);
   }
 
   const schema = await getGraphQLSchema();
@@ -185,7 +186,7 @@ export async function enhanceHttpServerWithWebSockets<
   let socketId = 0;
 
   let v0Wss: WebSocket.Server | null = null;
-  if (options.websockets.includes('v0')) {
+  if (websockets.includes('v0')) {
     v0Wss = new WebSocket.Server({ noServer: true });
     SubscriptionServer.create(
       {
@@ -324,7 +325,7 @@ export async function enhanceHttpServerWithWebSockets<
   }
 
   let v1Wss: WebSocket.Server | null = null;
-  if (options.websockets.includes('v1')) {
+  if (websockets.includes('v1')) {
     v1Wss = new WebSocket.Server({ noServer: true });
     useServer(
       {

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -73,7 +73,7 @@ export async function enhanceHttpServerWithWebSockets<
   const graphqlRoute =
     (subscriptionServerOptions && subscriptionServerOptions.graphqlRoute) ||
     (options.externalUrlBase || '') + (options.graphqlRoute || '/graphql');
-  const { subscriptions, websockets = subscriptions ? ['v0', 'v1'] : [] } = options;
+  const { subscriptions, live, websockets = subscriptions || live ? ['v0', 'v1'] : [] } = options;
 
   // enhance with WebSockets shouldnt be called if there are no websocket versions
   if (!websockets?.length) {


### PR DESCRIPTION
## Description

Fixes #1416.

Small oversight in `cli.ts`; also increased safety of `enhanceHttpServerWithWebSockets` so the API doesn't have a breaking change.

## Performance impact

Negligible.

## Security impact

None known.

