### PR TITLE
websites: Change navbar to show RC instead of Beta

### DIFF
--- a/graphile-build/website/docusaurus.config.js
+++ b/graphile-build/website/docusaurus.config.js
@@ -50,7 +50,7 @@ const config = {
           versions: {
             latest: { label: "Current" },
             4: { label: "v4 (current)", banner: "none" },
-            5: { label: "v5 (beta)", banner: "unreleased" },
+            5: { label: "v5 (rc)", banner: "unreleased" },
             current: { label: "Draft" },
           },
         },
@@ -76,7 +76,7 @@ const config = {
         versions: {
           latest: { label: "Current" },
           4: { label: "v4 (current)", banner: "none" },
-          5: { label: "v5 (beta)", banner: "unreleased" },
+          5: { label: "v5 (rc)", banner: "unreleased" },
           current: { label: "Draft" },
         },
       },

--- a/postgraphile/website/docusaurus.config.js
+++ b/postgraphile/website/docusaurus.config.js
@@ -52,7 +52,7 @@ const config = {
           versions: {
             latest: { label: "Current" },
             4: { label: "v4 (current)", banner: "none" },
-            5: { label: "v5 (beta)", banner: "unreleased" },
+            5: { label: "v5 (rc)", banner: "unreleased" },
             current: { label: "Draft" },
           },
         },


### PR DESCRIPTION
## Description


<img width="1009" height="267" alt="Screenshot 2025-10-29 at 12 49 07" src="https://github.com/user-attachments/assets/b503fa39-d9d6-4bd8-9ece-a10255a42d4b" />

Changed this navbar to show "rc" instead of "beta". The change is also reflected in the yellow warning box. I can't see that I need to update this anywhere else. 
