### PR TITLE
Patch changesets to not bump explicit peer dep ranges

### DIFF
--- a/.yarn/patches/@changesets-apply-release-plan-npm-7.0.13-14603bf9e7.patch
+++ b/.yarn/patches/@changesets-apply-release-plan-npm-7.0.13-14603bf9e7.patch
@@ -1,0 +1,38 @@
+diff --git a/dist/changesets-apply-release-plan.cjs.js b/dist/changesets-apply-release-plan.cjs.js
+index 6ec629342ce6651477413724380bc24a512ac60c..c15d121ddf44d0fb91627cb9797ba929fc81aacf 100644
+--- a/dist/changesets-apply-release-plan.cjs.js
++++ b/dist/changesets-apply-release-plan.cjs.js
+@@ -111,12 +111,13 @@ function getBumpLevel(type) {
+   return level;
+ }
+ function shouldUpdateDependencyBasedOnConfig(release, {
+-  depVersionRange,
++  depVersionRange: rawDVR,
+   depType
+ }, {
+   minReleaseType,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  const depVersionRange = rawDVR.startsWith("workspace:") ? rawDVR.slice(10) : rawDVR;
+   if (!semverSatisfies__default["default"](release.version, depVersionRange)) {
+     // Dependencies leaving semver range should always be updated
+     return true;
+diff --git a/dist/changesets-apply-release-plan.esm.js b/dist/changesets-apply-release-plan.esm.js
+index 468a3d7b9f4e3c5687d6e09638ba03a9168c22fd..5e0157b438b776fd886e2ab0ad994fd2d64db2ba 100644
+--- a/dist/changesets-apply-release-plan.esm.js
++++ b/dist/changesets-apply-release-plan.esm.js
+@@ -74,12 +74,13 @@ function getBumpLevel(type) {
+   return level;
+ }
+ function shouldUpdateDependencyBasedOnConfig(release, {
+-  depVersionRange,
++  depVersionRange: rawDVR,
+   depType
+ }, {
+   minReleaseType,
+   onlyUpdatePeerDependentsWhenOutOfRange
+ }) {
++  const depVersionRange = rawDVR.startsWith("workspace:") ? rawDVR.slice(10) : rawDVR;
+   if (!semverSatisfies(release.version, depVersionRange)) {
+     // Dependencies leaving semver range should always be updated
+     return true;

--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   },
   "packageManager": "yarn@4.12.0",
   "resolutions": {
+    "@changesets/apply-release-plan@npm:^7.0.13": "patch:@changesets/apply-release-plan@npm%3A7.0.13#~/.yarn/patches/@changesets-apply-release-plan-npm-7.0.13-14603bf9e7.patch",
     "graphql": "^16.9.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1825,7 +1825,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@changesets/apply-release-plan@npm:^7.0.13":
+"@changesets/apply-release-plan@npm:7.0.13":
   version: 7.0.13
   resolution: "@changesets/apply-release-plan@npm:7.0.13"
   dependencies:
@@ -1843,6 +1843,27 @@ __metadata:
     resolve-from: "npm:^5.0.0"
     semver: "npm:^7.5.3"
   checksum: 10/b2ef4fc9a68ffd5c0543f0a98b8ea2321ff58519d541720646692a03844a2cd8e860ebcb93846be1e062926414dc343333196bfd8806fab26f637e8db8adbb9e
+  languageName: node
+  linkType: hard
+
+"@changesets/apply-release-plan@patch:@changesets/apply-release-plan@npm%3A7.0.13#~/.yarn/patches/@changesets-apply-release-plan-npm-7.0.13-14603bf9e7.patch":
+  version: 7.0.13
+  resolution: "@changesets/apply-release-plan@patch:@changesets/apply-release-plan@npm%3A7.0.13#~/.yarn/patches/@changesets-apply-release-plan-npm-7.0.13-14603bf9e7.patch::version=7.0.13&hash=857536"
+  dependencies:
+    "@changesets/config": "npm:^3.1.1"
+    "@changesets/get-version-range-type": "npm:^0.4.0"
+    "@changesets/git": "npm:^3.0.4"
+    "@changesets/should-skip-package": "npm:^0.1.2"
+    "@changesets/types": "npm:^6.1.0"
+    "@manypkg/get-packages": "npm:^1.1.3"
+    detect-indent: "npm:^6.0.0"
+    fs-extra: "npm:^7.0.1"
+    lodash.startcase: "npm:^4.4.0"
+    outdent: "npm:^0.5.0"
+    prettier: "npm:^2.7.1"
+    resolve-from: "npm:^5.0.0"
+    semver: "npm:^7.5.3"
+  checksum: 10/e2187ad48be029a5c8870a3332247b56ff351e092d4ec7108c89651cafca4bf39ac3fb6ea287ef7f50923764ce5e1e064f6ae979923afb0c59aeae8637b8414e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Seems changesets calls `semver` for comparison before removing `workspace:` prefix, resulting in semver failing and thus changesets bumping dependency version.

This resolves the issue; perhaps not in the best way...

An alternative no-patch fix would be to remove `workspace:` as a prefix; but I'd rather not do that.