### PR TITLE
PgCondition "RECORD_EXPRESSION" mode

### DIFF
--- a/.changeset/beige-toes-tease.md
+++ b/.changeset/beige-toes-tease.md
@@ -1,0 +1,7 @@
+---
+"@dataplan/pg": patch
+---
+
+Add new `RECORD_EXPRESSION` mode to PgCondition so
+postgraphile-plugin-connection-filter doesn't need to rely on a hack to enable
+filtering on composite columns.

--- a/.changeset/beige-toes-tease.md
+++ b/.changeset/beige-toes-tease.md
@@ -4,4 +4,5 @@
 
 Add new `RECORD_EXPRESSION` mode to PgCondition so
 postgraphile-plugin-connection-filter doesn't need to rely on a hack to enable
-filtering on composite columns.
+filtering on composite columns. Also changes `PgCondition` signature to accept a
+configuration object.

--- a/grafast/dataplan-pg/src/steps/pgCondition.ts
+++ b/grafast/dataplan-pg/src/steps/pgCondition.ts
@@ -1,4 +1,4 @@
-import { Modifier } from "grafast";
+import { inspect, Modifier } from "grafast";
 import type { SQL } from "pg-sql2";
 import { $$toSQL, sql } from "pg-sql2";
 
@@ -39,12 +39,19 @@ type PgConditionModeExists = {
   equals?: boolean;
 };
 
+type PgConditionModeTableExpression = {
+  mode: "RECORD_EXPRESSION";
+  expression: SQL;
+  alias?: string;
+};
+
 export type PgConditionResolvedMode =
   | { mode: "PASS_THRU" }
   | { mode: "AND" }
   | { mode: "OR" }
   | { mode: "NOT" }
-  | PgConditionModeExists;
+  | PgConditionModeExists
+  | PgConditionModeTableExpression;
 
 export type PgConditionMode =
   | "PASS_THRU"
@@ -128,6 +135,16 @@ export class PgCondition<
           Symbol(this.resolvedMode.alias ?? "exists"),
         );
         break;
+      }
+      case "RECORD_EXPRESSION": {
+        this.alias = sql.identifier(
+          Symbol(this.resolvedMode.alias ?? "table_expression"),
+        );
+        break;
+      }
+      default: {
+        const never: never = this.resolvedMode;
+        throw new Error(`Unexpected mode ${inspect(never)}`);
       }
     }
   }
@@ -219,6 +236,12 @@ where ${sqlCondition}`})`;
           // Assume true
           return sqlExists;
         }
