### PR TITLE
Fix fieldArgs application for steps with side effects (and connections thereof)

### DIFF
--- a/.changeset/better-boats-lick.md
+++ b/.changeset/better-boats-lick.md
@@ -1,0 +1,9 @@
+---
+"graphile-build-pg": patch
+"postgraphile": patch
+"grafast": patch
+---
+
+`fieldArgs` are now created in the root plan and applied in the layer plan of
+the target step; this fixes an issue where fieldArgs could not be applied to
+step with side effects.

--- a/grafast/grafast/src/operationPlan-input.ts
+++ b/grafast/grafast/src/operationPlan-input.ts
@@ -112,43 +112,47 @@ export function withFieldArgsForArguments<T extends Step>(
       }
     },
     getRaw(path?: string | ReadonlyArray<string | number>) {
-      assertNotRuntime(operationPlan, `fieldArgs.getRaw()`);
-      if (path === undefined) {
-        return object(trackedArguments);
-      } else if (typeof path === "string") {
-        return trackedArguments[path];
-      } else if (Array.isArray(path)) {
-        const [first, ...rest] = path;
-        if (!first) {
-          throw new Error(`getRaw() must be called with a non-empty path`);
-        }
-        let $entry = trackedArguments[first];
-        for (const pathSegment of rest) {
-          if (typeof pathSegment === "number" && "at" in $entry) {
-            $entry = $entry.at(pathSegment);
-          } else if ("get" in $entry) {
-            $entry = ($entry.get as any)(pathSegment);
-          } else {
-            throw new Error(
-              `'getRaw' path must only relate to input objects right now; path was: '${path}' (failed at '${pathSegment}')`,
-            );
+      return operationPlan.withRootLayerPlan(() => {
+        assertNotRuntime(operationPlan, `fieldArgs.getRaw()`);
+        if (path === undefined) {
+          return object(trackedArguments);
+        } else if (typeof path === "string") {
+          return trackedArguments[path];
+        } else if (Array.isArray(path)) {
+          const [first, ...rest] = path;
+          if (!first) {
+            throw new Error(`getRaw() must be called with a non-empty path`);
           }
+          let $entry = trackedArguments[first];
+          for (const pathSegment of rest) {
+            if (typeof pathSegment === "number" && "at" in $entry) {
+              $entry = $entry.at(pathSegment);
+            } else if ("get" in $entry) {
+              $entry = ($entry.get as any)(pathSegment);
+            } else {
+              throw new Error(
+                `'getRaw' path must only relate to input objects right now; path was: '${path}' (failed at '${pathSegment}')`,
+              );
+            }
+          }
+          return $entry;
+        } else {
+          throw new Error(
+            `Invalid path passed to FieldArgs.getRaw(); please check your code. Path: ${inspect(
+              path,
+            )}`,
+          );
         }
-        return $entry;
-      } else {
-        throw new Error(
-          `Invalid path passed to FieldArgs.getRaw(); please check your code. Path: ${inspect(
-            path,
-          )}`,
-        );
-      }
+      });
     },
     getBaked(inPath: string | ReadonlyArray<string | number>) {
-      const path = typeof inPath === "string" ? [inPath] : inPath;
-      const $raw = this.getRaw(path);
-      const inputType = this.typeAt(path);
-      const $baked = bakedInput(inputType, $raw);
-      return $baked;
+      return operationPlan.withRootLayerPlan(() => {
+        const path = typeof inPath === "string" ? [inPath] : inPath;
+        const $raw = this.getRaw(path);
+        const inputType = this.typeAt(path);
+        const $baked = bakedInput(inputType, $raw);
+        return $baked;
+      });
     },
     autoApply($target) {
       if (!autoApplyDisabled) {
@@ -164,53 +168,59 @@ export function withFieldArgsForArguments<T extends Step>(
       }
     },
     apply($target, inPathOrGetTargetFromParent, maybeGetTargetFromParent) {
-      const inPath =
-        typeof inPathOrGetTargetFromParent === "function"
-          ? undefined
-          : inPathOrGetTargetFromParent;
-      const getTargetFromParent =
-        typeof inPathOrGetTargetFromParent === "function"
-          ? inPathOrGetTargetFromParent
-          : maybeGetTargetFromParent;
-      assertNotRuntime(operationPlan, `fieldArgs.apply()`);
-      const path = Array.isArray(inPath) ? inPath : inPath ? [inPath] : [];
-      const pathString = path.join(".");
-      const $existing = applied.get(pathString);
-      if ($existing) {
-        throw new Error(
-          `Attempted to apply 'applyPlan' at input path ${pathString} more than once - first time to ${$existing}, second time to ${$target}. Multiple applications are not currently supported.`,
-        );
-      }
-      if (path.length === 0) {
-        autoApplyDisabled = true;
-        // Auto-apply all the arguments
-        for (const argName of Object.keys(args)) {
-          fieldArgs.apply($target, [argName]);
-        }
-      } else {
-        const [argName, ...rest] = path;
-        if (typeof argName !== "string") {
+      return $target.withLayerPlan(() => {
+        const inPath =
+          typeof inPathOrGetTargetFromParent === "function"
+            ? undefined
+            : inPathOrGetTargetFromParent;
+        const getTargetFromParent =
+          typeof inPathOrGetTargetFromParent === "function"
+            ? inPathOrGetTargetFromParent
+            : maybeGetTargetFromParent;
+        assertNotRuntime(operationPlan, `fieldArgs.apply()`);
+        const path = Array.isArray(inPath) ? inPath : inPath ? [inPath] : [];
+        const pathString = path.join(".");
+        const $existing = applied.get(pathString);
+        if ($existing) {
           throw new Error(
-            `Invalid path; argument '${argName}' is an invalid argument name`,
+            `Attempted to apply 'applyPlan' at input path ${pathString} more than once - first time to ${$existing}, second time to ${$target}. Multiple applications are not currently supported.`,
           );
         }
-        const arg = args[argName];
-        if (!arg) {
-          throw new Error(`Invalid path; argument '${argName}' does not exist`);
-        }
-        const typeAtPath = getNullableInputTypeAtPath(arg.type, rest);
-        const $valueAtPath = fieldArgs.getRaw(inPath as any) as AnyInputStep;
-        if (
-          $valueAtPath instanceof ConstantStep &&
-          $valueAtPath.data === undefined
-        ) {
-          // Skip applying!
+        if (path.length === 0) {
+          autoApplyDisabled = true;
+          // Auto-apply all the arguments
+          for (const argName of Object.keys(args)) {
+            fieldArgs.apply($target, [argName]);
+          }
         } else {
-          $target.apply(
-            applyInput(typeAtPath, $valueAtPath, getTargetFromParent),
-          );
+          const [argName, ...rest] = path;
+          if (typeof argName !== "string") {
+            throw new Error(
+              `Invalid path; argument '${argName}' is an invalid argument name`,
+            );
+          }
+          const arg = args[argName];
+          if (!arg) {
+            throw new Error(
+              `Invalid path; argument '${argName}' does not exist`,
+            );
+          }
+          const typeAtPath = getNullableInputTypeAtPath(arg.type, rest);
+          const $valueAtPath = fieldArgs.getRaw(inPath as any) as AnyInputStep;
+          if (
+            $valueAtPath instanceof ConstantStep &&
+            $valueAtPath.data === undefined
+          ) {
+            // Skip applying!
+          } else {
+            $target.withLayerPlan(() => {
+              $target.apply(
+                applyInput(typeAtPath, $valueAtPath, getTargetFromParent),
+              );
+            });
+          }
         }
-      }
+      });
     },
   };
   for (const argName of Object.keys(args)) {
@@ -285,11 +295,13 @@ function processAfter(
           }
         },
       };
-      const result = autoApply($parent, $result, input, {
-        schema,
-        arg,
-        argName,
-      });
+      const result = $result.withLayerPlan(() =>
+        autoApply($parent, $result, input, {
+          schema,
+          arg,
+          argName,
+        }),
+      );
       if (result !== undefined) {
         const fullCoordinate = `${coordinate}(${argName}:)`;
         throw new Error(

--- a/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
+++ b/postgraphile/postgraphile/__tests__/kitchen-sink-schema.sql
@@ -416,6 +416,8 @@ create function c.table_mutation(id int) returns a.post as $$ select * from a.po
 create function c.table_set_query() returns setof c.person as $$ select * from c.person order by id asc $$ language sql stable;
 create function c.table_set_query_plpgsql() returns setof c.person as $$ begin return query select * from c.person order by id asc; end $$ language plpgsql stable;
 comment on function c.table_set_query() is E'@sortable\n@filterable';
+create function c.table_set_query_volatile() returns setof c.person as $$ select * from c.person order by id asc $$ language sql volatile;
+comment on function c.table_set_query_volatile() is E'@behavior +sort +filter +queryField -mutationField +list +connection';
 create function c.table_set_mutation() returns setof c.person as $$ select * from c.person order by id asc $$ language sql;
 create function c.int_set_query(x int, y int, z int) returns setof integer as $$ values (1), (2), (3), (4), (x), (y), (z) $$ language sql stable;
 create function c.int_set_mutation(x int, y int, z int) returns setof integer as $$ values (1), (2), (3), (4), (x), (y), (z) $$ language sql;

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.json5
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.json5
@@ -1,0 +1,23 @@
+{
+  tableSetQueryVolatile: {
+    edges: [
+      {
+        cursor: "WyJuYXR1cmFsIiwxXQ==",
+        node: {
+          name: "Budd Deey",
+        },
+      },
+    ],
+    pageInfo: {
+      startCursor: "WyJuYXR1cmFsIiwxXQ==",
+      endCursor: "WyJuYXR1cmFsIiwxXQ==",
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+  },
+  tableSetQueryVolatileList: [
+    {
+      name: "Budd Deey",
+    },
+  ],
+}

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.mermaid
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.mermaid
@@ -1,0 +1,88 @@
+%%{init: {'themeVariables': { 'fontSize': '12px'}}}%%
+graph TD
+    classDef path fill:#eee,stroke:#000,color:#000
+    classDef plan fill:#fff,stroke-width:1px,color:#000
+    classDef itemplan fill:#fff,stroke-width:2px,color:#000
+    classDef unbatchedplan fill:#dff,stroke-width:1px,color:#000
+    classDef sideeffectplan fill:#fcc,stroke-width:2px,color:#000
+    classDef bucket fill:#f6f6f6,color:#000,stroke-width:2px,text-align:left
+
+    subgraph "Buckets for queries/v4/procedure-query-volatile"
+    Bucket0("Bucket 0 (root)<br /><br />1: Access[11]<br />2: Access[12]<br />3: Object[13]<br />4: Constantᐸ2ᐳ[43]<br />5: Constantᐸundefinedᐳ[7]<br />6: Constantᐸ'Budd Deey'ᐳ[44]<br />7: __InputObject[8]<br />8: ApplyInput[15]<br />9: PgSelect[10]<br />10: __InputObject[16]<br />11: ApplyInput[21]<br />12: PgSelect[17]<br />13: Connection[14], PgSelectRows[22]<br />ᐳ: Access[33], Access[39]<br />14: ConnectionItems[25]<br />ᐳ: 32, 34, 35, 36"):::bucket
+    Bucket1("Bucket 1 (nullableBoundary)<br />Deps: 14, 10, 39, 25, 34, 36<br /><br />ROOT Connectionᐸ10ᐳ[14]"):::bucket
+    Bucket2("Bucket 2 (listItem)<br />Deps: 17<br /><br />ROOT __Item{2}ᐸ22ᐳ[23]"):::bucket
+    Bucket3("Bucket 3 (nullableBoundary)<br />Deps: 24<br /><br />ROOT PgSelectSingle{2}ᐸtable_set_query_volatileᐳ[24]"):::bucket
+    Bucket5("Bucket 5 (listItem)<br />Deps: 39<br /><br />ROOT __Item{5}ᐸ25ᐳ[29]"):::bucket
+    Bucket6("Bucket 6 (nullableBoundary)<br />Deps: 29, 30, 40<br /><br />ROOT Edge{5}[30]"):::bucket
+    Bucket7("Bucket 7 (nullableBoundary)<br />Deps: 41<br /><br />ROOT PgSelectSingle{6}ᐸtable_set_query_volatileᐳ[41]"):::bucket
+    end
+    Bucket0 --> Bucket1 & Bucket2
+    Bucket1 --> Bucket5
+    Bucket2 --> Bucket3
+    Bucket5 --> Bucket6
+    Bucket6 --> Bucket7
+
+    %% plan dependencies
+    PgSelect10[["PgSelect[10∈0] ➊<br />ᐸtable_set_query_volatile+1(mutation)ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[43]"]]:::sideeffectplan
+    Object13{{"Object[13∈0] ➊<br />ᐸ{pgSettings,withPgClient}ᐳ"}}:::plan
+    ApplyInput15{{"ApplyInput[15∈0] ➊"}}:::plan
+    Object13 & ApplyInput15 --> PgSelect10
+    PgSelect17[["PgSelect[17∈0] ➊<br />ᐸtable_set_query_volatile(mutation)ᐳ<br />More deps:<br />- Constantᐸ2ᐳ[43]"]]:::sideeffectplan
+    ApplyInput21{{"ApplyInput[21∈0] ➊"}}:::plan
+    Object13 & ApplyInput21 --> PgSelect17
+    __InputObject8{{"__InputObject[8∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[7]<br />- Constantᐸ'Budd Deey'ᐳ[44]"}}:::plan
+    Access11{{"Access[11∈0] ➊<br />ᐸ2.pgSettingsᐳ"}}:::plan
+    Access12{{"Access[12∈0] ➊<br />ᐸ2.withPgClientᐳ"}}:::plan
+    Access11 & Access12 --> Object13
+    Connection14[["Connection[14∈0] ➊<br />ᐸ10ᐳ<br />Dependents: 4<br />More deps:<br />- Constantᐸ2ᐳ[43]"]]:::plan
+    PgSelect10 --> Connection14
+    __InputObject16{{"__InputObject[16∈0] ➊<br />More deps:<br />- Constantᐸundefinedᐳ[7]<br />- Constantᐸ'Budd Deey'ᐳ[44]"}}:::plan
+    __Value2["__Value[2∈0] ➊<br />ᐸcontextᐳ"]:::plan
+    __Value2 --> Access11
+    __Value2 --> Access12
+    __InputObject8 --> ApplyInput15
+    __InputObject16 --> ApplyInput21
+    PgSelectRows22[["PgSelectRows[22∈0] ➊"]]:::plan
+    PgSelect17 --> PgSelectRows22
+    ConnectionItems25[["ConnectionItems[25∈0] ➊<br />Dependents: 3<br />More deps:<br />- Connection[14]"]]:::plan
+    First32{{"First[32∈0] ➊<br />More deps:<br />- ConnectionItems[25]"}}:::plan
+    Access33{{"Access[33∈0] ➊<br />ᐸ10.cursorDetailsᐳ"}}:::plan
+    PgSelect10 --> Access33
+    Last35{{"Last[35∈0] ➊<br />More deps:<br />- ConnectionItems[25]"}}:::plan
+    Access39{{"Access[39∈0] ➊<br />ᐸ10.cursorDetailsᐳ"}}:::plan
+    PgSelect10 --> Access39
+    PageInfo28{{"PageInfo[28∈1] ➊<br />More deps:<br />- Connection[14]"}}:::plan
+    Access37{{"Access[37∈1] ➊<br />ᐸ14.hasNextPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    Access38{{"Access[38∈1] ➊<br />ᐸ14.hasPreviousPageᐳ<br />More deps:<br />- Connection[14]"}}:::plan
+    __Item23[/"__Item[23∈2]<br />ᐸ22ᐳ"\]:::itemplan
+    PgSelectRows22 ==> __Item23
+    PgSelectSingle24{{"PgSelectSingle[24∈2]<br />ᐸtable_set_query_volatileᐳ"}}:::plan
+    __Item23 --> PgSelectSingle24
+    PgClassExpression31{{"PgClassExpression[31∈3]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
+    PgSelectSingle24 --> PgClassExpression31
+    Edge30{{"Edge[30∈5]"}}:::plan
+    __Item29[/"__Item[29∈5]<br />ᐸ25ᐳ<br />More deps:<br />- ConnectionItems[25]"\]:::itemplan
+    PgCursor40{{"PgCursor[40∈5]"}}:::plan
+    __Item29 & PgCursor40 --> Edge30
+    __Item29 & Access39 --> PgCursor40
+    PgSelectSingle41{{"PgSelectSingle[41∈6]<br />ᐸtable_set_query_volatileᐳ"}}:::plan
+    __Item29 --> PgSelectSingle41
+    PgClassExpression42{{"PgClassExpression[42∈7]<br />ᐸ__table_se...full_name”ᐳ"}}:::plan
+    PgSelectSingle41 --> PgClassExpression42
+
+    %% define steps
+    classDef bucket0 stroke:#696969
+    class Bucket0,__Value2,__InputObject8,PgSelect10,Access11,Access12,Object13,Connection14,ApplyInput15,__InputObject16,PgSelect17,ApplyInput21,PgSelectRows22,ConnectionItems25,First32,Access33,Last35,Access39 bucket0
+    classDef bucket1 stroke:#00bfff
+    class Bucket1,PageInfo28,Access37,Access38 bucket1
+    classDef bucket2 stroke:#7f007f
+    class Bucket2,__Item23,PgSelectSingle24 bucket2
+    classDef bucket3 stroke:#ffa500
+    class Bucket3,PgClassExpression31 bucket3
+    classDef bucket5 stroke:#7fff00
+    class Bucket5,__Item29,Edge30,PgCursor40 bucket5
+    classDef bucket6 stroke:#ff1493
+    class Bucket6,PgSelectSingle41 bucket6
+    classDef bucket7 stroke:#808000
+    class Bucket7,PgClassExpression42 bucket7
+

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.sql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.sql
@@ -1,0 +1,16 @@
+select
+  __table_set_query_volatile__."person_full_name" as "0",
+  (row_number() over (partition by 1))::text as "1"
+from "c"."table_set_query_volatile"() as __table_set_query_volatile__
+where (
+  __table_set_query_volatile__."person_full_name" = $1::"varchar"
+)
+limit 3;
+
+select
+  __table_set_query_volatile__."person_full_name" as "0"
+from "c"."table_set_query_volatile"() as __table_set_query_volatile__
+where (
+  __table_set_query_volatile__."person_full_name" = $1::"varchar"
+)
+limit 2;

--- a/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.test.graphql
+++ b/postgraphile/postgraphile/__tests__/queries/v4/procedure-query-volatile.test.graphql
@@ -1,0 +1,22 @@
+## expect(errors).toBeFalsy();
+#> schema: ["a", "b", "c"]
+#> subscriptions: true
+query {
+  tableSetQueryVolatile(first: 2, condition: { name: "Budd Deey" }) {
+    edges {
+      cursor
+      node {
+        name
+      }
+    }
+    pageInfo {
+      startCursor
+      endCursor
+      hasNextPage
+      hasPreviousPage
+    }
+  }
+  tableSetQueryVolatileList(first: 2, condition: { name: "Budd Deey" }) {
+    name
+  }
+}

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions-minified.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions-minified.1.export.mjs
@@ -1713,6 +1713,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -4561,6 +4562,18 @@ const registry = makeRegistry({
       extensions: {},
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {},
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -5325,6 +5338,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -7017,6 +7035,8 @@ export const typeDefs = /* GraphQL */`type Query implements Node {
   funcOutTableSetof(first: Int, last: Int, offset: Int, before: Cursor, after: Cursor): PeopleConnection
   tableSetQuery(first: Int, last: Int, offset: Int, before: Cursor, after: Cursor, condition: PersonCondition, orderBy: [PeopleOrderBy!]): PeopleConnection
   tableSetQueryPlpgsql(first: Int, last: Int, offset: Int, before: Cursor, after: Cursor): PeopleConnection
+  tableSetQueryVolatile(first: Int, last: Int, offset: Int, before: Cursor, after: Cursor, condition: PersonCondition): PeopleConnection
+  tableSetQueryVolatileList(first: Int, offset: Int, condition: PersonCondition): [Person]
   typeFunctionConnection(first: Int, last: Int, offset: Int, before: Cursor, after: Cursor): TypesConnection
   typeFunction(id: Int): Type
   typeFunctionList: [Type]
@@ -11791,6 +11811,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions-minified.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions-minified.1.graphql
@@ -2787,6 +2787,8 @@ type Query implements Node {
   tableQuery(id: Int): Post
   tableSetQuery(after: Cursor, before: Cursor, condition: PersonCondition, first: Int, last: Int, offset: Int, orderBy: [PeopleOrderBy!]): PeopleConnection
   tableSetQueryPlpgsql(after: Cursor, before: Cursor, first: Int, last: Int, offset: Int): PeopleConnection
+  tableSetQueryVolatile(after: Cursor, before: Cursor, condition: PersonCondition, first: Int, last: Int, offset: Int): PeopleConnection
+  tableSetQueryVolatileList(condition: PersonCondition, first: Int, offset: Int): [Person]
   type(nodeId: ID!): Type
   typeById(id: Int!): Type
   typeFunction(id: Int): Type

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6396,6 +6397,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7253,6 +7275,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9337,6 +9364,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20282,6 +20347,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.1.graphql
@@ -7967,6 +7967,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6396,6 +6397,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7253,6 +7275,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9337,6 +9364,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20282,6 +20347,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/defaultOptions.subscriptions.1.graphql
@@ -7967,6 +7967,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.export.mjs
@@ -1714,6 +1714,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
@@ -4001,6 +4002,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -4480,6 +4502,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const makeTableNodeIdHandler = ({
   typeName,
@@ -5674,6 +5701,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads a single \`MyTable\` using its globally unique \`ID\`."""
   myTable(
@@ -10381,6 +10446,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       typesQuery($root, args, _info) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-autofix.1.graphql
@@ -3937,6 +3937,44 @@ type Query implements Node {
     """
     offset: Int
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.export.mjs
@@ -1708,6 +1708,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
@@ -3995,6 +3996,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -4474,6 +4496,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const makeTableNodeIdHandler = ({
   typeName,
@@ -5671,6 +5698,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads a single \`MyTable\` using its globally unique \`ID\`."""
   myTable(
@@ -10426,6 +10491,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       typesQuery($root, args, _info) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/foreignKey-smart-tag-good.1.graphql
@@ -3967,6 +3967,44 @@ type Query implements Node {
     """
     offset: Int
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.export.mjs
@@ -2441,6 +2441,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6426,6 +6427,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7283,6 +7305,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9375,6 +9402,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20314,6 +20379,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash-with-tags-file-workaround.1.graphql
@@ -7961,6 +7961,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.export.mjs
@@ -2432,6 +2432,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6417,6 +6418,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7274,6 +7296,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9359,6 +9386,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20304,6 +20369,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/function-clash.1.graphql
@@ -7967,6 +7967,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.export.mjs
@@ -2942,6 +2942,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6955,6 +6956,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7820,6 +7842,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9864,6 +9891,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20296,6 +20361,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/indexes.1.graphql
@@ -7713,6 +7713,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-builtin-lowercase.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-builtin-lowercase.1.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6396,6 +6397,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7253,6 +7275,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9342,6 +9369,44 @@ type query implements node {
     """Read all values in the set after (below) this cursor."""
     after: cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20287,6 +20352,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-builtin-lowercase.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-builtin-lowercase.1.graphql
@@ -10457,6 +10457,44 @@ type query implements node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6396,6 +6397,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7253,6 +7275,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9342,6 +9369,44 @@ type Q implements N {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20287,6 +20352,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/inflect-core.1.graphql
@@ -7972,6 +7972,44 @@ type Q implements N {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.export.mjs
@@ -1704,6 +1704,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
@@ -3991,6 +3992,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -4456,6 +4478,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const makeTableNodeIdHandler = ({
   typeName,
@@ -5512,6 +5539,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person!]
 
   """Reads a single \`MyTable\` using its globally unique \`ID\`."""
   myTable(
@@ -8608,6 +8673,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       typesQuery($root, args, _info) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/noDefaultMutations.1.graphql
@@ -2772,6 +2772,44 @@ type Query implements Node {
     """
     offset: Int
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person!]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/pgStrictFunctions.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pgStrictFunctions.1.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6494,6 +6495,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7359,6 +7381,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9443,6 +9470,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20388,6 +20453,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/pgStrictFunctions.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/pgStrictFunctions.1.graphql
@@ -7967,6 +7967,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.export.mjs
@@ -3254,6 +3254,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const types_resourceOptionsConfig = {
@@ -7456,6 +7457,28 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        },
+        canExecute: false
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7910,6 +7933,33 @@ const EMPTY_ARRAY = Object.freeze([]);
 const makeArgs_current_user_id = () => EMPTY_ARRAY;
 const resource_current_user_idPgResource = registry.pgResources["current_user_id"];
 const resource_return_table_without_grantsPgResource = registry.pgResources["return_table_without_grants"];
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_current_user_id(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
+};
+function applyFirstArg(_, $connection, arg) {
+  $connection.setFirst(arg.getRaw());
+}
+function applyLastArg(_, $connection, val) {
+  $connection.setLast(val.getRaw());
+}
+function applyOffsetArg(_, $connection, val) {
+  $connection.setOffset(val.getRaw());
+}
+function applyBeforeArg(_, $connection, val) {
+  $connection.setBefore(val.getRaw());
+}
+function applyAfterArg(_, $connection, val) {
+  $connection.setAfter(val.getRaw());
+}
+function qbWhereBuilder(qb) {
+  return qb.whereBuilder();
+}
+const applyConditionArgToConnection = (_condition, $connection, arg) => {
+  const $select = $connection.getSubplan();
+  arg.apply($select, qbWhereBuilder);
+};
 const makeTableNodeIdHandler = ({
   typeName,
   nodeIdCodec,
@@ -8010,28 +8060,6 @@ const nodeIdHandler_Person = makeTableNodeIdHandler({
 const nodeFetcher_Person = $nodeId => {
   const $decoded = lambda($nodeId, specForHandler(nodeIdHandler_Person));
   return nodeIdHandler_Person.get(nodeIdHandler_Person.getSpec($decoded));
-};
-function applyFirstArg(_, $connection, arg) {
-  $connection.setFirst(arg.getRaw());
-}
-function applyLastArg(_, $connection, val) {
-  $connection.setLast(val.getRaw());
-}
-function applyOffsetArg(_, $connection, val) {
-  $connection.setOffset(val.getRaw());
-}
-function applyBeforeArg(_, $connection, val) {
-  $connection.setBefore(val.getRaw());
-}
-function applyAfterArg(_, $connection, val) {
-  $connection.setAfter(val.getRaw());
-}
-function qbWhereBuilder(qb) {
-  return qb.whereBuilder();
-}
-const applyConditionArgToConnection = (_condition, $connection, arg) => {
-  const $select = $connection.getSubplan();
-  arg.apply($select, qbWhereBuilder);
 };
 function applyOrderByArgToConnection(parent, $connection, value) {
   const $select = $connection.getSubplan();
@@ -8157,6 +8185,7 @@ const PostsOrderBy_ID_DESCApply = queryBuilder => {
   queryBuilder.setOrderIsUnique();
 };
 const resource_compound_keyPgResource = registry.pgResources["compound_key"];
+const pgFieldSource_person_computed_outPgResource = registry.pgResources["person_computed_out"];
 const PersonSecretCondition_personIdApply = ($condition, val) => applyAttributeCondition("person_id", TYPES.int, $condition, val);
 const PersonSecretsOrderBy_PERSON_ID_ASCApply = queryBuilder => {
   queryBuilder.orderBy({
@@ -8172,7 +8201,6 @@ const PersonSecretsOrderBy_PERSON_ID_DESCApply = queryBuilder => {
   });
   queryBuilder.setOrderIsUnique();
 };
-const pgFieldSource_person_computed_outPgResource = registry.pgResources["person_computed_out"];
 const pgFieldSource_person_first_namePgResource = registry.pgResources["person_first_name"];
 const argDetailsSimple_left_arm_identity = [{
   graphqlArgName: "leftArm",
@@ -8333,6 +8361,44 @@ type Query implements Node {
   personByEmail(email: Email!): Person
   currentUserId: Int
   returnTableWithoutGrants: CompoundKey
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads a single \`PersonSecret\` using its globally unique \`ID\`."""
   personSecret(
@@ -8705,6 +8771,78 @@ type CompoundKey {
   personByPersonId2: Person
 }
 
+"""A connection to a list of \`Person\` values."""
+type PeopleConnection {
+  """A list of \`Person\` objects."""
+  nodes: [Person]!
+
+  """
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  """
+  edges: [PeopleEdge]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Person\` edge in the connection."""
+type PeopleEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person
+}
+
+"""
+A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input PersonCondition {
+  """Checks for equality with the object’s \`id\` field."""
+  id: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`aliases\` field."""
+  aliases: [String]
+
+  """Checks for equality with the object’s \`about\` field."""
+  about: String
+
+  """Checks for equality with the object’s \`email\` field."""
+  email: Email
+
+  """Checks for equality with the object’s \`site\` field."""
+  site: WrappedUrlInput
+
+  """Checks for equality with the object’s \`config\` field."""
+  config: KeyValueHash
+
+  """Checks for equality with the object’s \`lastLoginFromIp\` field."""
+  lastLoginFromIp: InternetAddress
+
+  """Checks for equality with the object’s \`lastLoginFromSubnet\` field."""
+  lastLoginFromSubnet: String
+
+  """Checks for equality with the object’s \`userMac\` field."""
+  userMac: String
+
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+
+  """Checks for equality with the object’s \`computedOut\` field."""
+  computedOut: String
+}
+
+"""An input for mutations affecting \`WrappedUrl\`"""
+input WrappedUrlInput {
+  url: NotNullUrl!
+}
+
 """A connection to a list of \`PersonSecret\` values."""
 type PersonSecretsConnection {
   """A list of \`PersonSecret\` objects."""
@@ -8810,78 +8948,6 @@ enum LeftArmsOrderBy {
   LENGTH_IN_METRES_DESC
   MOOD_ASC
   MOOD_DESC
-}
-
-"""A connection to a list of \`Person\` values."""
-type PeopleConnection {
-  """A list of \`Person\` objects."""
-  nodes: [Person]!
-
-  """
-  A list of edges which contains the \`Person\` and cursor to aid in pagination.
-  """
-  edges: [PeopleEdge]!
-
-  """Information to aid in pagination."""
-  pageInfo: PageInfo!
-
-  """The count of *all* \`Person\` you could get from the connection."""
-  totalCount: Int!
-}
-
-"""A \`Person\` edge in the connection."""
-type PeopleEdge {
-  """A cursor for use in pagination."""
-  cursor: Cursor
-
-  """The \`Person\` at the end of the edge."""
-  node: Person
-}
-
-"""
-A condition to be used against \`Person\` object types. All fields are tested for equality and combined with a logical ‘and.’
-"""
-input PersonCondition {
-  """Checks for equality with the object’s \`id\` field."""
-  id: Int
-
-  """Checks for equality with the object’s \`name\` field."""
-  name: String
-
-  """Checks for equality with the object’s \`aliases\` field."""
-  aliases: [String]
-
-  """Checks for equality with the object’s \`about\` field."""
-  about: String
-
-  """Checks for equality with the object’s \`email\` field."""
-  email: Email
-
-  """Checks for equality with the object’s \`site\` field."""
-  site: WrappedUrlInput
-
-  """Checks for equality with the object’s \`config\` field."""
-  config: KeyValueHash
-
-  """Checks for equality with the object’s \`lastLoginFromIp\` field."""
-  lastLoginFromIp: InternetAddress
-
-  """Checks for equality with the object’s \`lastLoginFromSubnet\` field."""
-  lastLoginFromSubnet: String
-
-  """Checks for equality with the object’s \`userMac\` field."""
-  userMac: String
-
-  """Checks for equality with the object’s \`createdAt\` field."""
-  createdAt: Datetime
-
-  """Checks for equality with the object’s \`computedOut\` field."""
-  computedOut: String
-}
-
-"""An input for mutations affecting \`WrappedUrl\`"""
-input WrappedUrlInput {
-  url: NotNullUrl!
 }
 
 """Methods to use when ordering \`Person\`."""
@@ -9713,6 +9779,30 @@ export const objects = {
       returnTableWithoutGrants($root, args, _info) {
         const selectArgs = makeArgs_current_user_id(args);
         return resource_return_table_without_grantsPgResource.execute(selectArgs);
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
+        }
       }
     }
   },

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.1.graphql
@@ -1124,6 +1124,44 @@ type Query implements Node {
   """
   query: Query!
   returnTableWithoutGrants: CompoundKey
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
 }
 
 """All input for the `updateLeftArmById` mutation."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6396,6 +6397,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7253,6 +7275,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9337,6 +9364,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20282,6 +20347,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.ignore.1.graphql
@@ -7967,6 +7967,44 @@ type Query implements Node {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Reads a single `Type` using its globally unique `ID`."""
   type(
     """The globally unique `ID` to be used in selecting a single `Type`."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.export.mjs
@@ -1704,6 +1704,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
@@ -3991,6 +3992,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -4456,6 +4478,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const makeTableNodeIdHandler = ({
   typeName,
@@ -5650,6 +5677,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person!]
 
   """Reads a single \`MyTable\` using its globally unique \`ID\`."""
   myTable(
@@ -10316,6 +10381,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       typesQuery($root, args, _info) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/relay1.1.graphql
@@ -3895,6 +3895,44 @@ type Query implements Node {
     """
     offset: Int
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person!]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.export.mjs
@@ -1704,6 +1704,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
@@ -3991,6 +3992,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -4462,6 +4484,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const makeTableNodeIdHandler = ({
   typeName,
@@ -5750,6 +5777,44 @@ type Query implements Node {
 
     """Skip the first \`n\` values."""
     offset: Int
+  ): [Person!]
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
   ): [Person!]
 
   """Reads a single \`MyTable\` using its globally unique \`ID\`."""
@@ -10771,6 +10836,28 @@ export const objects = {
         args: {
           first: applyFirstArg,
           offset: applyOffsetArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition: applyConditionArg
         }
       },
       typesQuery($root, args, _info) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.1.graphql
@@ -4182,6 +4182,44 @@ type Query implements Node {
     """Skip the first `n` values."""
     offset: Int
   ): [Person!]
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person!]
   typesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 }
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.export.mjs
@@ -1,5 +1,5 @@
 import { LIST_TYPES, PgExecutor, PgResource, PgSelectSingleStep, PgSelectStep, TYPES, assertPgClassSingleStep, domainOfCodec, enumCodec, listOfCodec, makeRegistry, pgClassExpression, pgDeleteSingle, pgFromExpression, pgInsertSingle, pgSelectFromRecords, pgSelectSingleFromRecord, pgUpdateSingle, rangeOfCodec, recordCodec, sqlFromArgDigests, sqlValueWithCodec } from "@dataplan/pg";
-import { ObjectStep, __ValueStep, access, assertStep, bakedInput, bakedInputRuntime, constant, context, createObjectAndApplyChildren, get as get2, inhibitOnNull, inspect, lambda, list, makeDecodeNodeId, makeGrafastSchema, markSyncAndSafe, object, operationPlan, rootValue, specFromNodeId, stepAMayDependOnStepB, trap } from "grafast";
+import { ConnectionStep, ObjectStep, __ValueStep, access, assertStep, bakedInput, bakedInputRuntime, connection, constant, context, createObjectAndApplyChildren, get as get2, inhibitOnNull, inspect, lambda, list, makeDecodeNodeId, makeGrafastSchema, markSyncAndSafe, object, operationPlan, rootValue, specFromNodeId, stepAMayDependOnStepB, trap } from "grafast";
 import { GraphQLError, GraphQLInt, GraphQLString, Kind, valueFromASTUntyped } from "graphql";
 import { sql } from "pg-sql2";
 const rawNodeIdCodec = {
@@ -1704,6 +1704,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const person_type_function_connectionFunctionIdentifer = sql.identifier("c", "person_type_function_connection");
@@ -3991,6 +3992,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -4402,6 +4424,11 @@ function applyOrderByArg(parent, $select, value) {
   value.apply($select);
 }
 const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_set_query_plpgsql"];
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
+};
 const makeTableNodeIdHandler = ({
   typeName,
   nodeIdCodec,
@@ -5399,6 +5426,44 @@ type Query implements Node {
     offset: Int
   ): [Person!]
 
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person!]
+
   """Reads a single \`MyTable\` using its globally unique \`ID\`."""
   myTable(
     """The globally unique \`ID\` to be used in selecting a single \`MyTable\`."""
@@ -6282,6 +6347,50 @@ input PersonCondition {
 """An input for mutations affecting \`WrappedUrl\`"""
 input WrappedUrlInput {
   url: NotNullUrl!
+}
+
+"""A connection to a list of \`Person\` values."""
+type PeopleConnection {
+  """A list of \`Person\` objects."""
+  nodes: [Person!]!
+
+  """
+  A list of edges which contains the \`Person\` and cursor to aid in pagination.
+  """
+  edges: [PeopleEdge!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* \`Person\` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A \`Person\` edge in the connection."""
+type PeopleEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The \`Person\` at the end of the edge."""
+  node: Person!
+}
+
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
 }
 
 """
@@ -9277,6 +9386,37 @@ export const objects = {
           offset: applyOffsetArg
         }
       },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last(_, $connection, val) {
+            $connection.setLast(val.getRaw());
+          },
+          offset: applyOffsetArg,
+          before(_, $connection, val) {
+            $connection.setBefore(val.getRaw());
+          },
+          after(_, $connection, val) {
+            $connection.setAfter(val.getRaw());
+          },
+          condition(_condition, $connection, arg) {
+            const $select = $connection.getSubplan();
+            arg.apply($select, qbWhereBuilder);
+          }
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition: applyConditionArg
+        }
+      },
       typesQuery($root, args, _info) {
         const selectArgs = makeArgs_types_query(args);
         return resource_types_queryPgResource.execute(selectArgs);
@@ -10792,6 +10932,14 @@ export const objects = {
       return resource_null_test_recordPgResource.get(spec);
     }
   },
+  PeopleConnection: {
+    assertStep: ConnectionStep,
+    plans: {
+      totalCount($connection) {
+        return $connection.cloneSubplanWithoutPagination("aggregate").singleAsRecord().select(sql`count(*)`, TYPES.bigint, false);
+      }
+    }
+  },
   Person: {
     assertStep: assertPgClassSingleStep,
     plans: {
@@ -11922,6 +12070,16 @@ export const scalars = {
         return ast.value;
       }
       throw new GraphQLError(`BigInt can only parse string values (kind='${ast.kind}')`);
+    }
+  },
+  Cursor: {
+    serialize: toString,
+    parseValue: toString,
+    parseLiteral(ast) {
+      if (ast.kind === Kind.STRING) {
+        return ast.value;
+      }
+      throw new GraphQLError(`Cursor can only parse string values (kind='${ast.kind}')`);
     }
   },
   Date: {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simple-collections.only.1.graphql
@@ -420,6 +420,9 @@ type CreatePersonSecretPayload {
   query: Query
 }
 
+"""A location in a connection that can be used for resuming pagination."""
+scalar Cursor
+
 """A calendar date in YYYY-MM-DD format."""
 scalar Date
 
@@ -2422,6 +2425,47 @@ enum NullTestRecordsOrderBy {
   PRIMARY_KEY_DESC
 }
 
+"""Information about pagination in a connection."""
+type PageInfo {
+  """When paginating forwards, the cursor to continue."""
+  endCursor: Cursor
+
+  """When paginating forwards, are there more items?"""
+  hasNextPage: Boolean!
+
+  """When paginating backwards, are there more items?"""
+  hasPreviousPage: Boolean!
+
+  """When paginating backwards, the cursor to continue."""
+  startCursor: Cursor
+}
+
+"""A connection to a list of `Person` values."""
+type PeopleConnection {
+  """
+  A list of edges which contains the `Person` and cursor to aid in pagination.
+  """
+  edges: [PeopleEdge!]!
+
+  """A list of `Person` objects."""
+  nodes: [Person!]!
+
+  """Information to aid in pagination."""
+  pageInfo: PageInfo!
+
+  """The count of *all* `Person` you could get from the connection."""
+  totalCount: Int!
+}
+
+"""A `Person` edge in the connection."""
+type PeopleEdge {
+  """A cursor for use in pagination."""
+  cursor: Cursor
+
+  """The `Person` at the end of the edge."""
+  node: Person!
+}
+
 """Methods to use when ordering `Person`."""
 enum PeopleOrderBy {
   ABOUT_ASC
@@ -3071,6 +3115,44 @@ type Query implements Node {
     orderBy: [PeopleOrderBy!]
   ): [Person!]
   tableSetQueryPlpgsqlList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person!]
+
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
     """Only read the first `n` values of the set."""
     first: Int
 

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.export.mjs
@@ -2431,6 +2431,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6396,6 +6397,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7253,6 +7275,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -9337,6 +9364,44 @@ type Query implements Node {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -20282,6 +20347,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       type(_$parent, args) {

--- a/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/simplePrint.graphql
@@ -431,6 +431,44 @@ type Query implements Node {
     after: Cursor
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
+
   """Reads and enables pagination through a set of `Type`."""
   typeFunctionConnection(
     """Only read the first `n` values of the set."""

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.export.mjs
@@ -2380,6 +2380,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const listsUniques = [{
@@ -6345,6 +6346,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    table_set_query_volatile: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
+      name: "table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     person_computed_first_arg_inout: PgResource.functionResourceOptions(person_resourceOptionsConfig, {
       name: "person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7202,6 +7224,11 @@ const resource_table_set_query_plpgsqlPgResource = registry.pgResources["table_s
 const table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_person_computed_out(args);
   return resource_table_set_query_plpgsqlPgResource.execute(selectArgs);
+};
+const resource_table_set_query_volatilePgResource = registry.pgResources["table_set_query_volatile"];
+const table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_person_computed_out(args);
+  return resource_table_set_query_volatilePgResource.execute(selectArgs);
 };
 const resource_type_function_connectionPgResource = registry.pgResources["type_function_connection"];
 const type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
@@ -8899,6 +8926,44 @@ type Query {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): PeopleConnection
+
+  """Reads and enables pagination through a set of \`Person\`."""
+  tableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Only read the last \`n\` values of the set."""
+    last: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+  ): [Person]
 
   """Reads and enables pagination through a set of \`Type\`."""
   typeFunctionConnection(
@@ -18589,6 +18654,30 @@ export const objects = {
           offset: applyOffsetArg,
           before: applyBeforeArg,
           after: applyAfterArg
+        }
+      },
+      tableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          last: applyLastArg,
+          offset: applyOffsetArg,
+          before: applyBeforeArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      tableSetQueryVolatileList: {
+        plan: table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       typeById(_$root, {

--- a/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v4/skipNodePlugin.1.graphql
@@ -7165,6 +7165,44 @@ type Query {
     offset: Int
   ): PeopleConnection
 
+  """Reads and enables pagination through a set of `Person`."""
+  tableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """Read all values in the set before (above) this cursor."""
+    before: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Only read the last `n` values of the set."""
+    last: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): PeopleConnection
+  tableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: PersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [Person]
+
   """Get a single `Type`."""
   typeById(id: Int!): Type
   typeFunction(id: Int): Type

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.export.mjs
@@ -2368,6 +2368,7 @@ const mutation_out_table_setofFunctionIdentifer = sql.identifier("c", "mutation_
 const table_set_mutationFunctionIdentifer = sql.identifier("c", "table_set_mutation");
 const table_set_queryFunctionIdentifer = sql.identifier("c", "table_set_query");
 const table_set_query_plpgsqlFunctionIdentifer = sql.identifier("c", "table_set_query_plpgsql");
+const table_set_query_volatileFunctionIdentifer = sql.identifier("c", "table_set_query_volatile");
 const person_computed_first_arg_inoutFunctionIdentifer = sql.identifier("c", "person_computed_first_arg_inout");
 const person_friendsFunctionIdentifer = sql.identifier("c", "person_friends");
 const b_listsUniques = [{
@@ -6323,6 +6324,27 @@ const registry = makeRegistry({
       },
       hasImplicitOrder: true
     }),
+    c_table_set_query_volatile: PgResource.functionResourceOptions(c_person_resourceOptionsConfig, {
+      name: "c_table_set_query_volatile",
+      identifier: "main.c.table_set_query_volatile()",
+      from(...args) {
+        return sql`${table_set_query_volatileFunctionIdentifer}(${sqlFromArgDigests(args)})`;
+      },
+      parameters: [],
+      returnsSetof: true,
+      extensions: {
+        pg: {
+          serviceName: "main",
+          schemaName: "c",
+          name: "table_set_query_volatile"
+        },
+        tags: {
+          behavior: "+sort +filter +queryField -mutationField +list +connection"
+        }
+      },
+      isMutation: true,
+      hasImplicitOrder: true
+    }),
     c_person_computed_first_arg_inout: PgResource.functionResourceOptions(c_person_resourceOptionsConfig, {
       name: "c_person_computed_first_arg_inout",
       identifier: "main.c.person_computed_first_arg_inout(c.person)",
@@ -7174,6 +7196,18 @@ const c_table_set_query_plpgsql_getSelectPlanFromParentAndArgs = ($root, args, _
   const selectArgs = makeArgs_c_person_computed_out(args);
   return resource_c_table_set_query_plpgsqlPgResource.execute(selectArgs);
 };
+const resource_c_table_set_query_volatilePgResource = registry.pgResources["c_table_set_query_volatile"];
+const c_table_set_query_volatile_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
+  const selectArgs = makeArgs_c_person_computed_out(args);
+  return resource_c_table_set_query_volatilePgResource.execute(selectArgs);
+};
+function qbWhereBuilder(qb) {
+  return qb.whereBuilder();
+}
+const applyConditionArgToConnection = (_condition, $connection, arg) => {
+  const $select = $connection.getSubplan();
+  arg.apply($select, qbWhereBuilder);
+};
 const resource_b_type_function_connectionPgResource = registry.pgResources["b_type_function_connection"];
 const b_type_function_connection_getSelectPlanFromParentAndArgs = ($root, args, _info) => {
   const selectArgs = makeArgs_c_person_computed_out(args);
@@ -7194,13 +7228,6 @@ function applyLastArg(_, $connection, val) {
 function applyBeforeArg(_, $connection, val) {
   $connection.setBefore(val.getRaw());
 }
-function qbWhereBuilder(qb) {
-  return qb.whereBuilder();
-}
-const applyConditionArgToConnection = (_condition, $connection, arg) => {
-  const $select = $connection.getSubplan();
-  arg.apply($select, qbWhereBuilder);
-};
 function applyOrderByArgToConnection(parent, $connection, value) {
   const $select = $connection.getSubplan();
   value.apply($select);
@@ -8796,6 +8823,38 @@ type Query {
     """Read all values in the set after (below) this cursor."""
     after: Cursor
   ): CPersonConnection
+
+  """Reads and enables pagination through a set of \`CPerson\`."""
+  cTableSetQueryVolatile(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """
+    Skip the first \`n\` values from our \`after\` cursor, an alternative to cursor
+    based pagination. May not be used with \`last\`.
+    """
+    offset: Int
+
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CPersonCondition
+  ): CPersonConnection
+  cTableSetQueryVolatileList(
+    """Only read the first \`n\` values of the set."""
+    first: Int
+
+    """Skip the first \`n\` values."""
+    offset: Int
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CPersonCondition
+  ): [CPerson]
 
   """Reads and enables pagination through a set of \`BType\`."""
   bTypeFunctionConnection(
@@ -11144,6 +11203,35 @@ type CFuncOutComplexSetofEdge {
   node: CFuncOutComplexSetofRecord
 }
 
+"""
+A condition to be used against \`CPerson\` object types. All fields are tested for equality and combined with a logical ‘and.’
+"""
+input CPersonCondition {
+  """Checks for equality with the object’s \`rowId\` field."""
+  rowId: Int
+
+  """Checks for equality with the object’s \`name\` field."""
+  name: String
+
+  """Checks for equality with the object’s \`about\` field."""
+  about: String
+
+  """Checks for equality with the object’s \`email\` field."""
+  email: BEmail
+
+  """Checks for equality with the object’s \`lastLoginFromIp\` field."""
+  lastLoginFromIp: InternetAddress
+
+  """Checks for equality with the object’s \`lastLoginFromSubnet\` field."""
+  lastLoginFromSubnet: CidrAddress
+
+  """Checks for equality with the object’s \`userMac\` field."""
+  userMac: MacAddress
+
+  """Checks for equality with the object’s \`createdAt\` field."""
+  createdAt: Datetime
+}
+
 """A connection to a list of \`NonUpdatableView\` values."""
 type NonUpdatableViewConnection {
   """A list of \`NonUpdatableView\` objects."""
@@ -12175,35 +12263,6 @@ enum CIssue756OrderBy {
   ROW_ID_DESC
   TS_ASC
   TS_DESC
-}
-
-"""
-A condition to be used against \`CPerson\` object types. All fields are tested for equality and combined with a logical ‘and.’
-"""
-input CPersonCondition {
-  """Checks for equality with the object’s \`rowId\` field."""
-  rowId: Int
-
-  """Checks for equality with the object’s \`name\` field."""
-  name: String
-
-  """Checks for equality with the object’s \`about\` field."""
-  about: String
-
-  """Checks for equality with the object’s \`email\` field."""
-  email: BEmail
-
-  """Checks for equality with the object’s \`lastLoginFromIp\` field."""
-  lastLoginFromIp: InternetAddress
-
-  """Checks for equality with the object’s \`lastLoginFromSubnet\` field."""
-  lastLoginFromSubnet: CidrAddress
-
-  """Checks for equality with the object’s \`userMac\` field."""
-  userMac: MacAddress
-
-  """Checks for equality with the object’s \`createdAt\` field."""
-  createdAt: Datetime
 }
 
 """Methods to use when ordering \`CPerson\`."""
@@ -18364,6 +18423,28 @@ export const objects = {
           first: applyFirstArg,
           offset: applyOffsetArg,
           after: applyAfterArg
+        }
+      },
+      cTableSetQueryVolatile: {
+        plan($parent, args, info) {
+          const $select = c_table_set_query_volatile_getSelectPlanFromParentAndArgs($parent, args, info);
+          return connection($select);
+        },
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          after: applyAfterArg,
+          condition: applyConditionArgToConnection
+        }
+      },
+      cTableSetQueryVolatileList: {
+        plan: c_table_set_query_volatile_getSelectPlanFromParentAndArgs,
+        args: {
+          first: applyFirstArg,
+          offset: applyOffsetArg,
+          condition(_condition, $select, arg) {
+            arg.apply($select, qbWhereBuilder);
+          }
         }
       },
       cTypesQuery($root, args, _info) {

--- a/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
+++ b/postgraphile/postgraphile/__tests__/schema/v5/skipNodePlugin.1.graphql
@@ -7644,6 +7644,38 @@ type Query {
     """
     offset: Int
   ): CPersonConnection
+
+  """Reads and enables pagination through a set of `CPerson`."""
+  cTableSetQueryVolatile(
+    """Read all values in the set after (below) this cursor."""
+    after: Cursor
+
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CPersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """
+    Skip the first `n` values from our `after` cursor, an alternative to cursor
+    based pagination. May not be used with `last`.
+    """
+    offset: Int
+  ): CPersonConnection
+  cTableSetQueryVolatileList(
+    """
+    A condition to be used in determining which values should be returned by the collection.
+    """
+    condition: CPersonCondition
+
+    """Only read the first `n` values of the set."""
+    first: Int
+
+    """Skip the first `n` values."""
+    offset: Int
+  ): [CPerson]
   cTypesQuery(a: BigInt!, b: Boolean!, c: String!, d: [Int]!, e: JSON!, f: FloatRangeInput!): Boolean
 
   """Get a single `DefaultValue`."""


### PR DESCRIPTION
Getting `fieldArgs` now builds resulting steps directly in the root layer plan. When applying fieldArgs to a step, we now set the current layerPlan to that step's layerPlan (since fieldArgs can only mutate a step, and so that step must be able to depend on any newly created steps, so they must be in the target layerPlan).

- Fixes https://github.com/graphile-contrib/postgraphile-plugin-connection-filter/issues/231