### PR TITLE
feat(ci): build arm64

### DIFF
--- a/.github/workflows/docker-hub.yaml
+++ b/.github/workflows/docker-hub.yaml
@@ -15,6 +15,12 @@ jobs:
       - name: Check out the repo
         uses: actions/checkout@v2
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+
       - name: Login to Docker Hub
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
@@ -42,3 +48,4 @@ jobs:
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64/v8


### PR DESCRIPTION
## Description

Newer Mac computers with their M1 chips use the ARM architecture [1]. Currently there is no docker image for postgraphile published to Docker Hub supporting the `arm64` platform, only for `amd64`. This commit adds compilation for an ARM image as well, so that developers on newer Mac computers can use postgraphile inside a container as well.

[1] https://en.wikipedia.org/wiki/Apple_M1

## Performance impact

The build time will be longer. Especially cross-platform compilation for ARM will take longer than AMD compilation on AMD ci workers due to necessary QEMU virtualization.

## Security impact

none

## Checklist

- [ ] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.

## Additional info

As this is a CI change, I don't think any of the checklist items apply. Please correct me if I'm wrong.
I chose `fix` as the type, as it does not really add a new feature to postgraphile but adds a missing platform for Mac.
