### PR TITLE
loadOne/loadMany should unwrap promises in result arrays

### DIFF
--- a/.changeset/rich-lines-deny.md
+++ b/.changeset/rich-lines-deny.md
@@ -1,0 +1,8 @@
+---
+"grafast": patch
+"postgraphile": patch
+---
+
+Fix types in `loadOne`/`loadMany` that were allowing steps to become
+`Step<Promise<TData>>` rather than `Step<TData>`. Steps will never represent a
+promise.

--- a/grafast/grafast/__tests__/dcc/dcc-data.ts
+++ b/grafast/grafast/__tests__/dcc/dcc-data.ts
@@ -738,9 +738,12 @@ export const batchGetLootDataByItemTypeAndId: LoadManyCallback<
   never,
   Database
 > = (identifiersList, { shared: data }) => {
-  return identifiersList.map(([type, id]) =>
-    data.lootData.filter((c) => c.itemType === type && c.itemId === id),
-  );
+  return identifiersList.map(([type, id]) => {
+    const items = data.lootData.filter(
+      (c) => c.itemType === type && c.itemId === id,
+    );
+    return Math.random() > 0.5 ? Promise.resolve(items) : items;
+  });
 };
 
 export const batchGetLootDataByLootBoxId: LoadManyCallback<

--- a/grafast/grafast/src/steps/loadMany.ts
+++ b/grafast/grafast/src/steps/loadMany.ts
@@ -52,7 +52,7 @@ export type LoadManyCallback<
   (
     lookups: ReadonlyArray<TLookup>,
     info: LoadManyInfo<TItem, TParams, TShared>,
-  ): PromiseOrDirect<ReadonlyArray<TData>>;
+  ): PromiseOrDirect<ReadonlyArray<PromiseOrDirect<TData>>>;
   displayName?: string;
 };
 

--- a/grafast/grafast/src/steps/loadOne.ts
+++ b/grafast/grafast/src/steps/loadOne.ts
@@ -42,7 +42,7 @@ export type LoadOneCallback<
   (
     specs: ReadonlyArray<TSpec>,
     info: LoadOneInfo<TItem, TParams, TUnarySpec>,
-  ): PromiseOrDirect<ReadonlyArray<TData>>;
+  ): PromiseOrDirect<ReadonlyArray<PromiseOrDirect<TData>>>;
   displayName?: string;
 };
 


### PR DESCRIPTION
Steps may return `[Promise<...>, Promise<...>]` inside their result. Currently loadOne/loadMany will turn this into the type `Step<Promise<...>>` which is incorrect - a Step will never represent a promise, since the system resolves promises for you. This PR unwraps it.