### PR TITLE
website: Grafast footnotes

### DIFF
--- a/grafast/website/src/css/custom.css
+++ b/grafast/website/src/css/custom.css
@@ -88,4 +88,16 @@ sup a {
 
 .footnotes li::marker {
   color: var(--grafast-color-pink);
+  font-weight: bold;
+}
+
+[data-theme="dark"] .footnotes {
+  color: var(--ifm-color-gray-200);
+  border-top: 2px solid var(--ifm-color-gray-400);
+}
+
+@media screen and (max-width: 995px) {
+  .footnotes {
+    font-size: 1rem;
+  }
 }


### PR DESCRIPTION
## Description

Some nice footnote styling for the Grafast website. 

<img width="1478" height="491" alt="Screenshot 2025-07-25 at 16 05 42" src="https://github.com/user-attachments/assets/49be25be-202e-4d99-b34d-f6b0537a8a61" />

<img width="1480" height="468" alt="Screenshot 2025-07-25 at 16 05 51" src="https://github.com/user-attachments/assets/a4a8e394-83de-4566-8d3f-f473df8c87ce" />

<img width="452" height="952" alt="Screenshot 2025-07-28 at 16 39 09" src="https://github.com/user-attachments/assets/c575617f-bf44-4465-a5ea-959105b8b58f" />

<img width="468" height="955" alt="Screenshot 2025-07-28 at 16 39 43" src="https://github.com/user-attachments/assets/feb7df99-b6ae-4960-a4cc-0dbc91d786e5" />
