### PR TITLE
Update missing index detection query

### DIFF
--- a/postgraphile/website/postgraphile/postgresql-indexes.md
+++ b/postgraphile/website/postgraphile/postgresql-indexes.md
@@ -44,7 +44,8 @@ with indexed_tables as (
       i.relname as index_name,
       string_agg(a.attname::text, ', ' order by array_position(ix.indkey, a.attnum)) as column_names,
       ix.indrelid,
-      array_agg(a.attnum order by array_position(ix.indkey, a.attnum))::smallint[] as indkey
+      -- cast int2vector to smallint[]
+      string_to_array(ix.indkey::text, ' ')::smallint[] as indkey
   from pg_class i
   join pg_index ix on i.oid = ix.indrelid
   join pg_class t on ix.indrelid = t.oid


### PR DESCRIPTION
## Description

This:

```sql
where indrelid = conrelid
and conkey = indkey
or (array_length(indkey, 1) > 1 and indkey @> conkey)
```

is parsed by PostgreSQL as:

```sql
(
  indrelid = conrelid
  and conkey = indkey
)
OR
(
  array_length(indkey, 1) > 1
  and indkey @> conkey
)
```

Which means any multi-column index anywhere that happens to contain the FK columns will satisfy the EXISTS, even if it’s on a different table. Result: NOT EXISTS becomes false for every FK → empty set. The fix should be to group the index conditions under the same table constraint.

## Performance impact

unknown

## Security impact

unknown

## Checklist

<!-- If this PR is work in progress, please open it as a "Draft PR". -->
<!-- To tick a checkbox, change it from `[ ]` to `[x]` -->

- [x] My code matches the project's code style and `yarn lint:fix` passes.
- [ ] I've added tests for the new feature, and `yarn test` passes. (docs only)
- [x] I have detailed the new feature in the relevant documentation.
- [x] I have added this feature to 'Pending' in the `RELEASE_NOTES.md` file (if one exists).
- [x] If this is a breaking change I've explained why.

<!-- For some Graphile projects the documentation is the README.md file, for
      others please see https://github.com/graphile/graphile.github.io -->
