### PR TITLE
Allow pgDefaultRole with pgSettings(req)

### DIFF
--- a/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
+++ b/src/postgraphile/http/createPostGraphileHttpRequestHandler.ts
@@ -222,11 +222,6 @@ export default function createPostGraphileHttpRequestHandler(
 
   const origGraphiqlHtml = pluginHook('postgraphile:graphiql:html', baseGraphiqlHtml, { options });
 
-  if (pgDefaultRole && typeof pgSettings === 'function') {
-    throw new Error(
-      'pgDefaultRole cannot be combined with pgSettings(req) - please remove pgDefaultRole and instead always return a `role` key from pgSettings(req).',
-    );
-  }
   if (
     pgDefaultRole &&
     pgSettings &&


### PR DESCRIPTION
## Description
Remove error which stops use of both `pgDefaultRole` and `pgSettings(req)` (originally added in #606)

Role is already set in order
1. pgDefaultRole: https://github.com/graphile/postgraphile/blob/2e89f875050ecfc554cfff6b96b9a6335abf7bcc/src/postgraphile/withPostGraphileContext.ts#L320
2. JWT role claim: https://github.com/graphile/postgraphile/blob/2e89f875050ecfc554cfff6b96b9a6335abf7bcc/src/postgraphile/withPostGraphileContext.ts#L387
3. pgSettings(req) role key: https://github.com/graphile/postgraphile/blob/2e89f875050ecfc554cfff6b96b9a6335abf7bcc/src/postgraphile/withPostGraphileContext.ts#L416



<!-- If this PR adds a feature, what does it add and what was the motivation for it? -->
Allows use of both `pgDefaultRole` and `pgSettings(req)` options. I am using `pgSettings(req)`, but I would like to use the default JWT role claim parsing, as well have have a default role to fall back to in case of no JWT.

<!-- If this PR fixes an issue, what is the issue? -->
<!-- Please link to the relevant GitHub issues/Discord discussion/etc as appropriate -->

## Performance impact

<!-- Detail any impact on performance of this PR, or put 'unknown' if not known -->

none

## Security impact

unknown

<!-- Detail any impact on security of this PR, or put 'unknown' if not known -->

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
