### PR TITLE
refactor(ws): make sure operation is available before validating

### DIFF
--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -283,15 +283,19 @@ export async function enhanceHttpServerWithWebSockets<
                 ? hookedParams.query
                 : parse(hookedParams.query),
           };
-          const operation = getOperationAST(finalParams.query, finalParams.operationName);
-          if (!operation) {
+          if (!finalParams.query) {
             return [
               // same error that graphql.validate would throw if the document is missing
               new GraphQLError('Must provide document.'),
             ];
           }
 
-          const isSubscription = !!operation && operation.operation === 'subscription';
+          const operation = getOperationAST(finalParams.query, finalParams.operationName);
+          if (!operation) {
+            return [new GraphQLError('Unable to identify operation')];
+          }
+
+          const isSubscription = operation.operation === 'subscription';
           const context = await getContext(socket, opId, isSubscription);
           Object.assign(params.context, context);
 
@@ -410,17 +414,19 @@ export async function enhanceHttpServerWithWebSockets<
                 options,
               })
             : args) as ExecutionArgs;
-          const operation = args.document
-            ? getOperationAST(args.document, hookedArgs.operationName)
-            : null;
-          if (!operation) {
+          if (!args.document) {
             return [
               // same error that graphql.validate would throw if the document is missing
               new GraphQLError('Must provide document.'),
             ];
           }
 
-          const isSubscription = !!operation && operation.operation === 'subscription';
+          const operation = getOperationAST(args.document, hookedArgs.operationName);
+          if (!operation) {
+            return [new GraphQLError('Unable to identify operation')];
+          }
+
+          const isSubscription = operation.operation === 'subscription';
           const context = await getContext(ctx.extra.socket, msg.id, isSubscription);
           Object.assign(hookedArgs.contextValue, context);
 

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -286,7 +286,7 @@ export async function enhanceHttpServerWithWebSockets<
           if (!finalParams.query) {
             return [
               // same error that graphql.validate would throw if the document is missing
-              new GraphQLError('Must provide document.'),
+              new GraphQLError('Must provide document'),
             ];
           }
 
@@ -417,7 +417,7 @@ export async function enhanceHttpServerWithWebSockets<
           if (!args.document) {
             return [
               // same error that graphql.validate would throw if the document is missing
-              new GraphQLError('Must provide document.'),
+              new GraphQLError('Must provide document'),
             ];
           }
 

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -284,6 +284,13 @@ export async function enhanceHttpServerWithWebSockets<
                 : parse(hookedParams.query),
           };
           const operation = getOperationAST(finalParams.query, finalParams.operationName);
+          if (!operation) {
+            return [
+              // same error that graphql.validate would throw if the document is missing
+              new GraphQLError('Must provide document.'),
+            ];
+          }
+
           const isSubscription = !!operation && operation.operation === 'subscription';
           const context = await getContext(socket, opId, isSubscription);
           Object.assign(params.context, context);
@@ -406,6 +413,13 @@ export async function enhanceHttpServerWithWebSockets<
           const operation = args.document
             ? getOperationAST(args.document, hookedArgs.operationName)
             : null;
+          if (!operation) {
+            return [
+              // same error that graphql.validate would throw if the document is missing
+              new GraphQLError('Must provide document.'),
+            ];
+          }
+
           const isSubscription = !!operation && operation.operation === 'subscription';
           const context = await getContext(ctx.extra.socket, msg.id, isSubscription);
           Object.assign(hookedArgs.contextValue, context);

--- a/src/postgraphile/http/subscriptions.ts
+++ b/src/postgraphile/http/subscriptions.ts
@@ -284,15 +284,12 @@ export async function enhanceHttpServerWithWebSockets<
                 : parse(hookedParams.query),
           };
           if (!finalParams.query) {
-            return [
-              // same error that graphql.validate would throw if the document is missing
-              new GraphQLError('Must provide document'),
-            ];
+            return Promise.reject(new Error('Must provide document'));
           }
 
           const operation = getOperationAST(finalParams.query, finalParams.operationName);
           if (!operation) {
-            return [new GraphQLError('Unable to identify operation')];
+            return Promise.reject(new Error('Unable to identify operation'));
           }
 
           const isSubscription = operation.operation === 'subscription';


### PR DESCRIPTION
## Description

[`graphql.validate`](https://github.com/graphql/graphql-js/blob/b38429f4d46b17f23d15406a2ca0d1eb201864b6/src/validation/validate.ts#L38-L46) will throw if its typings are not respected.

This PR adds pre-validation steps making sure the operation document, as well as the operation AST, is available.

Note that we don't do the same for the schema - not having it is a fatal error still.

## Performance impact

None.

## Security impact

None.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] ~I've added tests for the new feature, and `yarn test` passes.~
- [ ] ~I have detailed the new feature in the relevant documentation.~
- [ ] ~I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).~
- [ ] ~If this is a breaking change I've explained why.~
