### PR TITLE
[WIP] Progressive introspection

### DIFF
--- a/postgraphile/postgraphile/__tests__/schema/v4/rbac.test.ts
+++ b/postgraphile/postgraphile/__tests__/schema/v4/rbac.test.ts
@@ -2,7 +2,15 @@ import * as core from "./core.ts";
 
 test(
   "prints a schema from non-root role, using RBAC permissions",
-  core.test(__filename, ["a", "b", "c"], { ignoreRBAC: false }, (client) =>
-    client.query("set role postgraphile_test_authenticator"),
+  core.test(
+    __filename,
+    ["a", "b", "c"],
+    { ignoreRBAC: false },
+    async (client) => {
+      await client.query(
+        "revoke usage on schema enum_tables from postgraphile_test_authenticator",
+      );
+      await client.query("set role postgraphile_test_authenticator");
+    },
   ),
 );


### PR DESCRIPTION
Progressive introspection limits introspection to just the chosen schemas and then spiders outwards to referenced types/classes/attributes/functions/etc. This aids memory efficiency, especially for folks with lots of (repeated) schemas that aren't to be exposed, but it also helps with permissions issues - if you have one schema for one API, and one for another, and permissions differ, then enum table values in one might not need to be read by the other. We can't simply not load enum table values if they're not in the schema list because they _might_ be referenced, for example `create table public.foo(enum text references hidden.enum_table);` needs to reference the `hidden.enum_table` values even though it's not in the `public` schema.

Ultimately we aim to build the same introspection object as before, but we'll do so in waves by first introspecting the main schema, then expanding outward from there based on what is actually referenced:

- column types
- type references (e.g. domain, array, range, etc -> these then reference another type, or maybe enum values/range details)
- function parameters
- function return types
- foreign key relationships (both directions?)
- probably not smart tags - those come at a later phase.