### PR TITLE
Fix changesets action

### DIFF
--- a/grafast/ruru/package.json
+++ b/grafast/ruru/package.json
@@ -33,8 +33,9 @@
     "webpack": "node --loader ts-node/esm \"$(yarn bin webpack-cli)\" --config webpack.config.mts",
     "watch": "yarn webpack --watch --mode=development",
     "make-ruru-html": "node --experimental-strip-types scripts/make-ruru-html.mts",
-    "postversion": "tsc -b tsconfig.build.json && yarn run make-ruru-html && git add ../website/static/myruru/index.html",
-    "build": "yarn webpack --mode=${BUILD_MODE:-production} && tsc -b tsconfig.build.json && cp src/.npmignore dist/ && chmod +x dist/cli-run.js && yarn make-ruru-html"
+    "postversion": "yarn workspace ruru-components build-package && yarn build-base && yarn run make-ruru-html && git add ../website/static/myruru/index.html",
+    "build-base": "yarn webpack --mode=${BUILD_MODE:-production} && tsc -b tsconfig.build.json && cp src/.npmignore dist/ && chmod +x dist/cli-run.js && yarn make-ruru-html",
+    "build": "yarn build-base && yarn make-ruru-html"
   },
   "repository": {
     "type": "git",

--- a/scripts/postversion.mjs
+++ b/scripts/postversion.mjs
@@ -56,7 +56,6 @@ await $`yarn install --mode=update-lockfile --no-immutable`;
 await $`git add yarn.lock`;
 
 // 4. Run `postversion` scripts
-await $`yarn build-init`;
 await $`yarn workspaces foreach --topological-dev --all run postversion`;
 
 // 5. Commit changes (including `.changeset/pre.json`) with helpful commit message


### PR DESCRIPTION
This time... `ruru`'s HTML generation failed because it needed `tsc -b` to pass and the dependencies didn't exist yet. Long term we should sort out this webpack/static bundling stuff. But for now, we'll put up with it.