### PR TITLE
chore(ci): remove Postgres <12 and Node <10 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,14 +43,10 @@ jobs:
       fail-fast: false
       matrix:
         postgres-version: 
-          - 9.4
-          - 10
-          - 11
           - 12
           - 13
           - 14
         node-version:
-          - 8.x
           - 10.x
           - 12.x
           - 14.x


### PR DESCRIPTION
CI seems to be failing on Node 8.x and PG 9.6, 10 and 11 due to dependency shifts in Docker and other such CI-only things. Fixing these things is non-trivial (e.g. we'd have to roll our own Docker images) and I can't justify the expenditure of effort there when I want to focus on getting V5 ready to use, so I'm just removing these legacy versions from CI. We'll need to be careful/strict in future PRs to ensure we don't merge anything that would break on PG 9.6 or Node 8.x - but we're not anticipating merging anything major into PostGraphile V4 anyway, so this shouldn't be a big deal.
