### PR TITLE
Support for graphile.config.mts files

### DIFF
--- a/.changeset/slimy-owls-dream.md
+++ b/.changeset/slimy-owls-dream.md
@@ -1,0 +1,13 @@
+---
+"graphile-config": minor
+"ruru": patch
+"pgl": patch
+"postgraphile": patch
+"graphile": patch
+---
+
+CLIs will now correctly auto-import `graphile.config.mts` files (previously
+`graphile.config.ts` files worked, but `graphile.config.mts` files would be
+ignored). With all major versions of Node.js now having native support for type
+stripping and require(esm), we recommend moving your configuration files to
+TypeScript (using ESM and erasable syntax only).

--- a/utils/graphile-config/src/loadConfig.ts
+++ b/utils/graphile-config/src/loadConfig.ts
@@ -6,7 +6,23 @@ import { resolve } from "node:path";
 import { pathToFileURL } from "node:url";
 
 import type { Extension } from "interpret";
-import { jsVariants } from "interpret";
+import { jsVariants as baseJsVariants } from "interpret";
+
+const jsVariants = { ...baseJsVariants };
+const tsVariant = jsVariants[".ts"];
+const tsxVariant = jsVariants[".tsx"];
+if (tsVariant && !jsVariants[".mts"]) {
+  jsVariants[".mts"] = tsVariant;
+}
+if (tsVariant && !jsVariants[".cts"]) {
+  jsVariants[".cts"] = tsVariant;
+}
+if (tsxVariant && !jsVariants[".mtsx"]) {
+  jsVariants[".mtsx"] = tsxVariant;
+}
+if (tsxVariant && !jsVariants[".ctsx"]) {
+  jsVariants[".ctsx"] = tsxVariant;
+}
 
 const extensions = Object.keys(jsVariants);
 


### PR DESCRIPTION
Due to misconfiguration, previously `graphile.config.ts` would work but `graphile.config.mts` would need to be manually imported.