### PR TITLE
Add parentType to fieldInfo

### DIFF
--- a/.changeset/small-dryers-shake.md
+++ b/.changeset/small-dryers-shake.md
@@ -1,0 +1,7 @@
+---
+"grafast": patch
+"postgraphile": patch
+---
+
+Adds `parentType` to `FieldInfo` so it's easier to emulate GraphQLResolveInfo
+when migrating to Grafast.

--- a/grafast/grafast/src/engine/OperationPlan.ts
+++ b/grafast/grafast/src/engine/OperationPlan.ts
@@ -3062,9 +3062,10 @@ export class OperationPlan {
         coordinate,
         (fieldArgs) =>
           planResolver(parentStep, fieldArgs, {
+            schema: this.schema,
             fieldName,
             field,
-            schema: this.schema,
+            parentType: assertObjectType(this.schema.getType(typeName)),
           }),
       );
       let haltTree = false;

--- a/grafast/grafast/src/interfaces.ts
+++ b/grafast/grafast/src/interfaces.ts
@@ -284,9 +284,10 @@ export type AnyInputStepDollars = {
 };
 
 export interface FieldInfo {
+  schema: GraphQLSchema;
   fieldName: string;
   field: GraphQLField<any, any, any>;
-  schema: GraphQLSchema;
+  parentType: GraphQLObjectType;
 }
 
 /**


### PR DESCRIPTION
:thinking: I wonder if we should just populate most of the GraphQLResolveInfo properties into FieldInfo... Certainly if they're just property accesses it shouldn't be too expensive to do so, though users explicitly accessing them themselves (rather than simply property access) would be more explicit - certainly for steps.

Anyway... short of the resolver emulation, we can't currently get parentType in a plan resolver so this unblocks that.