### PR TITLE
Fix @skip/@include on fragment spreads in abstract positions

### DIFF
--- a/.changeset/goofy-flies-type.md
+++ b/.changeset/goofy-flies-type.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Fix a bug where `@skip` and `@include` on fragment spreads were not honoured in
+abstract positions.

--- a/grafast/grafast/__tests__/conformance/include-test.ts
+++ b/grafast/grafast/__tests__/conformance/include-test.ts
@@ -1,0 +1,51 @@
+/* eslint-disable graphile-export/exhaustive-deps, graphile-export/export-methods, graphile-export/export-plans, graphile-export/export-instances, graphile-export/export-subclasses, graphile-export/no-nested */
+import { describe, it } from "mocha";
+
+import { assertConformance, makeConformanceSchema } from "./utils.ts";
+
+const schema = makeConformanceSchema(/* GraphQL */ `
+  type Query implements SomeInterface {
+    int: Int
+    abstract: SomeInterface
+  }
+
+  interface SomeInterface {
+    int: Int
+  }
+`);
+
+describe("handles @include within abstract position fragment spreads", () => {
+  const source = /* GraphQL */ `
+    query ($include: Boolean!) {
+      abstract {
+        ... @include(if: $include) {
+          int
+        }
+      }
+    }
+  `;
+  it("handles $include: true", async () => {
+    await assertConformance(schema, source, { include: true });
+  });
+  it("handles $include: false", async () => {
+    await assertConformance(schema, source, { include: false });
+  });
+});
+
+describe("handles @skip within abstract position fragment spreads", () => {
+  const source = /* GraphQL */ `
+    query ($exclude: Boolean!) {
+      abstract {
+        ... @skip(if: $exclude) {
+          int
+        }
+      }
+    }
+  `;
+  it("handles $exclude: true", async () => {
+    await assertConformance(schema, source, { exclude: true });
+  });
+  it("handles $exclude: false", async () => {
+    await assertConformance(schema, source, { exclude: false });
+  });
+});

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -2710,7 +2710,17 @@ export class OperationPlan {
         }
 
         // find all selections compatible with `type`
-        const fieldNodes = fieldSelectionsForType(this, type, selections);
+        const fieldNodes = withGlobalLayerPlan(
+          layerPlan,
+          newPolymorphicPaths,
+          polymorphicPlanningPath,
+          null,
+          fieldSelectionsForType,
+          null,
+          this,
+          type,
+          selections,
+        );
         this.queueNextLayer(this.polymorphicPlanObjectType, {
           outputPlan: polymorphicOutputPlan,
           path,

--- a/grafast/grafast/src/graphqlCollectFields.ts
+++ b/grafast/grafast/src/graphqlCollectFields.ts
@@ -203,6 +203,38 @@ export function newSelectionSetDigest(resolverEmulation: boolean) {
   };
 }
 
+export function selectionIsSkipped(
+  operationPlan: OperationPlan,
+  selection: SelectionNode,
+) {
+  const trackedVariableValuesStep = operationPlan.trackedVariableValuesStep;
+  if (selection.directives !== undefined) {
+    if (
+      evalDirectiveArg<boolean | null>(
+        selection,
+        "skip",
+        "if",
+        trackedVariableValuesStep,
+        true,
+      ) === true
+    ) {
+      return true;
+    }
+    if (
+      evalDirectiveArg<boolean | null>(
+        selection,
+        "include",
+        "if",
+        trackedVariableValuesStep,
+        true,
+      ) === false
+    ) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /**
  * Implements the `GraphQLCollectFields` algorithm - like `CollectFields` the
  * GraphQL spec, but modified such that access to variables is tracked.
@@ -222,32 +254,10 @@ export function graphqlCollectFields(
   visitedFragments: { [fragmentName: string]: true } = Object.create(null),
 ): SelectionSetDigest {
   // const objectTypeFields = objectType.getFields();
-  const trackedVariableValuesStep = operationPlan.trackedVariableValuesStep;
   for (let i = 0, l = selections.length; i < l; i++) {
     const selection = selections[i];
-    if (selection.directives !== undefined) {
-      if (
-        evalDirectiveArg<boolean | null>(
-          selection,
-          "skip",
-          "if",
-          trackedVariableValuesStep,
-          true,
-        ) === true
-      ) {
-        continue;
-      }
-      if (
-        evalDirectiveArg<boolean | null>(
-          selection,
-          "include",
-          "if",
-          trackedVariableValuesStep,
-          true,
-        ) === false
-      ) {
-        continue;
-      }
+    if (selectionIsSkipped(operationPlan, selection)) {
+      continue;
     }
 
     switch (selection.kind) {

--- a/grafast/grafast/src/graphqlMergeSelectionSets.ts
+++ b/grafast/grafast/src/graphqlMergeSelectionSets.ts
@@ -6,6 +6,7 @@ import type {
 } from "graphql";
 import * as graphql from "graphql";
 
+import { selectionIsSkipped } from "./graphqlCollectFields.ts";
 import type { OperationPlan } from "./index.ts";
 import { inspect } from "./inspect.ts";
 
@@ -46,6 +47,9 @@ export function fieldSelectionsForType(
 ): ReadonlyArray<FieldNode> {
   for (let i = 0, l = selections.length; i < l; i++) {
     const selection = selections[i];
+    if (selectionIsSkipped(operationPlan, selection)) {
+      continue;
+    }
     switch (selection.kind) {
       case Kind.FRAGMENT_SPREAD: {
         // Assumed to exist because query passed validation.


### PR DESCRIPTION
Due to an oversight, `@skip` and `@include` when used on a named or inline fragment spread in an abstract position were previously ignored; this fixes the issue.