### PR TITLE
Enable last update author and time in Docusaurus config

### DIFF
--- a/grafast/website/docusaurus.config.js
+++ b/grafast/website/docusaurus.config.js
@@ -46,7 +46,6 @@ const config = {
           routeBasePath: "grafast",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl,
-          showLastUpdateAuthor: true,
           showLastUpdateTime: true,
           remarkPlugins: [
             [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
@@ -74,6 +73,7 @@ const config = {
         routeBasePath: "grafserv",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -84,6 +84,7 @@ const config = {
         routeBasePath: "ruru",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
       },
     ],
     [

--- a/graphile-build/website/docusaurus.config.js
+++ b/graphile-build/website/docusaurus.config.js
@@ -45,6 +45,7 @@ const config = {
           routeBasePath: "graphile-build",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl,
+          showLastUpdateTime: true,
           lastVersion: "latest",
           //includeCurrentVersion: false,
           versions: {
@@ -71,6 +72,7 @@ const config = {
         routeBasePath: "graphile-build-pg",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
         lastVersion: "latest",
         //includeCurrentVersion: false,
         versions: {

--- a/postgraphile/website/docusaurus.config.js
+++ b/postgraphile/website/docusaurus.config.js
@@ -44,6 +44,7 @@ const config = {
           routeBasePath: "postgraphile",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl,
+          showLastUpdateTime: true,
           remarkPlugins: [
             [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
           ],

--- a/utils/website/docusaurus.config.js
+++ b/utils/website/docusaurus.config.js
@@ -45,6 +45,7 @@ const config = {
           routeBasePath: "graphile-config",
           sidebarPath: require.resolve("./sidebars.js"),
           editUrl,
+          showLastUpdateTime: true,
         },
         blog: false,
         theme: {
@@ -63,6 +64,7 @@ const config = {
         routeBasePath: "graphile-export",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -73,6 +75,7 @@ const config = {
         routeBasePath: "pg-introspection",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -83,6 +86,7 @@ const config = {
         routeBasePath: "pg-sql2",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
       },
     ],
     [
@@ -93,6 +97,7 @@ const config = {
         routeBasePath: "tamedevil",
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
+        showLastUpdateTime: true,
       },
     ],
 


### PR DESCRIPTION
Assuming `publish-websites.sh` is the code to deploy the Grafast documentation, and that during the build process there is [access to the commit history for extracting the dates](https://github.com/facebook/docusaurus/issues/2798#issuecomment-636602951), these simple changes should display the date next to "Edit this page".