### PR TITLE
docs: Add info about not using TS

### DIFF
--- a/grafast/website/grafast/getting-started/index.mdx
+++ b/grafast/website/grafast/getting-started/index.mdx
@@ -58,9 +58,9 @@ deal with these changes (if any action is necessary).
 
 You do not need to use TypeScript to use PostGraphile, but without it you will
 find editors such as VSCode will highlight your import paths with error
-notifications. To stop this, you can add the following to your `package.json`:
+notifications. To stop this, you can add the following to `jsconfig.json`:
 
-```
+```json title="jsconfig.json"
 {
   "compilerOptions": {
     "moduleResolution": "node16"

--- a/postgraphile/website/postgraphile/requirements.md
+++ b/postgraphile/website/postgraphile/requirements.md
@@ -97,9 +97,9 @@ deal with these changes (if any action is necessary).
 
 You do not need to use TypeScript to use PostGraphile, but without it you will
 find editors such as VSCode will highlight your import paths with error
-notifications. To stop this, you can add the following to your `package.json`:
+notifications. To stop this, you can add the following to `jsconfig.json`:
 
-```
+```json title="jsconfig.json"
 {
   "compilerOptions": {
     "moduleResolution": "node16"

--- a/postgraphile/website/versioned_docs/version-5/requirements.md
+++ b/postgraphile/website/versioned_docs/version-5/requirements.md
@@ -97,9 +97,9 @@ deal with these changes (if any action is necessary).
 
 You do not need to use TypeScript to use PostGraphile, but without it you will
 find editors such as VSCode will highlight your import paths with error
-notifications. To stop this, you can add the following to your `package.json`:
+notifications. To stop this, you can add the following to `jsconfig.json`:
 
-```
+```json title="jsconfig.json"
 {
   "compilerOptions": {
     "moduleResolution": "node16"


### PR DESCRIPTION
## Description

Closes issue #1846 

Do check what I've written, I've just assumed that it's the `package.json` this gets added to. 

**Edit**: Actually, should this be added to https://grafast.org/grafast/getting-started#typescript-v500-optional as well? **Edit**: Yes.