### PR TITLE
Fix changesets action

### DIFF
--- a/scripts/postversion.mjs
+++ b/scripts/postversion.mjs
@@ -51,11 +51,11 @@ export const version = ${JSON.stringify(packageJson.version)};
 
 releasedPackages.sort();
 
-// 3. run yarn (on CI, force mutation)
+// 3. Run yarn (on CI, force mutation)
 await $`yarn install --mode=update-lockfile --no-immutable`;
 await $`git add yarn.lock`;
 
-// 4. run `postversion` scripts
+// 4. Run `postversion` scripts
 await $`yarn workspaces foreach --topological-dev --all run postversion`;
 
 // 5. Commit changes (including `.changeset/pre.json`) with helpful commit message


### PR DESCRIPTION
Running `yarn` in CI failed, most likely due to the fact it's running with a frozen lockfile. This explicitly tells it to update the lockfile. Further, in my local testing the `postversion` script was not called (I was hoping that `changesets version` would call it), so I've added that too.