### PR TITLE
Remove special status from "rootValue"

### DIFF
--- a/grafast/grafast/README.md
+++ b/grafast/grafast/README.md
@@ -82,7 +82,6 @@ requirements:
 - for every request:
   - `context` must be an object (anything suitable to be used as the key to a
     `WeakMap`); if you do not need a context then `{}` is perfectly acceptable
-  - `rootValue` must be an object or `null`/`undefined`
 - resolver limitations:
   - only explicit field resolvers (baked into the GraphQL schema) are supported,
     i.e. resolvers passed via `rootValue` are not (currently) supported

--- a/grafast/grafast/src/bucket.ts
+++ b/grafast/grafast/src/bucket.ts
@@ -16,6 +16,8 @@ export interface RequestTools {
   /** @internal */
   args: GrafastExecutionArgs;
   /** @internal */
+  currentRootValue: any;
+  /** @internal */
   onError: ErrorBehavior;
   /** The `timeSource.now()` at which the request started executing */
   startTime: number;

--- a/grafast/grafast/src/constants.ts
+++ b/grafast/grafast/src/constants.ts
@@ -29,6 +29,7 @@ export const $$idempotent = Symbol("idempotent");
  * The event emitter used for outputting execution events.
  */
 export const $$eventEmitter = Symbol("executionEventEmitter");
+export const $$originalRootValue = Symbol("originalRootValue");
 
 /**
  * Used to indicate that an array has more results available via a stream.

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1503,7 +1503,7 @@ export class OperationPlan {
           deferredLayerPlan,
           outputPlan.rootStep,
           {
-            mode: "object",
+            mode: outputPlan.type.mode === "root" ? "root" : "object",
             deferLabel: deferred.label,
             typeName: objectType.name,
           },

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -74,6 +74,7 @@ export type OutputPlanTypeRoot = {
    */
   mode: "root";
   typeName: string;
+  deferLabel?: string | undefined;
 };
 export type OutputPlanTypeObject = {
   /**
@@ -214,10 +215,10 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
     | undefined;
 
   /**
-   * For object output plan types only.
+   * For root and object output plan types only.
    */
   public deferredOutputPlans: OutputPlan<
-    OutputPlanTypeObject | OutputPlanTypePolymorphicObject
+    OutputPlanTypeRoot | OutputPlanTypeObject | OutputPlanTypePolymorphicObject
   >[] = [];
 
   public layerPlan: LayerPlan;

--- a/grafast/grafast/src/execute.ts
+++ b/grafast/grafast/src/execute.ts
@@ -6,7 +6,11 @@ import type {
 } from "graphql";
 import type { PromiseOrValue } from "graphql/jsutils/PromiseOrValue.js";
 
-import { $$eventEmitter, $$extensions } from "./constants.ts";
+import {
+  $$eventEmitter,
+  $$extensions,
+  $$originalRootValue,
+} from "./constants.ts";
 import type {
   ExecuteEvent,
   ExecutionEventEmitter,
@@ -28,6 +32,10 @@ export function withGrafastArgs(
   ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
 > {
   const options = args.resolvedPreset?.grafast;
+  args[$$originalRootValue] = args.rootValue;
+  if (args.rootValue == null) {
+    args.rootValue = Object.create(null);
+  }
   const explain = options?.explain;
   const shouldExplain = !!explain;
 
@@ -51,8 +59,6 @@ export function withGrafastArgs(
     eventEmitter!.on("explainOperation", handleExplainOperation);
     unlisten = () => {
       eventEmitter!.removeListener("explainOperation", handleExplainOperation);
-      delete args[$$eventEmitter];
-      delete args[$$extensions];
     };
   }
 

--- a/grafast/grafast/src/execute.ts
+++ b/grafast/grafast/src/execute.ts
@@ -7,8 +7,6 @@ import type {
 import type { PromiseOrValue } from "graphql/jsutils/PromiseOrValue.js";
 
 import { $$eventEmitter, $$extensions } from "./constants.ts";
-import { isDev } from "./dev.ts";
-import { inspect } from "./inspect.ts";
 import type {
   ExecuteEvent,
   ExecutionEventEmitter,
@@ -30,25 +28,6 @@ export function withGrafastArgs(
   ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
 > {
   const options = args.resolvedPreset?.grafast;
-  if (isDev) {
-    if (
-      args.rootValue != null &&
-      (typeof args.rootValue !== "object" ||
-        Object.keys(args.rootValue).length > 0)
-    ) {
-      throw new Error(
-        `Grafast executor doesn't support there being a rootValue (found ${inspect(
-          args.rootValue,
-        )})`,
-      );
-    }
-  }
-  if (args.rootValue == null) {
-    args.rootValue = Object.create(null);
-  }
-  if (typeof args.rootValue !== "object" || args.rootValue == null) {
-    throw new Error("Grafast requires that the 'rootValue' be an object");
-  }
   const explain = options?.explain;
   const shouldExplain = !!explain;
 
@@ -56,14 +35,12 @@ export function withGrafastArgs(
   if (shouldExplain) {
     const eventEmitter: ExecutionEventEmitter | undefined = new EventEmitter();
     const explainOperations: any[] = [];
-    args.rootValue = Object.assign(Object.create(null), args.rootValue, {
-      [$$eventEmitter]: eventEmitter,
-      [$$extensions]: {
-        explain: {
-          operations: explainOperations,
-        },
+    args[$$eventEmitter] = eventEmitter;
+    args[$$extensions] = {
+      explain: {
+        operations: explainOperations,
       },
-    });
+    };
     const handleExplainOperation = ({
       operation,
     }: ExecutionEventMap["explainOperation"]) => {
@@ -74,6 +51,8 @@ export function withGrafastArgs(
     eventEmitter!.on("explainOperation", handleExplainOperation);
     unlisten = () => {
       eventEmitter!.removeListener("explainOperation", handleExplainOperation);
+      delete args[$$eventEmitter];
+      delete args[$$extensions];
     };
   }
 

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -31,6 +31,7 @@ import type { Bucket, RequestTools } from "./bucket.ts";
 import {
   $$eventEmitter,
   $$extensions,
+  $$originalRootValue,
   type $$streamMore,
   type $$timeout,
   type $$ts,
@@ -829,6 +830,7 @@ export interface GrafastExecutionArgs extends ExecutionArgs {
   outputDataAsString?: boolean;
   [$$eventEmitter]?: ExecutionEventEmitter;
   [$$extensions]?: Record<string, unknown>;
+  [$$originalRootValue]?: any;
 }
 
 export interface ValidateSchemaEvent {

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -28,11 +28,13 @@ import type {
 import type { ObjMap } from "graphql/jsutils/ObjMap.js";
 
 import type { Bucket, RequestTools } from "./bucket.ts";
-import type {
-  $$streamMore,
-  $$timeout,
-  $$ts,
-  ExecutionEntryFlags,
+import {
+  $$eventEmitter,
+  $$extensions,
+  type $$streamMore,
+  type $$timeout,
+  type $$ts,
+  type ExecutionEntryFlags,
 } from "./constants.ts";
 import type { Constraint } from "./constraints.ts";
 import type { LayerPlanReasonListItemStream } from "./engine/LayerPlan.ts";
@@ -825,6 +827,8 @@ export interface GrafastExecutionArgs extends ExecutionArgs {
   middleware?: Middleware<GraphileConfig.GrafastMiddleware> | null;
   requestContext?: Partial<Grafast.RequestContext>;
   outputDataAsString?: boolean;
+  [$$eventEmitter]?: ExecutionEventEmitter;
+  [$$extensions]?: Record<string, unknown>;
 }
 
 export interface ValidateSchemaEvent {

--- a/grafast/grafast/src/prepare.ts
+++ b/grafast/grafast/src/prepare.ts
@@ -363,7 +363,7 @@ function executePreemptive(
     startTime,
     stopTime,
     // toSerialize: [],
-    eventEmitter: rootValue?.[$$eventEmitter],
+    eventEmitter: args[$$eventEmitter],
     abortSignal,
     insideGraphQL: false,
   };
@@ -421,7 +421,7 @@ function executePreemptive(
       return finalize(
         result,
         ctx,
-        index === 0 ? (rootValue[$$extensions] ?? undefined) : undefined,
+        index === 0 ? (args[$$extensions] ?? undefined) : undefined,
         outputDataAsString,
       );
     }
@@ -460,7 +460,7 @@ function executePreemptive(
       ];
       const payload = Object.create(null) as ExecutionResult;
       payload.errors = errors;
-      const extensions = bucketRootValue[$$extensions];
+      const extensions = args[$$extensions];
       if (extensions != null) {
         payload.extensions = extensions;
       }
@@ -564,7 +564,7 @@ function executePreemptive(
     return finalize(
       result,
       ctx,
-      rootValue[$$extensions] ?? undefined,
+      args[$$extensions] ?? undefined,
       outputDataAsString,
     );
   }
@@ -601,7 +601,7 @@ export function grafastPrepare(
   const {
     schema,
     contextValue: context,
-    rootValue = Object.create(null),
+    rootValue,
     // operationName,
     // document,
     middleware,
@@ -612,7 +612,7 @@ export function grafastPrepare(
   if (Array.isArray(exeContext) || "length" in exeContext) {
     return Object.assign(Object.create(bypassGraphQLObj), {
       errors: exeContext,
-      extensions: rootValue[$$extensions],
+      extensions: args[$$extensions],
     });
   }
 
@@ -674,7 +674,7 @@ export function grafastPrepare(
     if (operationPlan[$$contextPlanCache] == null) {
       operationPlan[$$contextPlanCache] = operationPlan.generatePlanJSON();
     }
-    rootValue[$$extensions]?.explain?.operations.push({
+    (args[$$extensions] as any)?.explain?.operations.push({
       type: "plan",
       title: "Plan",
       plan: operationPlan[$$contextPlanCache],

--- a/grafast/grafast/src/prepare.ts
+++ b/grafast/grafast/src/prepare.ts
@@ -12,6 +12,7 @@ import {
   $$contextPlanCache,
   $$eventEmitter,
   $$extensions,
+  $$originalRootValue,
   $$streamMore,
   FLAG_ERROR,
   NO_FLAGS,
@@ -359,6 +360,7 @@ function executePreemptive(
     executionTimeout !== null ? startTime + executionTimeout : null;
   const requestContext: RequestTools = {
     args,
+    currentRootValue: args[$$originalRootValue],
     onError,
     startTime,
     stopTime,
@@ -404,14 +406,21 @@ function executePreemptive(
       iterators: [new Set()],
       size: 1, //store.size
     });
-    const bucketPromise = executeBucket(subscriptionBucket, requestContext);
+    const subscriptionRequestContext: RequestTools = {
+      ...requestContext,
+      currentRootValue: payload,
+    };
+    const bucketPromise = executeBucket(
+      subscriptionBucket,
+      subscriptionRequestContext,
+    );
     function outputStreamBucket() {
       // NOTE: this is the root output plan for a subscription operation.
       const [ctx, result] = outputBucket(
         operationPlan.rootOutputPlan,
         subscriptionBucket,
         ZERO,
-        requestContext,
+        subscriptionRequestContext,
         [],
         rootBucket.store
           .get(operationPlan.variableValuesStep.id)!

--- a/grafast/grafast/src/steps/graphqlResolver.ts
+++ b/grafast/grafast/src/steps/graphqlResolver.ts
@@ -97,15 +97,17 @@ export class GraphQLResolverStep extends UnbatchedStep {
     variableValues: any,
     rootValue: any,
   ): any {
+    const executionRootValue = extra._requestContext.currentRootValue;
     if (!extra.stream) {
       if (this.isNotRoot && source == null) {
         return source;
       }
+      const resolverSource = this.isNotRoot ? source : executionRootValue;
       const resolveInfo: GraphQLResolveInfo = Object.assign(
         Object.create(this.resolveInfoBase),
         {
           variableValues,
-          rootValue,
+          rootValue: executionRootValue,
           path: {
             typename: this.resolveInfoBase.parentType.name,
             key: this.resolveInfoBase.fieldName,
@@ -114,7 +116,12 @@ export class GraphQLResolverStep extends UnbatchedStep {
           },
         },
       );
-      const data = this.resolver?.(source, args, context, resolveInfo);
+      const data = this.resolver?.(
+        resolverSource,
+        args,
+        context,
+        resolveInfo,
+      );
       return flagErrorIfErrorAsync(data);
     } else {
       if (this.isNotRoot) {
@@ -128,10 +135,15 @@ export class GraphQLResolverStep extends UnbatchedStep {
         {
           // ENHANCE: add support for path
           variableValues,
-          rootValue,
+          rootValue: executionRootValue,
         },
       );
-      const data = this.subscriber(source, args, context, resolveInfo);
+      const data = this.subscriber(
+        executionRootValue,
+        args,
+        context,
+        resolveInfo,
+      );
       return flagErrorIfErrorAsync(data);
     }
   }

--- a/grafast/website/grafast/getting-started/existing-schema.md
+++ b/grafast/website/grafast/getting-started/existing-schema.md
@@ -22,7 +22,6 @@ following hold:
   currently populate that in an equivalent fashion
 - `context` must be an object (anything suitable to be used as the key to a
   `WeakMap`); if you do not need a context then `{}` is perfectly acceptable
-- `rootValue`, if specified, must be an object or `null`/`undefined`
 - `resolveType` and `isTypeOf`, if specified, must return the
   GraphQL type name as a string (rather than returning the object type itself)
   and their version of `GraphQLResolveInfo` is even more cut down (but you


### PR DESCRIPTION
## Description

Prior to this `rootValue` was required to be a mutable object so we could write to it. We would automatically coerce an undefined `rootValue` to an object to make this the case. However, this means that any resolver wrappers that people are using `source == null` on to detect root selection set will fail. So we should remove this to improve compatibility with traditional GraphQL resolvers.

## Performance impact

Minimal.

## Security impact

None known.

## Checklist

Internal refactor.