### PR TITLE
chore: update to Node 16 LTS in CI & published docker images

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.x
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          node-version: 16.x
       - run: yarn --immutable --ignore-engines
 
       - name: "Check Code Format"
@@ -42,7 +42,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        postgres-version: 
+        postgres-version:
           - 9.4
           - 10
           - 11

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:12-alpine as builder
+FROM node:16-alpine as builder
 
 WORKDIR /postgraphile/
 
@@ -26,7 +26,7 @@ RUN ./scripts/build
 
 ########################################
 
-FROM node:12-alpine as clean
+FROM node:16-alpine as clean
 
 # Again, install yarn ASAP because it's the slowest
 COPY package.json yarn.lock /postgraphile/
@@ -40,7 +40,7 @@ COPY --from=builder /postgraphile/sponsors.json /postgraphile/
 
 ########################################
 
-FROM node:12-alpine
+FROM node:16-alpine
 LABEL description="Instant extensible high-performance GraphQL API for your PostgreSQL database https://graphile.org/postgraphile"
 
 EXPOSE 5000


### PR DESCRIPTION
## Description

The issue is with Node 12 being so old I had TLS connection issues that would hang after startup and silently use all available memory. The node 12 image is using alpine3.15 anyway so this PR keeps alpine the same. While changing versions just moved any reference to node to the current LTS.

## Performance impact

Would expect an improvement.

## Security impact

Published docker images would be using a supported version of Node.
Potentially could remove node 8, 10 and 12 from the matrix as they go out of support.

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->

## Comments

All I've tested is manually installing node 17 within the existing container and things seemed to work fine. Hopefully the CI tests can rundown any issues.