### PR TITLE
fix(windows): CLI recognition of absolute paths on Windows

### DIFF
--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -604,6 +604,12 @@ const loadPlugins = (rawNames: mixed) => {
     }
     const name = String(rawName);
     const parts = name.split(':');
+    if (process.platform === 'win32' && parts[0].length === 1 && ['\\', '/'].includes(name[2])) {
+      // Assume this is a windows path `C:/path/to/module.js` or `C:\path\to\module.js`
+      const driveLetter = parts.shift();
+      // Add the drive part back onto the path
+      parts[0] = `${driveLetter}:${parts[0]}`;
+    }
     let root;
     try {
       root = require(String(parts.shift()));


### PR DESCRIPTION
## Description

In `--append-plugins` and related options on the CLI we use `:` as the separator between the module path and the export within the module, e.g. `/foo/bar:baz:qux` translates to `require('/foo/bar').baz.qux`. This works fine on Unix-like operation systems, but on Windows absolute paths will have a `:` after the drive letter (e.g. `C:\foo\bar:baz:qux`); applying the previous rules means that we look for the `C` module and then try and access the `\foo\bar` export in it.

This fix looks for a single letter module name on Windows and assumes that it's actually part of the path and makes the relevant changes. I considered checking if the third letter in the path was a `\` or `/` but that would not work with mistyped (but somehow correct?) paths such as `c:foo\bar.js`.

## Performance impact

Negligible.

## Security impact

Prevents using single-letter module names on Windows; but it's unlikely there's any single-letter postgraphile plugins...

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [x] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [x] ~~I have detailed the new feature in the relevant documentation.~~
- [x] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [x] ~~If this is a breaking change I've explained why.~~

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
