### PR TITLE
website: Grafast glossary editorial

### DIFF
--- a/grafast/website/grafast/glossary.md
+++ b/grafast/website/grafast/glossary.md
@@ -13,6 +13,8 @@ Feel free to add more terms and/or definitions via pull requests!
 
 ## GraphQL Terms
 
+The Gra*fast* documentation and project assumes you have a basic understanding of GraphQL, including the concept of resolvers. Below you can find some simple definitions of common GraphQL terminology, it is also recommended to read [Introduction to GraphQL](https://graphql.org/learn/) and in particular [GraphQL Execution](https://graphql.org/learn/execution/).
+
 ### (GraphQL) context
 
 Data passed by the GraphQL server into execution that provides additional
@@ -27,8 +29,8 @@ context about the running request, for example:
 - etc
 
 This is the `contextValue` passed to `graphql({...})` or `grafast({...})`, and
-is also the third argument to a [traditional resolver](#traditional-resolver).
-In a [plan resolver](#plan-resolver), a step representing the context can be
+is also the third argument to a **[traditional resolver](#traditional-resolver)**.
+In a **[plan resolver](#plan-resolver)**, a step representing the context can be
 retrieved through [`context()`](./standard-steps/context.md).
 
 ### (GraphQL) document
@@ -38,19 +40,19 @@ Typically an executable document.
 
 ### (GraphQL) executable document
 
-A [document](#graphql-document) consisting only of executable definitions
+A **[document](#graphql-document)** consisting only of executable definitions
 (operation and fragment definitions), as [defined in the GraphQL
 spec](https://spec.graphql.org/draft/#ExecutableDocument).
 
 ### (GraphQL) mutation
 
-An operation to mutate data,
+An **[operation](#graphql-operation)** to mutate data,
 as [defined in the GraphQL spec](https://spec.graphql.org/draft/#sec-Mutation).
 
 ### (GraphQL) operation
 
 Typically refers to an operation definition (and associated fragments) within a
-GraphQL executable document ([GraphQL spec
+GraphQL executable document (See the [GraphQL spec
 reference](https://spec.graphql.org/draft/#sec-Language.Operations)).
 
 ### (GraphQL) operation type
@@ -68,7 +70,7 @@ As defined in the GraphQL spec as ["a request for
 execution"](https://spec.graphql.org/draft/#request).
 
 - `schema` - the GraphQL schema
-- `document` - the GraphQL [document](#document)
+- `document` - the GraphQL **[document](#document)**
 
 ### GraphQL response
 
@@ -87,6 +89,8 @@ spec](<https://spec.graphql.org/draft/#ResolveFieldValue()>).
 
 ## Gra*fast* Terms
 
+The following is a quick reference for Gra*fast* specific terms.
+
 ### Abstract type plan resolver
 
 See [`planType`](./polymorphism.mdx#plantype).
@@ -97,20 +101,20 @@ See [Argument plan resolvers](./index.mdx#argument-plan-resolvers).
 
 ### Batch execution value
 
-An [execution value](#execution-value) that represents a batch of values.
+An **[execution value](#execution-value)** that represents a batch of values.
 `ev.isBatch` will be `true`, and data can be accessed via `ev.at(index)` for
 each index in the batch size (`executionDetails.count`).
 
 ### Bucket
 
-Stores the data for a [layer plan](#layer-plan) during execution of an
+Stores the data for a **[layer plan](#layer-plan)** during execution of an
 individual request. Contains the execution state of each step in the layer plan
-along with its [execution value](#execution-value), and also stores links to
-other buckets such that the [output plan](#output-plan) may later traverse to
+along with its **[execution value](#execution-value)**, and also stores links to
+other buckets such that the **[output plan](#output-plan)** may later traverse to
 access the data.
 
-When the context is clearly plan-time, it's common to use the term "bucket" as a
-short-hand for "layer plan". This isn't technically correct, but is
+When the context is clearly **[plan-time](#plan-time)**, it's common to use the term "bucket" as a
+short-hand for "**[layer plan](#layer-plan)**". This isn't technically correct, but is
 convenient.
 
 ### Field plan resolver
@@ -118,14 +122,14 @@ convenient.
 See [Field plan resolvers](./index.mdx#field-plan-resolvers).
 
 A simple JavaScript function that runs at [plan-time](#plan-time) to determine
-a step that satisfies the requirements for a given field. May infolve the
+a step that satisfies the requirements for a given field. May involve the
 creation of zero or more steps in the draft execution plan.
 
 ### Execution plan
 
 A directed acyclic graph of steps that detail the actions to take for execution
-of a GraphQL request. Part of the [operation plan](#operation-plan). Also
-details the [layer plans](#layer-plan) within, and their relationships.
+of a GraphQL request. Part of the **[operation plan](#operation-plan)**. Also
+details the **[layer plans](#layer-plan)** within, and their relationships.
 
 ### Execution-time
 
@@ -136,53 +140,53 @@ called "execution-time".
 ### Execution value
 
 The execution-time storage of all the values for a step, used as input to the
-`execute` method of a [step class](#step-class). Typically represented by the
-variable name `ev`. For unary steps this will be a [unary execution
-value](#unary-execution-value), for all other steps it will be a [batch
-execution value](#batch-execution-value).
+`execute` method of a **[step class](#step-class)**. Typically represented by the
+variable name `ev`. For unary steps this will be a **[unary execution
+value](#unary-execution-value)**, for all other steps it will be a **[batch
+execution value](#batch-execution-value)**.
 
 ### Layer plan
 
-Every [step](#step) belongs to exactly one layer plan within the execution plan.
+Every **[step](#step)** belongs to exactly one layer plan within the execution plan.
 The root layer plan represents request data and always
 has a batch size of 1; any time the batch size might change (up or down), a new
 layer plan is introduced to handle this transition - normally this will be a
 result of traversing types and selections in the GraphQL request.
 
 Layer plans are a plan-time concern; when executing an individual request a
-[bucket](#bucket) stores the data for a layer plan.
+**[bucket](#bucket)** stores the data for a layer plan.
 
 See: [Layer plans](./operation-plan.mdx#layer-plans).
 
 ### Lifecycle methods
 
-[Step classes](#step-class) contain methods for handling key events during their
+**[Step classes](#step-class)** contain methods for handling key events during their
 lifecycle:
 
 - `deduplicate` to help eliminate redundant work
 - `deduplicatedWith` when a step is disposed of due to deduplication
 - `optimize` to allow a step to talk to its ancestors, request they do
   additional work, and replace itself with a step that does less work
-- `finalize` to allow a step to do any "once only" (**not** once per request)
+- `finalize` to allow a step to do any "once only" (_not_ once per request)
   actions such as compiling SQL statements to text or hashing parameters
 - `execute` to produce (synchronously or asynchronously) the result data from
-  the [execution values](#execution-value) for each of its dependencies.
+  the **[execution values](#execution-value)** for each of its dependencies.
 
 ### Operation plan
 
-The combination of an [execution plan](#execution-plan) and [output
-plan](#output-plan) that details how to execute and output the result of a
+The combination of an **[execution plan](#execution-plan)** and **[output
+plan](#output-plan)** that details how to execute and output the result of a
 _GraphQL request_.
 
 ### Output plan
 
-Details how to take data from the [steps](#step) executed as part of the
-[execution plan](#execution-plan) for an individual _GraphQL request_ and format
+Details how to take data from the **[steps](#step)** executed as part of the
+**[execution plan](#execution-plan)** for an individual _GraphQL request_ and format
 them into a valid _GraphQL response_.
 
 ### Plan diagram
 
-Any visual representation of an [operation plan](#operation-plan) or subset
+Any visual representation of an **[operation plan](#operation-plan)** or subset
 thereof. Typically this is a render of the steps and layer plans in an execution
 plan via the Mermaid library.
 
@@ -190,9 +194,9 @@ plan via the Mermaid library.
 
 One of:
 
-- [field plan resolver](#field-plan-resolver) (most common)
-- [argument plan resolver](#argument-plan-resolver)
-- [abstract type plan resolver](#abstract-type-plan-resolver)
+- **[field plan resolver](#field-plan-resolver)** (most common)
+- **[argument plan resolver](#argument-plan-resolver)**
+- **[abstract type plan resolver](#abstract-type-plan-resolver)**
 
 ### Plan-time
 
@@ -203,19 +207,19 @@ is built; the period of time during which a plan is built is called "plan-time".
 ### Step
 
 The building block of an execution plan. A particular action or transform
-performed as part of executing a _GraphQL request_. An instance of a [step
-class](#step-class). By convention, steps are stored into variables that are
-named with a `$` prefix. Each step belongs to exactly one [layer
-plan](#layer-plan). A step is a plan-time representation of a specific value
+performed as part of executing a **[GraphQL request](#graphql-request)**. An instance of a **[step
+class](#step-class)**. By convention, steps are stored into variables that are
+named with a `$` prefix. Each step belongs to exactly one **[layer
+plan](#layer-plan)**. A step is a plan-time representation of a specific value
 (for example "a Post's author ID") (reminder: plans, and thus steps, are reused across
 requests). When executing an individual request, the data for a step is stored in
-an [execution value](#execution-value) which contains the full batch of values
+an **[execution value](#execution-value)** which contains the full batch of values
 the step represents (for example "the author IDs of all the returned Posts").
 
 ### Step class
 
 The backing logic of a step, see [step classes](./step-classes.mdx). Implements
-the [lifecycle methods](#lifecycle-methods).
+the **[lifecycle methods](#lifecycle-methods)**.
 
 ### Step function
 
@@ -224,7 +228,7 @@ calling other step functions).
 
 ### Unary execution value
 
-An [execution value](#execution-value) that represents exactly one value.
+An **[execution value](#execution-value)** that represents exactly one value.
 `ev.isBatch` will be `false`, and data can be accessed via `ev.unaryValue()`.
 Like a batch execution value, data can also be accessed via `ev.at(index)` for
 each index in the batch size, but the return result of all of these will be
@@ -236,4 +240,4 @@ batch).
 A step that will always have exactly one value when executing a request (i.e.
 does not require batching). Includes constants, field arguments, the GraphQL
 context, the root value, and many values derived from these. At execution time,
-the data will be stored into a [unary execution value](#unary-execution-value).
+the data will be stored into a **[unary execution value](#unary-execution-value)**.


### PR DESCRIPTION
## Description

- Terms in two sections: GraphQL terms and Grafast specific terms
- Terms in alphabetical order
- When the link is to an anchor on the same page, I have bolded it. 
