### PR TITLE
chore: minor refactoring of websocket code

### DIFF
--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -90,8 +90,9 @@ export async function enhanceHttpServerWithWebSockets<
   const contextKey = (ws: WebSocket, opId: string): string => ws['postgraphileId'] + '|' + opId;
 
   const releaseAllContextsForSocket = (ws: WebSocket): void => {
+    const prefix = ws['postgraphileId'] + '|';
     for (const [key, promise] of Object.entries(keepalivePromisesByContextKey)) {
-      if (key.startsWith(ws['postgraphileId'] + '|') && promise) {
+      if (key.startsWith(prefix)) {
         promise.resolve();
         delete keepalivePromisesByContextKey[key];
       }

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -84,7 +84,7 @@ export async function enhanceHttpServerWithWebSockets<
 
   const schema = await getGraphQLSchema();
 
-  const keepalivePromisesByContextKey: { [contextKey: string]: Deferred<void> | null } = {};
+  const keepalivePromisesByContextKey: { [contextKey: string]: Deferred<void> } = {};
 
   // IMPORTANT: if you change this, be sure to change `releaseAllContextsForSocket` too
   const contextKey = (ws: WebSocket, opId: string): string => ws['postgraphileId'] + '|' + opId;
@@ -93,7 +93,7 @@ export async function enhanceHttpServerWithWebSockets<
     for (const [key, promise] of Object.entries(keepalivePromisesByContextKey)) {
       if (key.startsWith(ws['postgraphileId'] + '|') && promise) {
         promise.resolve();
-        keepalivePromisesByContextKey[key] = null;
+        delete keepalivePromisesByContextKey[key];
       }
     }
   };
@@ -102,7 +102,7 @@ export async function enhanceHttpServerWithWebSockets<
     const promise = keepalivePromisesByContextKey[contextKey(ws, opId)];
     if (promise) {
       promise.resolve();
-      keepalivePromisesByContextKey[contextKey(ws, opId)] = null;
+      delete keepalivePromisesByContextKey[contextKey(ws, opId)];
     }
   };
 

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -86,6 +86,7 @@ export async function enhanceHttpServerWithWebSockets<
 
   const keepalivePromisesByContextKey: { [contextKey: string]: Deferred<void> | null } = {};
 
+  // IMPORTANT: if you change this, be sure to change `releaseAllContextsForSocket` too
   const contextKey = (ws: WebSocket, opId: string): string => ws['postgraphileId'] + '|' + opId;
 
   const releaseAllContextsForSocket = (ws: WebSocket): void => {


### PR DESCRIPTION
## Description

Follow up to #1612

## Performance impact

Infinitesimal improvement.

## Security impact

For long running PostGraphile servers that handle websockets this prevents the `keepalivePromisesByContextKey` growing unbounded. It'd take a long time to exploit this, but it is an improvement.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~

