### PR TITLE
Add "unknown" codec

### DIFF
--- a/.changeset/green-keys-sneeze.md
+++ b/.changeset/green-keys-sneeze.md
@@ -1,0 +1,7 @@
+---
+"graphile-build-pg": patch
+"@dataplan/pg": patch
+"postgraphile": patch
+---
+
+Add `TYPES.unknown` codec to make porting from V4 easier

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -131,6 +131,14 @@ represented (even if the contents are mutated).
 Exception to the above: `const $foo = context().get("foo");` is fine, and
 preferred over the two statement equivalent.
 
+When writing plan resolvers against PostgreSQL resources, prefer the resource
+and step helpers before constructing low-level plans by hand. For example, use
+argument destructuring such as `(_$root, { $name })`, `users.find()`,
+`$users.where(...)`, and `$users.placeholder($name, TYPES.text)` where they fit,
+rather than building a custom `pgSelect({ identifiers, args, from })` wrapper.
+Reach for low-level constructors only when the resource/step APIs do not express
+the query shape.
+
 ## Testing Rules
 
 - Prefer **incremental** tests: cover public APIs and critical paths first.

--- a/grafast/dataplan-pg/src/codecs.ts
+++ b/grafast/dataplan-pg/src/codecs.ts
@@ -1107,6 +1107,7 @@ const reg = { hasNaturalOrdering: false };
  * names (those that would be found in the `pg_type` table).
  */
 export const TYPES = {
+  unknown: t<SQLRawValue>()("705", "unknown"), // unknown: 705
   void: t<void>()("2278", "void"), // void: 2278
   boolean: s<boolean>()("16", "bool", {
     fromPg: (value) => value[0] === "t",
@@ -1382,7 +1383,7 @@ export const LIST_TYPES = {
 } satisfies {
   [name in Exclude<
     keyof typeof TYPES,
-    "void"
+    "unknown" | "void"
   >]: (typeof TYPES)[name] extends PgCodec<
     infer UName,
     any,
@@ -1414,6 +1415,8 @@ for (const [name, codec] of Object.entries(LIST_TYPES)) {
  */
 export function getCodecByPgCatalogTypeName(pgCatalogTypeName: string) {
   switch (pgCatalogTypeName) {
+    case "unknown":
+      return TYPES.unknown;
     case "void":
       return TYPES.void;
     case "bool":

--- a/grafast/dataplan-pg/src/codecs.ts
+++ b/grafast/dataplan-pg/src/codecs.ts
@@ -1137,6 +1137,7 @@ function encodeUnknown(value: unknown): string | null {
  * names (those that would be found in the `pg_type` table).
  */
 export const TYPES = {
+  /** Experimental support for "unknown" data on input. @experimental */
   unknown: t<SQLRawValue>()("705", "unknown", {
     toPg(value) {
       return encodeUnknown(value);

--- a/grafast/dataplan-pg/src/codecs.ts
+++ b/grafast/dataplan-pg/src/codecs.ts
@@ -649,6 +649,40 @@ type PgCodecTFromJavaScript<
     ? UFromJs
     : any;
 
+function listEncode(
+  innerCodecToPg: PgEncode<any>,
+  typeDelim: string,
+  value: readonly unknown[],
+) {
+  let result = "{";
+  for (let i = 0, l = value.length; i < l; i++) {
+    if (i > 0) {
+      result += typeDelim;
+    }
+    const v = value[i];
+    if (v == null) {
+      result += "NULL";
+      continue;
+    }
+    const str = innerCodecToPg(v);
+    if (str == null) {
+      result += "NULL";
+      continue;
+    }
+    if (typeof str !== "string" && typeof str !== "number") {
+      throw new Error(
+        `Do not know how to encode ${inspect(str)} to an array (send a PR!)`,
+      );
+    }
+    // > To put a double quote or backslash in a quoted array element
+    // > value, precede it with a backslash.
+    // -- https://www.postgresql.org/docs/current/arrays.html#ARRAYS-IO
+    result += `"${String(str).replace(/[\\"]/g, "\\$&")}"`;
+  }
+  result += "}";
+  return result;
+}
+
 /**
  * Given a PgCodec, this returns a new PgCodec that represents a list
  * of the former.
@@ -732,37 +766,7 @@ export function listOfCodec<
       innerCodecFromPg === identity && typeDelim === ","
         ? parseArray
         : makeParseArrayWithTransform(innerCodecFromPg, typeDelim),
-    toPg: (value) => {
-      let result = "{";
-      for (let i = 0, l = value.length; i < l; i++) {
-        if (i > 0) {
-          result += typeDelim;
-        }
-        const v = value[i];
-        if (v == null) {
-          result += "NULL";
-          continue;
-        }
-        const str = innerCodecToPg(v);
-        if (str == null) {
-          result += "NULL";
-          continue;
-        }
-        if (typeof str !== "string" && typeof str !== "number") {
-          throw new Error(
-            `Do not know how to encode ${inspect(
-              str,
-            )} to an array (send a PR!)`,
-          );
-        }
-        // > To put a double quote or backslash in a quoted array element
-        // > value, precede it with a backslash.
-        // -- https://www.postgresql.org/docs/current/arrays.html#ARRAYS-IO
-        result += `"${String(str).replace(/[\\"]/g, "\\$&")}"`;
-      }
-      result += "}";
-      return result;
-    },
+    toPg: (value) => listEncode(innerCodecToPg, typeDelim, value),
     attributes: undefined,
     description,
     extensions,
@@ -1101,13 +1105,47 @@ const stripSubnet32 = {
   },
 };
 const reg = { hasNaturalOrdering: false };
+
+// Rough emulation of what I think the `pg` module does
+function encodeUnknown(value: unknown): string | null {
+  if (value == null) {
+    return null;
+  }
+  const t = typeof value;
+  if (t === "string") {
+    return value as string;
+  } else if (t === "boolean") {
+    return String(value);
+  } else if (t === "number") {
+    return String(value);
+  } else if (Array.isArray(value)) {
+    return listEncode(encodeUnknown, ",", value);
+  } else if (value instanceof Date) {
+    return value.toISOString();
+  } else if (Buffer.isBuffer(value)) {
+    throw new Error("Encoding buffer not supported for unknown");
+  } else if (t === "object") {
+    return JSON.stringify(value);
+  } else {
+    return String(value);
+  }
+}
+
 /**
  * Built in PostgreSQL types that we support; note the keys are the "ergonomic"
  * names (like 'bigint'), but the values use the underlying PostgreSQL true
  * names (those that would be found in the `pg_type` table).
  */
 export const TYPES = {
-  unknown: t<SQLRawValue>()("705", "unknown"), // unknown: 705
+  unknown: t<SQLRawValue>()("705", "unknown", {
+    toPg(value) {
+      return encodeUnknown(value);
+    },
+    fromPg(value) {
+      // TODO: warning?
+      return String(value);
+    },
+  }), // unknown: 705
   void: t<void>()("2278", "void"), // void: 2278
   boolean: s<boolean>()("16", "bool", {
     fromPg: (value) => value[0] === "t",

--- a/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
+++ b/graphile-build/graphile-build-pg/src/plugins/PgCodecsPlugin.ts
@@ -989,6 +989,7 @@ export const PgCodecsPlugin: GraphileConfig.Plugin = {
               | null
               | { [situation: string]: string | null };
           } = {
+            unknown: null,
             void: null,
             boolean: "Boolean",
             int2: "Int",

--- a/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
+++ b/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
@@ -872,6 +872,8 @@ it("enables setting apply for enum values", async () => {
   }
   class ThingyStep extends Step {
     private applyDepIds: number[] = [];
+    // Disable warning
+    isSyncAndSafe = false;
     apply($step: Step<(n: Thingy) => void>) {
       this.applyDepIds.push(this.addUnaryDependency($step));
     }
@@ -960,6 +962,8 @@ it("enables setting apply for enum values", async () => {
 
 class NumberStep extends Step {
   baseValue: number;
+  // Disable warning
+  isSyncAndSafe = false;
   operations: { opName: "add" | "subtract"; depId: number }[];
   constructor(value: number) {
     super();

--- a/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
+++ b/graphile-build/graphile-utils/__tests__/makeExtendSchemaPlugin.test.ts
@@ -428,6 +428,72 @@ it("supports arbitrary sql queries, does not dedup unrelated queries", async () 
   });
 });
 
+it("supports arbitrary sql queries with unknown placeholders", async () => {
+  const preset: GraphileConfig.Preset = {
+    extends: [PostGraphileAmberPreset],
+    plugins: [
+      extendSchema((build) => {
+        const { users } = build.input.pgRegistry.pgResources;
+        const { sql } = build;
+        return {
+          typeDefs: gql`
+            extend type Query {
+              usersByUnknownName(name: String!): UserConnection
+            }
+          `,
+          objects: {
+            Query: {
+              plans: {
+                usersByUnknownName(_$root, { $name }) {
+                  const $users = users.find();
+                  $users.where(
+                    sql`${$users.alias}.name = ${$users.placeholder($name, TYPES.unknown)}`,
+                  );
+                  return connection($users);
+                },
+              },
+            },
+          },
+        };
+      }),
+    ],
+    pgServices: [
+      makePgService({
+        pool: pgPool!,
+        schemas: ["graphile_utils"],
+      }),
+    ],
+  };
+  const { schema, resolvedPreset } = await makeSchema(preset);
+  const result = await grafast({
+    schema,
+    resolvedPreset,
+    requestContext: {},
+    source: /* GraphQL */ `
+      {
+        usersByUnknownName(name: "Alice") {
+          nodes {
+            name
+            email
+          }
+        }
+      }
+    `,
+  });
+  expect(result).toEqual({
+    data: {
+      usersByUnknownName: {
+        nodes: [
+          {
+            name: "Alice",
+            email: "alice@example.com",
+          },
+        ],
+      },
+    },
+  });
+});
+
 it("scope", async () => {
   const scopes: Record<string, any> = Object.create(null);
   const preset: GraphileConfig.Preset = {


### PR DESCRIPTION
When porting from V4, `sql.value(foo)` is typically replaced by `$pgSelect.placeholder($foo, TYPES.bar)`. The issue is, we don't always know what `bar` is. This PR makes it so we can use `TYPES.unknown` until the actual type is known, making it obvious to the user to return and refactor, whilst maintaining equivalence with V4 code.