### PR TITLE
website: Enable ext link icon

### DIFF
--- a/grafast/website/src/theme/MDXComponents/A.jsx
+++ b/grafast/website/src/theme/MDXComponents/A.jsx
@@ -1,0 +1,13 @@
+import React from "react";
+import Link from "@docusaurus/Link";
+import isInternalUrl from "@docusaurus/isInternalUrl";
+import IconExternalLink from "@theme/Icon/ExternalLink";
+
+const MDXA = ({ href, children, ...props }) => (
+  <Link {...props} href={href}>
+    {children}
+    {!isInternalUrl(href) && <IconExternalLink />}
+  </Link>
+);
+
+export default MDXA;


### PR DESCRIPTION
## Description

External links within the body of the website are now denoted with an external link icon, including being styled appropriately: 

<img width="858" height="182" alt="Screenshot 2025-11-24 at 13 41 40" src="https://github.com/user-attachments/assets/c71fe374-0061-4945-a1c4-a761fc6a718c" />


<img width="842" height="239" alt="Screenshot 2025-11-24 at 13 41 51" src="https://github.com/user-attachments/assets/f324a2e9-2076-4c26-9416-f249e9de9ff0" />


Took longer than it looks because I had no idea docusaurus had a built in `isInternalUrl` flag. So in the end, all that was needed was to "swizzle" the A component in the theme folder. 