### PR TITLE
V4 preset: ignore `@omit select` and `@omit insert`

### DIFF
--- a/.changeset/silent-streets-own.md
+++ b/.changeset/silent-streets-own.md
@@ -1,0 +1,8 @@
+---
+"postgraphile": minor
+---
+
+Bugfix: the V4 preset now correctly ignores `@omit select` like V4 would.
+Previously, the V4 preset would silently turn `@omit select` into `-select`,
+which differs to V4's handling of this. (Note: `@omit read` is probably what
+you're looking for, `@omit select` is silently ignored.)

--- a/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
@@ -46,13 +46,24 @@ export const PgV4SmartTagsPlugin: GraphileConfig.Plugin = {
         // memoizes because it mutates the return result; if this changes then
         // the code will no longer achieve its goal.
         for (const pgClass of introspection.classes) {
-          processTags(pgClass.getTags());
+          processTags(
+            pgClass.getTags(),
+            `pg_class ${pgClass.getNamespace()?.nspname}.${pgClass.relname}`,
+          );
         }
         for (const pgAttr of introspection.attributes) {
-          processTags(pgAttr.getTags());
+          const pgClass = pgAttr.getClass();
+          processTags(
+            pgAttr.getTags(),
+            `pg_attribute ${pgClass?.getNamespace()?.nspname}.${pgClass?.relname}.${pgAttr.attname}`,
+          );
         }
         for (const pgConstraint of introspection.constraints) {
-          processTags(pgConstraint.getTags());
+          const pgClass = pgConstraint.getClass();
+          processTags(
+            pgConstraint.getTags(),
+            `pg_constraint ${pgClass?.getNamespace()?.nspname}.${pgClass?.relname}.${pgConstraint.conname}`,
+          );
 
           // In V4, if a attribute has `@omit read` then any constraint that uses that attribute also has `@omit read`
           if (pgConstraint.contype === "f") {
@@ -73,15 +84,24 @@ export const PgV4SmartTagsPlugin: GraphileConfig.Plugin = {
           }
         }
         for (const pgProc of introspection.procs) {
-          processTags(pgProc.getTags());
+          processTags(
+            pgProc.getTags(),
+            `pg_proc ${pgProc.getNamespace()?.nspname}.${pgProc.proname}`,
+          );
         }
         for (const pgType of introspection.types) {
-          processTags(pgType.getTags());
+          processTags(
+            pgType.getTags(),
+            `pg_type ${pgType.getNamespace()?.nspname}.${pgType.typname}`,
+          );
         }
       },
       pgFakeConstraints_constraint(info, event) {
         const { entity } = event;
-        processTags(entity.getTags());
+        processTags(
+          entity.getTags(),
+          `fake pg_constraint ${entity.getNamespace()?.nspname}.${entity.conname}`,
+        );
       },
     },
   }),
@@ -91,9 +111,10 @@ export default PgV4SmartTagsPlugin;
 
 function processTags(
   tags: Partial<GraphileBuild.PgSmartTagsDict> | undefined,
+  source: string,
 ): void {
   processUniqueKey(tags);
-  processOmit(tags);
+  processOmit(tags, source);
   convertBoolean(
     tags,
     "sortable",
@@ -193,6 +214,7 @@ function expandOmit(omit: string) {
 
 function processOmit(
   tags: Partial<GraphileBuild.PgSmartTagsDict> | undefined,
+  source: string,
 ): void {
   const omit = tags?.omit;
   if (!omit) {
@@ -206,7 +228,7 @@ function processOmit(
         : rawOmit;
     if (typeof omit !== "string") {
       throw new Error(
-        `Issue in smart tags; expected omit to be true/string/string[], but found something unexpected: ${inspect(
+        `Issue in smart tags for ${source}; expected omit to be true/string/string[], but found something unexpected: ${inspect(
           omit,
         )}`,
       );
@@ -258,6 +280,12 @@ function processOmit(
           behavior.push("-manyToMany");
           break;
         }
+        case "select": {
+          console.warn(
+            `WARNING: an existing smart tag for ${source} includes 'select' in the list of @omit's. This would be ignored by V4 (likely you meant to \`@omit read\` instead), so we are ignoring it to match the V4 behavior.`,
+          );
+          break;
+        }
         case "": {
           // ignore
           break;
@@ -267,7 +295,7 @@ function processOmit(
           // omits here, e.g. `@omit manyToMany`
           const assumption = `-${part.replace(/[^a-zA-Z0-9]/g, "")}`;
           console.warn(
-            `Option '${part}' in '@omit' string '${omit}' not recognized; assuming ${assumption} behavior`,
+            `Option '${part}' in '@omit' string '${omit}' for ${source} not recognized; assuming ${assumption} behavior`,
           );
           behavior.push(assumption);
           break;

--- a/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
+++ b/postgraphile/postgraphile/src/plugins/PgV4SmartTagsPlugin.ts
@@ -286,6 +286,12 @@ function processOmit(
           );
           break;
         }
+        case "insert": {
+          console.warn(
+            `WARNING: an existing smart tag for ${source} includes 'insert' in the list of @omit's. This would be ignored by V4 (likely you meant to \`@omit create\` instead), so we are ignoring it to match the V4 behavior.`,
+          );
+          break;
+        }
         case "": {
           // ignore
           break;


### PR DESCRIPTION
V4 ignored `@omit select` (`@omit read` is what's supported) and `@omit insert` (`@omit create` is what's supported). V5 was accidentally turning these into `@behavior -select` and `@behavior -insert` respectively, which is a significant departure from V4's behavior.