### PR TITLE
Fix deprecated withPgClientTransaction in documentation

### DIFF
--- a/postgraphile/website/postgraphile/extend-schema.md
+++ b/postgraphile/website/postgraphile/extend-schema.md
@@ -665,7 +665,7 @@ user into the database and also sends them an email:
 ```ts
 import { extendSchema } from "postgraphile/utils";
 import { access, constant, object } from "postgraphile/grafast";
-import { withPgClientTransaction } from "postgraphile/@dataplan/pg";
+import { sideEffectWithPgClientTransaction } from "postgraphile/@dataplan/pg";
 
 export const MyRegisterUserMutationPlugin = extendSchema((build) => {
   const { sql, pgResources } = build;
@@ -696,7 +696,7 @@ export const MyRegisterUserMutationPlugin = extendSchema((build) => {
         plans: {
           registerUser(_, fieldArgs) {
             const $input = fieldArgs.getRaw("input");
-            const $user = withPgClientTransaction(
+            const $user = sideEffectWithPgClientTransaction(
               executor,
               $input,
               async (pgClient, input) => {
@@ -771,7 +771,7 @@ check that the user performing the soft-delete is the owner of the record.
 ```ts
 import { extendSchema } from "postgraphile/utils";
 import { context, list, specFromNodeId } from "postgraphile/grafast";
-import { withPgClientTransaction } from "postgraphile/@dataplan/pg";
+import { sideEffectWithPgClientTransaction } from "postgraphile/@dataplan/pg";
 
 const DeleteItemByNodeIdPlugin = extendSchema((build) => {
   // We need the nodeId handler for the Item type so that we can decode the ID.
@@ -809,7 +809,7 @@ const DeleteItemByNodeIdPlugin = extendSchema((build) => {
             const spec = specFromNodeId(handler, $nodeId);
             const $itemId = spec.id;
 
-            const $success = withPgClientTransaction(
+            const $success = sideEffectWithPgClientTransaction(
               executor,
               // Passing a `list` step allows us to pass more than one dependency
               // through to our callback:

--- a/postgraphile/website/versioned_docs/version-5/extend-schema.md
+++ b/postgraphile/website/versioned_docs/version-5/extend-schema.md
@@ -655,7 +655,7 @@ user into the database and also sends them an email:
 ```ts
 import { extendSchema } from "postgraphile/utils";
 import { access, constant, object } from "postgraphile/grafast";
-import { withPgClientTransaction } from "postgraphile/@dataplan/pg";
+import { sideEffectWithPgClientTransaction } from "postgraphile/@dataplan/pg";
 
 export const MyRegisterUserMutationPlugin = extendSchema((build) => {
   const { sql } = build;
@@ -684,7 +684,7 @@ export const MyRegisterUserMutationPlugin = extendSchema((build) => {
         plans: {
           registerUser(_, fieldArgs) {
             const $input = fieldArgs.getRaw("input");
-            const $user = withPgClientTransaction(
+            const $user = sideEffectWithPgClientTransaction(
               executor,
               $input,
               async (pgClient, input) => {


### PR DESCRIPTION
## Description

`withPgClientTransaction` is deprecated in favour of `sideEffectWithPgClientTransaction` for mutations.

TODO: `withPgClient` is also deprecated in favour of `loadOneWithPgClient` or `loadManyWithPgClient`.

## Performance impact

N/A

## Security impact

N/A

## Checklist

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes.
- [ ] I have detailed the new feature in the relevant documentation.
- [ ] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [ ] If this is a breaking change I've explained why.