+      }
+      case "RECORD_EXPRESSION": {
+        return sql`(${sql.indent`\
+select ${sqlCondition}
+from (select ${this.resolvedMode.expression}.*) as ${this.alias}
+`})`;
       }
       default: {
         const never: never = this.resolvedMode;

--- a/grafast/dataplan-pg/src/steps/pgCondition.ts
+++ b/grafast/dataplan-pg/src/steps/pgCondition.ts
@@ -75,7 +75,7 @@ interface PgConditionOptions {
 function resolveOptions(
   isHavingOrOptions: PgConditionOptions | boolean | undefined,
   maybeMode: PgConditionMode | undefined,
-) {
+): PgConditionOptions {
   if (typeof isHavingOrOptions === "boolean") {
     return { isHaving: isHavingOrOptions, mode: maybeMode };
   } else if (isHavingOrOptions == null) {
@@ -84,10 +84,8 @@ function resolveOptions(
     throw new Error(
       `Invalid call signature to PgCondition constructor, use \`new PgCondition(parent, options)\``,
     );
-  } else if (isHavingOrOptions) {
-    return isHavingOrOptions;
   } else {
-    return {};
+    return isHavingOrOptions;
   }
 }
 

--- a/grafast/dataplan-pg/src/steps/pgCondition.ts
+++ b/grafast/dataplan-pg/src/steps/pgCondition.ts
@@ -39,10 +39,15 @@ type PgConditionModeExists = {
   equals?: boolean;
 };
 
-type PgConditionModeTableExpression = {
+type PgConditionModeRecordExpression = {
   mode: "RECORD_EXPRESSION";
+  /**
+   * BEWARE: this expression may be _repeated_ multiple times in the generated
+   * query, so it should be inexpensive and have no side effects. Intended for
+   * use with columns of a composite type, so expression should typically be
+   * wrapped in parenthesis, enabling `(my_table.my_column).my_attribute`
+   */
   expression: SQL;
-  alias?: string;
 };
 
 export type PgConditionResolvedMode =
@@ -51,7 +56,7 @@ export type PgConditionResolvedMode =
   | { mode: "OR" }
   | { mode: "NOT" }
   | PgConditionModeExists
-  | PgConditionModeTableExpression;
+  | PgConditionModeRecordExpression;
 
 export type PgConditionMode =
   | "PASS_THRU"
@@ -137,9 +142,7 @@ export class PgCondition<
         break;
       }
       case "RECORD_EXPRESSION": {
-        this.alias = sql.identifier(
-          Symbol(this.resolvedMode.alias ?? "table_expression"),
-        );
+        this.alias = this.resolvedMode.expression;
         break;
       }
       default: {
@@ -238,10 +241,7 @@ where ${sqlCondition}`})`;
         }
       }
       case "RECORD_EXPRESSION": {
-        return sql`(${sql.indent`\
-select ${sqlCondition}
-from (select ${this.resolvedMode.expression}.*) as ${this.alias}
-`})`;
+        return sqlCondition;
       }
       default: {
         const never: never = this.resolvedMode;

--- a/grafast/dataplan-pg/src/steps/pgCondition.ts
+++ b/grafast/dataplan-pg/src/steps/pgCondition.ts
@@ -53,6 +53,32 @@ export type PgConditionMode =
   | "NOT"
   | PgConditionResolvedMode;
 
+interface PgConditionOptions {
+  /** @defaultValue `false` */
+  isHaving?: boolean;
+  /** @defaultValue `"PASS_THRU"` */
+  mode?: PgConditionMode;
+}
+
+function resolveOptions(
+  isHavingOrOptions: PgConditionOptions | boolean | undefined,
+  maybeMode: PgConditionMode | undefined,
+) {
+  if (typeof isHavingOrOptions === "boolean") {
+    return { isHaving: isHavingOrOptions, mode: maybeMode };
+  } else if (isHavingOrOptions == null) {
+    return { mode: maybeMode };
+  } else if (maybeMode !== undefined) {
+    throw new Error(
+      `Invalid call signature to PgCondition constructor, use \`new PgCondition(parent, options)\``,
+    );
+  } else if (isHavingOrOptions) {
+    return isHavingOrOptions;
+  } else {
+    return {};
+  }
+}
+
 export class PgCondition<
     TParent extends PgConditionCapableParent = PgConditionCapableParent,
   >
@@ -73,12 +99,16 @@ export class PgCondition<
   public readonly resolvedMode: PgConditionResolvedMode;
   private isHaving: boolean;
 
+  constructor(parent: TParent, options: PgConditionOptions);
+  constructor(parent: TParent, isHaving?: boolean, mode?: PgConditionMode);
   constructor(
     parent: TParent,
-    isHaving = false,
-    mode: PgConditionMode = "PASS_THRU",
+    isHavingOrOptions?: PgConditionOptions | boolean,
+    maybeMode?: PgConditionMode,
   ) {
     super(parent);
+    const options = resolveOptions(isHavingOrOptions, maybeMode);
+    const { isHaving = false, mode = "PASS_THRU" } = options;
     this.isHaving = isHaving;
     if (typeof mode === "string") {
       this.resolvedMode = { mode };


### PR DESCRIPTION
Enables applying filters to a record expression e.g. `(my_table.my_column)` for dealing with composite columns: `(my_table.my_column).my_attribute = 'MyValue'`

**NOTE**: this is NOT for use with expensive expressions (e.g. `(my_function(row_value))`) since the expression may appear multiple times in the resulting query. We can add a different mode for that later that does `(select ${sqlConditions} from (select (${expr}).*) as ${alias})` instead - but that was excessive for this. We could actually do it with this mode but a flag to tell it to use a subquery (`subquery: true`).