### PR TITLE
fix(ws): getting context should be the very last thing

### DIFF
--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -285,8 +285,6 @@ export async function enhanceHttpServerWithWebSockets<
           };
           const operation = getOperationAST(finalParams.query, finalParams.operationName);
           const isSubscription = !!operation && operation.operation === 'subscription';
-          const context = await getContext(socket, opId, isSubscription);
-          Object.assign(params.context, context);
 
           // You are strongly encouraged to use
           // `postgraphile:validationRules:static` if possible - you should
@@ -313,6 +311,9 @@ export async function enhanceHttpServerWithWebSockets<
               return Promise.reject(error);
             }
           }
+
+          const context = await getContext(socket, opId, isSubscription);
+          Object.assign(params.context, context);
 
           return finalParams;
         },
@@ -407,8 +408,6 @@ export async function enhanceHttpServerWithWebSockets<
             ? getOperationAST(args.document, hookedArgs.operationName)
             : null;
           const isSubscription = !!operation && operation.operation === 'subscription';
-          const context = await getContext(ctx.extra.socket, msg.id, isSubscription);
-          Object.assign(hookedArgs.contextValue, context);
 
           // when supplying custom execution args from the
           // onSubscribe, you're trusted to do the validation
@@ -445,6 +444,9 @@ export async function enhanceHttpServerWithWebSockets<
               return moreValidationErrors;
             }
           }
+
+          const context = await getContext(ctx.extra.socket, msg.id, isSubscription);
+          Object.assign(hookedArgs.contextValue, context);
 
           return hookedArgs;
         },


### PR DESCRIPTION
## Description

Getting context before calling validate is silly - it sets up a transaction for an operation that might never execute. This PR moves the context code later.

## Performance impact

Negligible.

## Security impact

Negligible.

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~~I've added tests for the new feature, and `yarn test` passes.~~
- [ ] ~~I have detailed the new feature in the relevant documentation.~~
- [ ] ~~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~~
- [ ] ~~If this is a breaking change I've explained why.~~
