### PR TITLE
There is no `insideGraphQL`

### DIFF
--- a/.changeset/modern-candles-train.md
+++ b/.changeset/modern-candles-train.md
@@ -1,0 +1,5 @@
+---
+"grafast": patch
+---
+
+Remove vestigial `insideGraphQL` code.

--- a/grafast/grafast/src/bucket.ts
+++ b/grafast/grafast/src/bucket.ts
@@ -39,12 +39,6 @@ export interface RequestTools {
    * Called when the request either completes or is aborted.
    */
   readonly abortSignal: AbortSignal;
-
-  /**
-   * If we're running inside GraphQL then we should not serialize scalars,
-   * otherwise we'll face the double-serialization problem.
-   */
-  insideGraphQL: false;
 }
 
 /** @internal */

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -1028,16 +1028,6 @@ const nullExecutorString = makeExecutor({
   asString: true,
 });
 
-/* This is what leafExecutor should use if insideGraphQL (which isn't currently
-   * supported)
-  `\
-    if (root.insideGraphQL) {
-      // Don't serialize to avoid the double serialization problem
-      return bucketRootValue;
-    } else {
-      return this.type.graphqlType.serialize(bucketRootValue);
-    }
-  ` */
 const leafExecutor = makeExecutor<false, OutputPlanTypeLeaf>({
   inner(bucketRootValue) {
     return this.type.graphqlType.serialize(bucketRootValue) as JSONValue;

--- a/grafast/grafast/src/engine/executeOutputPlan.ts
+++ b/grafast/grafast/src/engine/executeOutputPlan.ts
@@ -33,12 +33,6 @@ export interface PayloadRoot {
   errorBehavior: ErrorBehavior;
 
   /**
-   * Serialization works differently if we're running inside GraphQL. (Namely:
-   * we don't serialize - that's GraphQL's job.)
-   */
-  insideGraphQL: false;
-
-  /**
    * The errors that have occurred; these are proper GraphQLErrors and will be
    * returned directly to clients so they must be complete.
    */

--- a/grafast/grafast/src/prepare.ts
+++ b/grafast/grafast/src/prepare.ts
@@ -265,7 +265,6 @@ function outputBucket(
   const operationPlan = rootBucket.layerPlan.operationPlan;
   const root: PayloadRoot = {
     errorBehavior: requestContext.args.onError ?? "PROPAGATE",
-    insideGraphQL: false,
     errors: [],
     queue: [],
     streams: [],
@@ -365,7 +364,6 @@ function executePreemptive(
     // toSerialize: [],
     eventEmitter: rootValue?.[$$eventEmitter],
     abortSignal,
-    insideGraphQL: false,
   };
 
   const bucketPromise = executeBucket(rootBucket, requestContext);


### PR DESCRIPTION
This was from 2020/2021 when we were trying to get Grafast to run inside GraphQL.js, but the overhead was too high.