### PR TITLE
fix(ws): release all socket's contexts on close

### DIFF
--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -90,7 +90,7 @@ export async function enhanceHttpServerWithWebSockets<
 
   const releaseAllContextsForSocket = (ws: WebSocket): void => {
     for (const [key, promise] of Object.entries(keepalivePromisesByContextKey)) {
-      if (key.startsWith(ws['postgraphileId']) && promise) {
+      if (key.startsWith(ws['postgraphileId'] + '|') && promise) {
         promise.resolve();
         keepalivePromisesByContextKey[key] = null;
       }


### PR DESCRIPTION
## Description

_*Speaking on behalf of `graphql-ws`, not sure if this happens with the deprecated `subscriptions-transport-ws`. Whatever the case is, the fix includes **both** libraries._

A server can close the socket at any time, even when a GQL operation is being prepared but not yet executed.

If the socket is closed while preparing, neither [`onError`](https://github.com/graphile/postgraphile/blob/b59c246b378dc72f8c90b27e633bf421c4fa3e0b/src/postgraphile/http/subscriptions.ts#L437-L442) nor [`onComplete`](https://github.com/graphile/postgraphile/blob/b59c246b378dc72f8c90b27e633bf421c4fa3e0b/src/postgraphile/http/subscriptions.ts#L451-L453) will be called simply because the operation was never executed. This causes a rather critical bug of not releasing PostGraphile contexts for the affected socket, leading to memory leaks, stuck operations and PG transactions.

Can happen, for example, when `postgraphile:ws:onSubscribe` hook throws an error - like when using [`@graphile/persisted-operations`](https://github.com/graphile/persisted-operations) and no query matching the hash is found.

With this PR, we simply make sure all socket's contexts are released on close.

## Performance impact

None.

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~I've added tests for the new feature, and `yarn test` passes.~
- [ ] ~I have detailed the new feature in the relevant documentation.~
- [ ] ~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~
- [ ] ~If this is a breaking change I've explained why.~