### PR TITLE
fix(graphile-utils): export smart-tag types from the package root

### DIFF
--- a/.changeset/smart-tag-types-exported.md
+++ b/.changeset/smart-tag-types-exported.md
@@ -1,0 +1,12 @@
+---
+"graphile-utils": patch
+---
+
+Re-export the smart-tag types (`PgSmartTagRule`, `PgSmartTagTags`,
+`PgSmartTagFilterFunction`, `JSONPgSmartTags`, and the update/subscribe
+callback types) from the package root. They are defined and `export`ed
+by `makePgSmartTagsPlugin.ts` but were missing from the barrel's
+`export type`, unlike every sibling plugin module — so consumers
+building typed rule arrays (e.g. `const rules: PgSmartTagRule[] = [...]`
+passed to `makePgSmartTagsPlugin`) could not import `PgSmartTagRule` from
+`graphile-utils` / `postgraphile/utils`.

--- a/.changeset/smart-tag-types-exported.md
+++ b/.changeset/smart-tag-types-exported.md
@@ -1,12 +1,7 @@
 ---
 "graphile-utils": patch
+"postgraphile": patch
 ---
 
-Re-export the smart-tag types (`PgSmartTagRule`, `PgSmartTagTags`,
-`PgSmartTagFilterFunction`, `JSONPgSmartTags`, and the update/subscribe
-callback types) from the package root. They are defined and `export`ed
-by `makePgSmartTagsPlugin.ts` but were missing from the barrel's
-`export type`, unlike every sibling plugin module — so consumers
-building typed rule arrays (e.g. `const rules: PgSmartTagRule[] = [...]`
-passed to `makePgSmartTagsPlugin`) could not import `PgSmartTagRule` from
-`graphile-utils` / `postgraphile/utils`.
+Export types related to the `pgSmartTags`/etc utils (`PgSmartTagRule`,
+`PgSmartTagTags`, `PgSmartTagFilterFunction`, `JSONPgSmartTags`, etc.).

--- a/graphile-build/graphile-utils/src/index.ts
+++ b/graphile-build/graphile-utils/src/index.ts
@@ -39,6 +39,16 @@ export {
   extendSchema,
   makeExtendSchemaPlugin,
 } from "./makeExtendSchemaPlugin.ts";
+export type {
+  JSONPgSmartTags,
+  PgSmartTagFilterFunction,
+  PgSmartTagRule,
+  PgSmartTagTags,
+  SubscribeToJSONPgSmartTagsUpdatesCallback,
+  SubscribeToPgSmartTagUpdatesCallback,
+  UpdateJSONPgSmartTagsCallback,
+  UpdatePgSmartTagRulesCallback,
+} from "./makePgSmartTagsPlugin.ts";
 export {
   jsonPgSmartTags,
   makeJSONPgSmartTagsPlugin,


### PR DESCRIPTION
> Transparency Note: Discovered the gap and drafted the PR with AI help during work in one of my projects.

## Description

`graphile-utils/src/makePgSmartTagsPlugin.ts` defines and `export`s these types:

- `PgSmartTagRule`
- `PgSmartTagTags`
- `PgSmartTagFilterFunction`
- `JSONPgSmartTags`
- `UpdatePgSmartTagRulesCallback`
- `SubscribeToPgSmartTagUpdatesCallback`
- `UpdateJSONPgSmartTagsCallback`
- `SubscribeToJSONPgSmartTagsUpdatesCallback`

…but the package barrel (`src/index.ts`) only re-exports the **runtime values** from that module (`makePgSmartTagsPlugin`, `pgSmartTags`, …). It's missing the `export type { … }` line that every sibling plugin module has — e.g. `makeChangeNullabilityPlugin`, `makeAddPgTableOrderByPlugin`, `makeExtendSchemaPlugin`, and `makeWrapPlansPlugin` all pair their value export with a type export. `makePgSmartTagsPlugin` is the only one that doesn't.

### Impact

Consumers building a typed rule array to hand to `makePgSmartTagsPlugin` can't name the type:

```ts
import { makePgSmartTagsPlugin, type PgSmartTagRule } from "postgraphile/utils";
//                                    ^^^^^^^^^^^^^^^
// TS2724: '"postgraphile/utils"' has no exported member named 'PgSmartTagRule'.

const rules: PgSmartTagRule[] = [
  { kind: "class", match: "my_schema.my_table", tags: { behavior: "-filter" } },
  // …
];
export const plugin = makePgSmartTagsPlugin(rules);
```

(`postgraphile/utils` just `export *`s `graphile-utils`, so it inherits the gap.)

## Changes

- Add `export type { … }` for the smart-tag types in `src/index.ts`
- Changeset (`graphile-utils`, patch)

Type-only / additive — no runtime change, no behavioural change.

## Performance impact

None (type-level re-export only).

## Security impact

None.

## Checklist

- [x] My code matches the project's code style and the existing `export type` convention in this file.
- [x] I have included a changeset (`graphile-utils`, patch).
- [ ] I have added tests — n/a (no runtime behaviour to test; this is a type re-export).