### PR TITLE
Enable npm2yarn

### DIFF
--- a/grafast/website/docusaurus.config.js
+++ b/grafast/website/docusaurus.config.js
@@ -74,6 +74,9 @@ const config = {
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
         showLastUpdateTime: true,
+        remarkPlugins: [
+          [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
+        ],
       },
     ],
     [
@@ -85,6 +88,9 @@ const config = {
         sidebarPath: require.resolve("./sidebars.js"),
         editUrl,
         showLastUpdateTime: true,
+        remarkPlugins: [
+          [require("@docusaurus/remark-plugin-npm2yarn"), { sync: true }],
+        ],
       },
     ],
     [


### PR DESCRIPTION
## Description

While checking 
- #2829 

I noticed that `npm2yarn` wasn't enabled for the Ruru docs even though we were trying to use it. Fixed! 