### PR TITLE
Stop treating rootValue specially

### DIFF
--- a/.changeset/hot-onions-kneel.md
+++ b/.changeset/hot-onions-kneel.md
@@ -1,0 +1,6 @@
+---
+"grafast": patch
+---
+
+Grafast no longer coerces `rootValue` to a mutable object, increasing
+compatibility with legacy resolvers.

--- a/grafast/grafast/README.md
+++ b/grafast/grafast/README.md
@@ -82,7 +82,6 @@ requirements:
 - for every request:
   - `context` must be an object (anything suitable to be used as the key to a
     `WeakMap`); if you do not need a context then `{}` is perfectly acceptable
-  - `rootValue` must be an object or `null`/`undefined`
 - resolver limitations:
   - only explicit field resolvers (baked into the GraphQL schema) are supported,
     i.e. resolvers passed via `rootValue` are not (currently) supported

--- a/grafast/grafast/__tests__/resolvers-test.ts
+++ b/grafast/grafast/__tests__/resolvers-test.ts
@@ -13,7 +13,7 @@ import {
 } from "graphql";
 import { it } from "mocha";
 
-import { grafast } from "../dist/index.js";
+import { grafast, GrafastExecutionArgs } from "../dist/index.js";
 
 const makeSchema = () => {
   const A = new GraphQLObjectType({
@@ -103,4 +103,70 @@ it("Resolves the same in Grafast as GraphQL.js", async () => {
 
   const grafastResult = (await grafast(executionArgs)) as ExecutionResult;
   expect(grafastResult).to.deep.equal(graphqlResult);
+});
+
+describe("has correct resolveInfo.rootValue", async () => {
+  let rootValues: [string, any][] = [];
+  const Item = new GraphQLObjectType({
+    name: "Item",
+    fields: {
+      value: {
+        type: GraphQLString,
+        resolve(source, _args, _context, info) {
+          rootValues.push([info.fieldName, info.rootValue]);
+          return source.value;
+        },
+      },
+    },
+  });
+  const Query = new GraphQLObjectType({
+    name: "Query",
+    fields: {
+      rootValueKind: {
+        type: GraphQLString,
+        resolve(_source, _args, _context, info) {
+          rootValues.push([info.fieldName, info.rootValue]);
+          return info.rootValue === null ? "null" : typeof info.rootValue;
+        },
+      },
+      items: {
+        type: new GraphQLList(Item),
+        resolve(_source, _args, _context, info) {
+          rootValues.push([info.fieldName, info.rootValue]);
+          return [{ value: "a" }, { value: "b" }];
+        },
+      },
+    },
+  });
+  const schema = new GraphQLSchema({ query: Query });
+
+  const runTest = async (extraArgs: Partial<GrafastExecutionArgs>) => {
+    const source = /* GraphQL */ `
+      query Q {
+        rootValueKind
+        items {
+          value
+        }
+      }
+    `;
+
+    rootValues = [];
+    const result = (await grafast({
+      schema,
+      source,
+      ...extraArgs,
+    })) as ExecutionResult;
+    expect(result.errors).not.to.exist;
+    expect(rootValues).to.eql([
+      ["rootValueKind", extraArgs.rootValue],
+      ["items", extraArgs.rootValue],
+      ["value", extraArgs.rootValue],
+      ["value", extraArgs.rootValue],
+    ]);
+  };
+
+  it("rootValue: unset", () => runTest({}));
+  it("rootValue: undefined", () => runTest({ rootValue: undefined }));
+  it("rootValue: null", () => runTest({ rootValue: null }));
+  it("rootValue: symbol", () => runTest({ rootValue: Symbol("rootValue") }));
 });

--- a/grafast/grafast/src/bucket.ts
+++ b/grafast/grafast/src/bucket.ts
@@ -2,7 +2,7 @@
 
 import type { LayerPlan } from "./engine/LayerPlan.ts";
 import type { MetaByMetaKey } from "./engine/OperationPlan.ts";
-import type { ErrorBehavior, GrafastExecutionArgs, Step } from "./index.ts";
+import type { ErrorBehavior, Step } from "./index.ts";
 import type {
   ExecutionEntryFlags,
   ExecutionEventEmitter,

--- a/grafast/grafast/src/bucket.ts
+++ b/grafast/grafast/src/bucket.ts
@@ -7,6 +7,7 @@ import type {
   ExecutionEntryFlags,
   ExecutionEventEmitter,
   ExecutionValue,
+  GrafastInternalExecutionArgs,
 } from "./interfaces.ts";
 
 /**
@@ -14,7 +15,7 @@ import type {
  */
 export interface RequestTools {
   /** @internal */
-  args: GrafastExecutionArgs;
+  args: GrafastInternalExecutionArgs;
   /** @internal */
   onError: ErrorBehavior;
   /** The `timeSource.now()` at which the request started executing */

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -1500,6 +1500,10 @@ export class OperationPlan {
             mode: "object",
             deferLabel: deferred.label,
             typeName: objectType.name,
+            hasRootBehavior:
+              outputPlan.type.mode === "root" ||
+              (outputPlan.type.mode === "object" &&
+                outputPlan.type.hasRootBehavior),
           },
           // LOGGING: the location details should be tweaked to reference this
           // fragment
@@ -2428,6 +2432,7 @@ export class OperationPlan {
             mode: "object",
             deferLabel: undefined,
             typeName: nullableFieldType.name,
+            hasRootBehavior: false,
           },
           locationDetails,
         );
@@ -2781,6 +2786,7 @@ export class OperationPlan {
           mode: "object",
           deferLabel: undefined,
           typeName: type.name,
+          hasRootBehavior: false,
         },
         locationDetails,
       );

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -83,9 +83,9 @@ export type OutputPlanTypeObject = {
   typeName: string;
   deferLabel: string | undefined;
   /**
-   * If we've not traversed any fields yet, then the fields that are executed
-   * get the "root" behavior, wherein a `null` source does not prevent their
-   * execution.
+   * If we represent a defer then, though we aren't technically the root, we
+   * will have a non-null result (unless there are errors). We do not need to
+   * check the parent value (which could be null/undefined rootValue).
    */
   hasRootBehavior: boolean;
 };

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -602,14 +602,14 @@ export class OutputPlan<TType extends OutputPlanType = OutputPlanType> {
           type.typeName,
           digestFieldTypes,
           this.deferredOutputPlans.length > 0,
-          type.mode === "root",
+          type.mode === "root" || type.hasRootBehavior,
           false,
         );
         this.executeString = makeObjectExecutor(
           type.typeName,
           digestFieldTypes,
           this.deferredOutputPlans.length > 0,
-          type.mode === "root",
+          type.mode === "root" || type.hasRootBehavior,
           true,
         );
         break;

--- a/grafast/grafast/src/engine/OutputPlan.ts
+++ b/grafast/grafast/src/engine/OutputPlan.ts
@@ -82,6 +82,12 @@ export type OutputPlanTypeObject = {
   mode: "object";
   typeName: string;
   deferLabel: string | undefined;
+  /**
+   * If we've not traversed any fields yet, then the fields that are executed
+   * get the "root" behavior, wherein a `null` source does not prevent their
+   * execution.
+   */
+  hasRootBehavior: boolean;
 };
 export type OutputPlanTypePolymorphicObject = {
   /**

--- a/grafast/grafast/src/execute.ts
+++ b/grafast/grafast/src/execute.ts
@@ -7,13 +7,12 @@ import type {
 import type { PromiseOrValue } from "graphql/jsutils/PromiseOrValue.js";
 
 import { $$eventEmitter, $$extensions } from "./constants.ts";
-import { isDev } from "./dev.ts";
-import { inspect } from "./inspect.ts";
 import type {
   ExecuteEvent,
   ExecutionEventEmitter,
   ExecutionEventMap,
   GrafastExecutionArgs,
+  GrafastInternalExecutionArgs,
 } from "./interfaces.ts";
 import { getGrafastMiddleware } from "./middleware.ts";
 import type { GrafastOperationOptions } from "./prepare.ts";
@@ -25,45 +24,27 @@ import { isPromiseLike } from "./utils.ts";
  * @internal
  */
 export function withGrafastArgs(
-  args: GrafastExecutionArgs,
+  inArgs: GrafastExecutionArgs,
 ): PromiseOrValue<
   ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
 > {
+  const args: GrafastInternalExecutionArgs = {
+    ...inArgs,
+  };
   const options = args.resolvedPreset?.grafast;
-  if (isDev) {
-    if (
-      args.rootValue != null &&
-      (typeof args.rootValue !== "object" ||
-        Object.keys(args.rootValue).length > 0)
-    ) {
-      throw new Error(
-        `Grafast executor doesn't support there being a rootValue (found ${inspect(
-          args.rootValue,
-        )})`,
-      );
-    }
-  }
-  if (args.rootValue == null) {
-    args.rootValue = Object.create(null);
-  }
-  if (typeof args.rootValue !== "object" || args.rootValue == null) {
-    throw new Error("Grafast requires that the 'rootValue' be an object");
-  }
   const explain = options?.explain;
   const shouldExplain = !!explain;
 
   let unlisten: (() => void) | null = null;
   if (shouldExplain) {
-    const eventEmitter: ExecutionEventEmitter | undefined = new EventEmitter();
+    const eventEmitter: ExecutionEventEmitter = new EventEmitter();
     const explainOperations: any[] = [];
-    args.rootValue = Object.assign(Object.create(null), args.rootValue, {
-      [$$eventEmitter]: eventEmitter,
-      [$$extensions]: {
-        explain: {
-          operations: explainOperations,
-        },
+    args[$$eventEmitter] = eventEmitter;
+    args[$$extensions] = {
+      explain: {
+        operations: explainOperations,
       },
-    });
+    };
     const handleExplainOperation = ({
       operation,
     }: ExecutionEventMap["explainOperation"]) => {
@@ -71,12 +52,13 @@ export function withGrafastArgs(
         explainOperations.push(operation);
       }
     };
-    eventEmitter!.on("explainOperation", handleExplainOperation);
+    eventEmitter.on("explainOperation", handleExplainOperation);
     unlisten = () => {
-      eventEmitter!.removeListener("explainOperation", handleExplainOperation);
+      eventEmitter.removeListener("explainOperation", handleExplainOperation);
     };
   }
 
+  // TODO: inline this into args
   const operationOptions: RequireAllKeys<GrafastOperationOptions> = {
     explain: options?.explain,
     timeouts: options?.timeouts,
@@ -84,15 +66,15 @@ export function withGrafastArgs(
     // TODO: Delete this
     outputDataAsString: args.outputDataAsString,
   };
-  const rootValue = grafastPrepare(args, operationOptions);
+  const executionResult = grafastPrepare(args, operationOptions);
   if (unlisten !== null) {
-    Promise.resolve(rootValue).then(unlisten, unlisten);
+    Promise.resolve(executionResult).then(unlisten, unlisten);
   }
   // Convert from PromiseOrDirect to PromiseOrValue
-  if (isPromiseLike(rootValue)) {
-    return Promise.resolve(rootValue);
+  if (isPromiseLike(executionResult)) {
+    return Promise.resolve(executionResult);
   } else {
-    return rootValue;
+    return executionResult;
   }
 }
 

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -29,6 +29,8 @@ import type { ObjMap } from "graphql/jsutils/ObjMap.js";
 
 import type { Bucket, RequestTools } from "./bucket.ts";
 import type {
+  $$eventEmitter,
+  $$extensions,
   $$streamMore,
   $$timeout,
   $$ts,
@@ -825,6 +827,16 @@ export interface GrafastExecutionArgs extends ExecutionArgs {
   middleware?: Middleware<GraphileConfig.GrafastMiddleware> | null;
   requestContext?: Partial<Grafast.RequestContext>;
   outputDataAsString?: boolean;
+}
+
+/** @internal */
+export interface GrafastInternalExecutionArgs extends GrafastExecutionArgs {
+  [$$eventEmitter]?: ExecutionEventEmitter;
+  [$$extensions]?: {
+    explain: {
+      operations: any[];
+    };
+  };
 }
 
 export interface ValidateSchemaEvent {

--- a/grafast/grafast/src/prepare.ts
+++ b/grafast/grafast/src/prepare.ts
@@ -42,7 +42,7 @@ import { establishOperationPlan } from "./establishOperationPlan.ts";
 import type {
   ErrorBehavior,
   EstablishOperationPlanEvent,
-  GrafastExecutionArgs,
+  GrafastInternalExecutionArgs,
   GrafastTimeouts,
   JSONValue,
   PromiseOrDirect,
@@ -318,12 +318,11 @@ function outputBucket(
   }
 }
 
+/** @internal */
 function executePreemptive(
-  args: GrafastExecutionArgs,
+  args: GrafastInternalExecutionArgs,
   operationPlan: OperationPlan,
   variableValues: any,
-  context: any,
-  rootValue: any,
   onError: ErrorBehavior,
   outputDataAsString: boolean,
   executionTimeout: number | null,
@@ -342,8 +341,14 @@ function executePreemptive(
     operationPlan.variableValuesStep.id,
     unaryExecutionValue(variableValues),
   );
-  store.set(operationPlan.contextStep.id, unaryExecutionValue(context));
-  store.set(operationPlan.rootValueStep.id, unaryExecutionValue(rootValue));
+  store.set(
+    operationPlan.contextStep.id,
+    unaryExecutionValue(args.contextValue),
+  );
+  store.set(
+    operationPlan.rootValueStep.id,
+    unaryExecutionValue(args.rootValue),
+  );
 
   const rootBucket = newBucket(null, {
     layerPlan: operationPlan.rootLayerPlan,
@@ -363,7 +368,7 @@ function executePreemptive(
     startTime,
     stopTime,
     // toSerialize: [],
-    eventEmitter: rootValue?.[$$eventEmitter],
+    eventEmitter: args[$$eventEmitter],
     abortSignal,
     insideGraphQL: false,
   };
@@ -421,7 +426,7 @@ function executePreemptive(
       return finalize(
         result,
         ctx,
-        index === 0 ? (rootValue[$$extensions] ?? undefined) : undefined,
+        index === 0 ? (args[$$extensions] ?? undefined) : undefined,
         outputDataAsString,
       );
     }
@@ -560,12 +565,7 @@ function executePreemptive(
       rootBucket.store.get(operationPlan.variableValuesStep.id)!.at(0),
       outputDataAsString,
     );
-    return finalize(
-      result,
-      ctx,
-      rootValue[$$extensions] ?? undefined,
-      outputDataAsString,
-    );
+    return finalize(result, ctx, args[$$extensions], outputDataAsString);
   }
 
   if (isPromiseLike(bucketPromise)) {
@@ -592,7 +592,7 @@ function establishOperationPlanFromEvent(event: EstablishOperationPlanEvent) {
  * @internal
  */
 export function grafastPrepare(
-  args: GrafastExecutionArgs,
+  args: GrafastInternalExecutionArgs,
   options: GrafastOperationOptions,
 ): PromiseOrDirect<
   ExecutionResult | AsyncGenerator<AsyncExecutionResult, void, void>
@@ -600,7 +600,7 @@ export function grafastPrepare(
   const {
     schema,
     contextValue: context,
-    rootValue = Object.create(null),
+    rootValue,
     // operationName,
     // document,
     middleware,
@@ -611,7 +611,7 @@ export function grafastPrepare(
   if (Array.isArray(exeContext) || "length" in exeContext) {
     return Object.assign(Object.create(bypassGraphQLObj), {
       errors: exeContext,
-      extensions: rootValue[$$extensions],
+      extensions: args[$$extensions],
     });
   }
 
@@ -668,7 +668,7 @@ export function grafastPrepare(
     if (operationPlan[$$contextPlanCache] == null) {
       operationPlan[$$contextPlanCache] = operationPlan.generatePlanJSON();
     }
-    rootValue[$$extensions]?.explain?.operations.push({
+    args[$$extensions]?.explain?.operations.push({
       type: "plan",
       title: "Plan",
       plan: operationPlan[$$contextPlanCache],
@@ -682,8 +682,6 @@ export function grafastPrepare(
       args,
       operationPlan,
       variableValues,
-      context,
-      rootValue,
       onError,
       options.outputDataAsString ?? false,
       executionTimeout,

--- a/grafast/website/grafast/getting-started/existing-schema.md
+++ b/grafast/website/grafast/getting-started/existing-schema.md
@@ -22,7 +22,6 @@ following hold:
   currently populate that in an equivalent fashion
 - `context` must be an object (anything suitable to be used as the key to a
   `WeakMap`); if you do not need a context then `{}` is perfectly acceptable
-- `rootValue`, if specified, must be an object or `null`/`undefined`
 - `resolveType` and `isTypeOf`, if specified, must return the
   GraphQL type name as a string (rather than returning the object type itself)
   and their version of `GraphQLResolveInfo` is even more cut down (but you


### PR DESCRIPTION
Grafast no longer coerces `rootValue` to a mutable object, increasing
compatibility with legacy resolvers.

- Fixes the AI slop #3039 