### PR TITLE
fix(cli): handling of SSL options from the connection string

### DIFF
--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -577,9 +577,7 @@ const coerce = (o: ReturnType<typeof parsePgConnectionString>): PoolConfig => {
         ? undefined
         : o.ssl.rejectUnauthorized == null
         ? !!o.ssl
-        : {
-            rejectUnauthorized: !!o.ssl.rejectUnauthorized,
-          },
+        : o.ssl,
     user: typeof o.user === 'string' ? o.user : undefined,
     database: typeof o.database === 'string' ? o.database : undefined,
     password: typeof o.password === 'string' ? o.password : undefined,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -575,9 +575,9 @@ const coerce = (o: ReturnType<typeof parsePgConnectionString>): PoolConfig => {
     ssl:
       o.ssl == null
         ? undefined
-        : o.ssl.rejectUnauthorized == null
+        : (o.ssl as any).rejectUnauthorized == null
         ? !!o.ssl
-        : o.ssl,
+        : (o.ssl as any),
     user: typeof o.user === 'string' ? o.user : undefined,
     database: typeof o.database === 'string' ? o.database : undefined,
     password: typeof o.password === 'string' ? o.password : undefined,

--- a/src/postgraphile/cli.ts
+++ b/src/postgraphile/cli.ts
@@ -572,7 +572,14 @@ const coerce = (o: ReturnType<typeof parsePgConnectionString>): PoolConfig => {
   return {
     ...o,
     application_name: o['application_name'] || undefined,
-    ssl: o.ssl != null ? !!o.ssl : undefined,
+    ssl:
+      o.ssl == null
+        ? undefined
+        : o.ssl.rejectUnauthorized == null
+        ? !!o.ssl
+        : {
+            rejectUnauthorized: !!o.ssl.rejectUnauthorized,
+          },
     user: typeof o.user === 'string' ? o.user : undefined,
     database: typeof o.database === 'string' ? o.database : undefined,
     password: typeof o.password === 'string' ? o.password : undefined,


### PR DESCRIPTION
## Description

Addresses the CLI side of https://github.com/graphile/postgraphile/issues/1455

## Performance impact

None

## Security impact

None

## Checklist

- [X] My code matches the project's code style and `yarn lint:fix` passes.
- [X] I've added tests for the new feature, and `yarn test` passes.
- [X] I have detailed the new feature in the relevant documentation.
- [X] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [X] If this is a breaking change I've explained why.
