### PR TITLE
chore: replace deprecated String.prototype.substr()

### DIFF
--- a/scripts/make-assets
+++ b/scripts/make-assets
@@ -19,7 +19,7 @@ async function main() {
       tier = [];
       tiers.push(tier);
     } else if (line.startsWith('* ') || line.startsWith('- ')) {
-      tier.push(line.substr(2).replace(/\s?\(.*$/, ''));
+      tier.push(line.slice(2).replace(/\s?\(.*$/, ''));
     }
   }
   tiers.reverse();

--- a/scripts/proxied-test-server.js
+++ b/scripts/proxied-test-server.js
@@ -56,7 +56,7 @@
   server.on('upgrade', (req, socket, head) => {
     if (req.url.match(/^\/api(\/|$)/)) {
       proxy.ws(req, socket, head, {
-        target: `ws://localhost:5000${req.url.substr(4)}`,
+        target: `ws://localhost:5000${req.url.slice(4)}`,
         ignorePath: true,
       });
     }

--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -418,7 +418,7 @@ export default function createPostGraphileHttpRequestHandler(
     const { pathname = '' } = parseUrl(req) || {};
     const { pathname: originalPathname = '' } = parseUrl.original(req) || {};
     if (originalPathname !== pathname && originalPathname.endsWith(pathname)) {
-      const base = originalPathname.substr(0, originalPathname.length - pathname.length);
+      const base = originalPathname.slice(0, originalPathname.length - pathname.length);
       // Our websocket GraphQL route must be at a different place
       graphqlRouteForWs = base + graphqlRouteForWs;
       if (externalUrlBase == null) {


### PR DESCRIPTION
## Description

[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.

## Performance impact

From past experience there is no performance impact due to switching to slice()

## Security impact

None as the returned values are still the same

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

