### PR TITLE
Bugfix to `addPgTableOrderBy`; add some plan/dev-time checks

### DIFF
--- a/.changeset/eleven-beds-help.md
+++ b/.changeset/eleven-beds-help.md
@@ -1,0 +1,7 @@
+---
+"@dataplan/pg": patch
+"postgraphile": patch
+---
+
+In development, `$pgSelect.orderBy(...)` now has some runtime validation rather
+than relying solely on types.

--- a/.changeset/four-cats-notice.md
+++ b/.changeset/four-cats-notice.md
@@ -1,0 +1,7 @@
+---
+"graphile-utils": patch
+"postgraphile": patch
+---
+
+Fix bug in `addPgTableOrderBy` that meant that an override for the `nullable`
+parameter would be ignored.

--- a/.changeset/tired-guests-help.md
+++ b/.changeset/tired-guests-help.md
@@ -1,0 +1,5 @@
+---
+"@dataplan/pg": patch
+---
+
+Throw an error when you don't pass a resource to pgSelect

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -1001,7 +1001,7 @@ export class PgSelectStep<
     order: PgSQLCallbackOrDirect<PgOrderSpec, this | PlantimeEmbeddable>,
   ): void {
     this.locker.assertParameterUnlocked("orderBy");
-    this.orders.push(this.scopedSQL(order));
+    this.orders.push(validateOrderSpec(this.scopedSQL(order)));
   }
 
   setOrderIsUnique(): void {
@@ -2888,7 +2888,7 @@ function buildTheQueryCore<
     },
     orderBy(spec) {
       if (info.mode !== "aggregate") {
-        info.orders.push(runtimeScopedSQL(spec));
+        info.orders.push(validateOrderSpec(runtimeScopedSQL(spec)));
       } else {
         // Throw it away?
         // Maybe later we can use it in the aggregates themself - e.g. `array_agg(... order by <blah>)`
@@ -4236,4 +4236,31 @@ function hasPreviousPageCb(
   } else {
     return false;
   }
+}
+
+function validateOrderSpec(orderSpec: PgOrderSpec) {
+  if (orderSpec.attribute != null) {
+    if (orderSpec.fragment != null) {
+      throw new Error(
+        `When specifying 'attribute' to orderBy, 'fragment' must not be specified`,
+      );
+    }
+    if (orderSpec.codec != null) {
+      throw new Error(
+        `When specifying 'attribute' to orderBy, 'codec' must not be specified`,
+      );
+    }
+  } else {
+    if (orderSpec.fragment == null) {
+      throw new Error(
+        `Either 'attribute' or 'fragment' must be specified for orderBy.`,
+      );
+    }
+    if (orderSpec.codec == null) {
+      throw new Error(
+        `When ordering by a 'fragment' you must also specify the 'codec' that best represents the result of the ordering. This is necessary so we can correctly parse and stringify cursors.`,
+      );
+    }
+  }
+  return orderSpec;
 }

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -4238,29 +4238,31 @@ function hasPreviousPageCb(
   }
 }
 
