### PR TITLE
Remove jwt not supported claims names

### DIFF
--- a/src/postgraphile/withPostGraphileContext.ts
+++ b/src/postgraphile/withPostGraphileContext.ts
@@ -430,7 +430,8 @@ async function getSettingsForPgClientTransaction({
   // If we have some JWT claims, we want to set those claims as local
   // settings with the namespace `jwt.claims`.
   for (const key in jwtClaims) {
-    if (Object.prototype.hasOwnProperty.call(jwtClaims, key)) {
+    // Exclude claims beginning with "_" as they are not supported by postgresql
+    if (Object.prototype.hasOwnProperty.call(jwtClaims, key) && key.indexOf('_') !== 0) {
       const rawValue = jwtClaims[key];
       // Unsafe to pass raw object/array to pg.query -> set_config; instead JSONify
       const value: mixed =


### PR DESCRIPTION
Exclude jwt claims beginning with "_" as they are not supported by postgresql

## Description

Problem when reusing a token that have a claim beginning by an underscore. Fix by just ignoring those claims

## Performance impact

None

## Security impact

None

## Checklist

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.
