### PR TITLE
feat(ws): plugin hooks for WS servers options

### DIFF
--- a/src/postgraphile/pluginHook.ts
+++ b/src/postgraphile/pluginHook.ts
@@ -11,7 +11,7 @@ import { version } from '../../package.json';
 import * as graphql from 'graphql';
 import * as graphqlWs from 'graphql-ws';
 import { Extra as GraphQLWSContextExtra } from 'graphql-ws/lib/use/ws';
-import { ExecutionParams } from 'subscriptions-transport-ws';
+import { ServerOptions, ExecutionParams } from 'subscriptions-transport-ws';
 import { PostGraphileResponse } from './http/frameworks';
 
 type PromiseOrValue<T> = T | Promise<T>;
@@ -89,6 +89,9 @@ export interface PostGraphilePlugin {
   'postgraphile:httpParamsList'?: HookFn<Array<Record<string, any>>>;
 
   'postgraphile:validationRules'?: HookFn<typeof graphql.specifiedRules>; // AVOID THIS where possible; use 'postgraphile:validationRules:static' instead.
+
+  'postgraphile:ws:graphqlWs:options'?: HookFn<graphqlWs.ServerOptions<GraphQLWSContextExtra>>;
+  'postgraphile:ws:subscriptionsTransportWs:options'?: HookFn<ServerOptions>;
 
   'postgraphile:ws:onOperation'?: HookFn<ExecutionParams>;
   'postgraphile:ws:onSubscribe'?: HookFn<


### PR DESCRIPTION
## Description

Introduce two new plugin hooks:
- `'postgraphile:ws:graphqlWs:options'` for supplying additional server options to [graphql-ws](https://github.com/enisdenjo/graphql-ws)
- `'postgraphile:ws:subscriptionsTransportWs:options'` for supplying additional server options to [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws)

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] ~If this is a breaking change I've explained why.~