### PR TITLE
feat(hooks): add postgraphile:liveSubscribe:executionResult hook

### DIFF
--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -13,6 +13,8 @@ import { Extra as GraphQLWSContextExtra } from 'graphql-ws/lib/use/ws';
 import { ExecutionParams } from 'subscriptions-transport-ws';
 import { PostGraphileResponse } from './http/frameworks';
 
+type PromiseOrValue<T> = T | Promise<T>;
+
 // tslint:disable-next-line no-any
 export type HookFn<TArg, TContext = any> = (arg: TArg, context: TContext) => TArg;
 export type PluginHookFn = <TArgument, TContext = Record<string, any>>(
@@ -96,6 +98,31 @@ export interface PostGraphilePlugin {
       context: graphqlWs.Context<GraphQLWSContextExtra>;
       message: graphqlWs.SubscribeMessage;
       options: CreateRequestHandlerOptions;
+    }
+  >;
+
+  'postgraphile:liveSubscribe:executionResult'?: HookFn<
+    PromiseOrValue<
+      graphql.ExecutionResult<
+        {
+          [key: string]: any;
+        },
+        {
+          [key: string]: any;
+        }
+      >
+    >,
+    {
+      schema: graphql.GraphQLSchema;
+      document: graphql.DocumentNode;
+      rootValue: any;
+      contextValue: any;
+      variableValues: { [key: string]: any } | undefined;
+      operationName: string | undefined;
+      fieldResolver: graphql.GraphQLFieldResolver<any, any, { [argName: string]: any }> | undefined;
+      subscribeFieldResolver:
+        | graphql.GraphQLFieldResolver<any, any, { [argName: string]: any }>
+        | undefined;
     }
   >;
 


### PR DESCRIPTION
## Description

Based on https://github.com/graphile/postgraphile/compare/main...Venryx:main and enabled by #1482  this adds a new pluginHook that can be used to augment results from the `liveSubscribe` method, for example to implement JSON patch transform.

## Performance impact

Very slight overhead added to every liveSubscribe execution.

## Security impact

None known.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~