-function validateOrderSpec(orderSpec: PgOrderSpec) {
-  if (orderSpec.attribute != null) {
-    if (orderSpec.fragment != null) {
-      throw new Error(
-        `When specifying 'attribute' to orderBy, 'fragment' must not be specified`,
-      );
+const validateOrderSpec: (orderSpec: PgOrderSpec) => PgOrderSpec = isDev
+  ? (orderSpec) => {
+      if (orderSpec.attribute != null) {
+        if (orderSpec.fragment != null) {
+          throw new Error(
+            `When specifying 'attribute' to orderBy, 'fragment' must not be specified`,
+          );
+        }
+        if (orderSpec.codec != null) {
+          throw new Error(
+            `When specifying 'attribute' to orderBy, 'codec' must not be specified`,
+          );
+        }
+      } else {
+        if (orderSpec.fragment == null) {
+          throw new Error(
+            `Either 'attribute' or 'fragment' must be specified for orderBy.`,
+          );
+        }
+        if (orderSpec.codec == null) {
+          throw new Error(
+            `When ordering by a 'fragment' you must also specify the 'codec' that best represents the result of the ordering. This is necessary so we can correctly parse and stringify cursors.`,
+          );
+        }
+      }
+      return orderSpec;
     }
-    if (orderSpec.codec != null) {
-      throw new Error(
-        `When specifying 'attribute' to orderBy, 'codec' must not be specified`,
-      );
-    }
-  } else {
-    if (orderSpec.fragment == null) {
-      throw new Error(
-        `Either 'attribute' or 'fragment' must be specified for orderBy.`,
-      );
-    }
-    if (orderSpec.codec == null) {
-      throw new Error(
-        `When ordering by a 'fragment' you must also specify the 'codec' that best represents the result of the ordering. This is necessary so we can correctly parse and stringify cursors.`,
-      );
-    }
-  }
-  return orderSpec;
-}
+  : (orderSpec) => orderSpec;

--- a/grafast/dataplan-pg/src/steps/pgSelect.ts
+++ b/grafast/dataplan-pg/src/steps/pgSelect.ts
@@ -24,6 +24,7 @@ import {
   DEFAULT_ACCEPT_FLAGS,
   exportAs,
   first,
+  inspect,
   isAsyncIterable,
   isDev,
   isPromiseLike,
@@ -660,6 +661,11 @@ export class PgSelectStep<
 
   constructor(options: PgSelectOptions<TResource>) {
     super();
+    if (!options.resource) {
+      throw new Error(
+        `Resource passed to \`pgSelect(...)\` was ${inspect(options.resource)} - perhaps you used the wrong resource name when looking it up in the registry?`,
+      );
+    }
     const {
       resource,
       parameters = resource.parameters,

--- a/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
+++ b/graphile-build/graphile-utils/src/makeAddPgTableOrderByPlugin.ts
@@ -145,9 +145,9 @@ export function orderByAscDesc(
             ) {
               queryBuilder.orderBy({
                 nulls: ascendingNulls,
+                nullable,
                 attribute: attributeOrSqlFragment,
                 direction: "ASC",
-                nullable,
               });
               if (unique) {
                 queryBuilder.setOrderIsUnique();
@@ -164,9 +164,9 @@ export function orderByAscDesc(
               ) {
                 queryBuilder.orderBy({
                   nulls: ascendingNulls,
+                  nullable,
                   ...attributeOrSqlFragment(queryBuilder, info),
                   direction: "ASC",
-                  nullable,
                 } as PgOrderSpec);
                 if (unique) {
                   queryBuilder.setOrderIsUnique();
@@ -176,9 +176,9 @@ export function orderByAscDesc(
           )
         : ((spec = {
             nulls: ascendingNulls,
+            nullable,
             ...attributeOrSqlFragment,
             direction: "ASC",
-            nullable,
           } as PgOrderSpec),
           EXPORTABLE(
             (spec, unique) =>
@@ -199,9 +199,9 @@ export function orderByAscDesc(
             ) {
               queryBuilder.orderBy({
                 nulls: descendingNulls,
+                nullable,
                 attribute: attributeOrSqlFragment,
                 direction: "DESC",
-                nullable,
               });
               if (unique) {
                 queryBuilder.setOrderIsUnique();
@@ -218,9 +218,9 @@ export function orderByAscDesc(
               ) {
                 queryBuilder.orderBy({
                   nulls: descendingNulls,
+                  nullable,
                   ...attributeOrSqlFragment(queryBuilder, info),
                   direction: "DESC",
-                  nullable,
                 } as PgOrderSpec);
                 if (unique) {
                   queryBuilder.setOrderIsUnique();
@@ -230,9 +230,9 @@ export function orderByAscDesc(
           )
         : ((spec = {
             nulls: descendingNulls,
+            nullable,
             ...attributeOrSqlFragment,
             direction: "DESC",
-            nullable,
           } as PgOrderSpec),
           EXPORTABLE(
             (spec, unique) =>


### PR DESCRIPTION
If you're not using TypeScript (or if your TypeScript is falling back to `any` in some places) you might end up calling `.orderBy(...)` or `pgSelect(...)` with invalid data. At runtime, these errors look like bugs in PostGraphile, but they're really where you failed to pass the relevant data that's required by the types. This PR adds some plan-time and development-time checks to help throw more useful errors in these cases.